### PR TITLE
Stream latest training checkpoints on BBTV

### DIFF
--- a/docs/bbtv-latest-checkpoint.md
+++ b/docs/bbtv-latest-checkpoint.md
@@ -1,0 +1,64 @@
+# BBTV latest-checkpoint follower
+
+BBTV is an external progress view for the current reward-screen experiment. It
+continuously plays the newest completed training checkpoint against that run's
+frozen warm-start policy. This pairing makes cumulative behavior change easier
+to see than latest-vs-latest self-play while still showing the freshest policy.
+
+The public page remains <https://bbtv.seconds0.com>. The WebSocket remains at
+`/ws`; no frontend or protocol change is required.
+
+## Safety contract
+
+`stream_backend/follow_latest.py`:
+
+- considers only checkpoint directories with `RUN_MANIFEST.json` and mode
+  `native_static_pool_reward_ablation`;
+- ignores bootstrap checkpoints and files whose byte size differs from the
+  manifest's expected checkpoint size;
+- requires size and timestamps to remain stable before reading a checkpoint;
+- hashes the source before conversion and confirms it did not change during
+  conversion;
+- writes converted Torch policies and metadata atomically under
+  `runs/bbtv-follow`, never in the trainer's checkpoint tree;
+- uses a separate, float-built Puffer environment at
+  `/home/rache/bloodbowl-rl-bbtv/vendor/PufferLib`, so it cannot rebuild or
+  replace the native module imported by the live trainer;
+- falls back to the prior league9-vs-league8 stream if discovery or conversion
+  fails; and
+- runs at nice level 19 and idle I/O priority.
+
+The follower rechecks after every two streamed games. Home and away are swapped
+between those games by the existing match runner. A just-finished checkpoint can
+therefore take up to one two-game cycle to appear.
+
+## RTX 2070 service
+
+The repository launcher is `stream_backend/run_follow_latest.sh`. Production is
+enabled with a reversible systemd user-service override:
+
+The checked-in override template is
+`stream_backend/bbstream-follow-latest.conf`; install it as
+`~/.config/systemd/user/bbstream.service.d/follow-latest.conf`.
+
+Apply or inspect it with:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart bbstream.service
+systemctl --user status bbstream.service
+cat /home/rache/bloodbowl-rl-audit/runs/bbtv-follow/selection.json
+```
+
+Rollback preserves the original static launcher:
+
+```bash
+rm ~/.config/systemd/user/bbstream.service.d/follow-latest.conf
+systemctl --user daemon-reload
+systemctl --user restart bbstream.service
+```
+
+Do not delete or rewrite the audit checkpoint tree to repair BBTV. If no valid
+checkpoint is discoverable, inspect `server_status.json`, the conversion
+metadata, and `journalctl --user -u bbstream.service`; the designed recovery path
+is the static-policy fallback.

--- a/docs/stream-connect.md
+++ b/docs/stream-connect.md
@@ -10,6 +10,7 @@ it on the site. Wire contract: `docs/stream-protocol.md` (unchanged, v1).*
 | Piece | Path (bloodbowl-rl repo) | Status |
 |-------|--------------------------|--------|
 | Game server | `stream_backend/server.py` (+ `game.py`, `decoder.py`) | ✅ verified: full game = 816 valid messages, live WS client tested |
+| Training follower | `stream_backend/follow_latest.py` + `run_follow_latest.sh` | ✅ newest complete manifested checkpoint vs frozen warm start; see `docs/bbtv-latest-checkpoint.md` |
 | Recorded real fixture | `stream_backend/fixture_match.jsonl` | ✅ a complete flagship-vs-teacher game (2 TDs, block odds cards) |
 | Frontend page | `stream/web/` (index.html, app.js, style.css) | built against the same protocol |
 | Mock WS player | `stream/mock/play.js` | replays any fixture JSONL at ws://localhost:8787/ws |
@@ -50,22 +51,19 @@ difference.
      nvidia-cuda-toolkit-free alternative — OR just build on the 2070 and use
      option (b) below until the Docker image is sorted. The Dockerfile is the
      one genuinely remaining piece of work.
-   - **2070 rig (works TODAY, $0):** the server is already running there.
-     Expose with a Cloudflare Tunnel: `cloudflared tunnel --url
-     http://localhost:8787` on the rig, then point the page's `?ws=` at the
-     tunnel hostname (wss). Uptime = the rig's uptime (it auto-recovers from
-     reboots; the babysitter keeps the trainer alive but a small systemd-style
-     wrapper for the stream server is in stream_backend/ TODO).
+   - **2070 rig (current production):** `bbstream.service` runs the
+     latest-checkpoint follower, `bbweb.service` serves the page, and
+     `bbtv-tunnel.service` exposes both through the named Cloudflare tunnel.
+     The stream launcher has low CPU/I/O priority and a static-policy fallback.
 3. **TLS note:** browsers require `wss://` from an https page — both Railway
    and CF Tunnel give you that for free; raw `ws://IP:8787` only works from
    http/localhost dev pages.
 
-## Current live dev endpoint
+## Current live endpoints
 
-On the tailnet right now: `ws://100.97.209.46:8787/ws` (the 2070). Any
-device on Alex's tailnet can open the page with
-`?ws=ws://100.97.209.46:8787/ws` and watch the flagship play. (Not reachable
-from the public internet until the CF Tunnel step.)
+- Public viewer: <https://bbtv.seconds0.com>
+- Public WebSocket: `wss://bbtv.seconds0.com/ws`
+- Tailnet WebSocket: `ws://100.97.209.46:8787/ws`
 
 ## Known v1 limitations (by design, see DECISIONS)
 

--- a/stream_backend/bbstream-follow-latest.conf
+++ b/stream_backend/bbstream-follow-latest.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=%h/bloodbowl-rl/stream_backend/run_follow_latest.sh

--- a/stream_backend/follow_latest.py
+++ b/stream_backend/follow_latest.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Continuously stream the newest stable Blood Bowl training checkpoint.
+
+The follower is deliberately outside the trainer. It discovers only checkpoint
+directories with immutable RUN_MANIFEST.json files, waits for a native blob to
+be complete and stable, converts it atomically into a Torch-only viewer cache,
+and starts ``server.py`` for a bounded match cycle. When the server exits after
+that cycle, discovery runs again and the next match uses the newest checkpoint.
+
+The default matchup is newest checkpoint versus that run's frozen warm-start.
+This makes visual progress legible without changing training, reward state,
+opponent pools, checkpoint files, or the production fallback artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True)
+class Candidate:
+    native_path: Path
+    manifest_path: Path
+    tag: str
+    seed: int
+    step: int
+    rollout_quantum: int
+    expected_bytes: int
+    warm_path: Path
+    mtime_ns: int
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def atomic_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    with temporary.open("w", encoding="utf-8") as target:
+        json.dump(value, target, indent=2, sort_keys=True, allow_nan=False)
+        target.write("\n")
+        target.flush()
+        os.fsync(target.fileno())
+    os.replace(temporary, path)
+
+
+def safe_label(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-._")
+    return cleaned[:96] or "checkpoint"
+
+
+def _manifest_candidate(
+    manifest_path: Path, native_path: Path, manifest: dict[str, Any]
+) -> Candidate | None:
+    try:
+        if manifest.get("mode") != "native_static_pool_reward_ablation":
+            return None
+        expected = int(manifest["expected_checkpoint_bytes"])
+        rollout = int(manifest["rollout_quantum"])
+        step = int(native_path.stem)
+        stat = native_path.stat()
+        warm = Path(str(manifest["warm"])).expanduser().resolve()
+        tag = str(manifest["tag"])
+        seed = int(manifest["seed"])
+    except (KeyError, TypeError, ValueError, OSError):
+        return None
+    if stat.st_size != expected or step <= rollout or not warm.is_file():
+        return None
+    return Candidate(
+        native_path=native_path.resolve(),
+        manifest_path=manifest_path.resolve(),
+        tag=tag,
+        seed=seed,
+        step=step,
+        rollout_quantum=rollout,
+        expected_bytes=expected,
+        warm_path=warm,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+
+def discover_candidates(checkpoint_root: Path) -> list[Candidate]:
+    """Return manifested, full-size, post-bootstrap native checkpoints."""
+    candidates: list[Candidate] = []
+    if not checkpoint_root.is_dir():
+        return candidates
+    for manifest_path in checkpoint_root.glob("*/RUN_MANIFEST.json"):
+        try:
+            manifest = load_json(manifest_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        for native_path in manifest_path.parent.glob("[0-9]*.bin"):
+            candidate = _manifest_candidate(manifest_path, native_path, manifest)
+            if candidate is not None:
+                candidates.append(candidate)
+    return sorted(candidates, key=lambda item: (item.mtime_ns, item.step))
+
+
+def stable_native(path: Path, expected_bytes: int, seconds: float) -> os.stat_result:
+    before = path.stat()
+    if before.st_size != expected_bytes:
+        raise RuntimeError(
+            f"checkpoint size changed or is incomplete: {path} "
+            f"({before.st_size} != {expected_bytes})"
+        )
+    if seconds > 0:
+        time.sleep(seconds)
+    after = path.stat()
+    identity_before = (
+        before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns
+    )
+    identity_after = (
+        after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns
+    )
+    if identity_before != identity_after:
+        raise RuntimeError(f"checkpoint changed during stability gate: {path}")
+    return after
+
+
+def _conversion_label(candidate: Candidate, digest: str) -> str:
+    return safe_label(
+        f"{candidate.tag}-step{candidate.step:012d}-{digest[:10]}_torch.bin"
+    )
+
+
+def _baseline_label(candidate: Candidate, digest: str) -> str:
+    return safe_label(
+        f"baseline-{candidate.warm_path.stem}-{digest[:10]}_torch.bin"
+    )
+
+
+def convert_native(
+    source: Path,
+    expected_bytes: int,
+    label: str,
+    cache_dir: Path,
+    converter_python: Path,
+    converter_script: Path,
+    config_path: Path,
+    stability_seconds: float,
+) -> dict[str, Any]:
+    stable_native(source, expected_bytes, stability_seconds)
+    source_sha = sha256_file(source)
+    output = cache_dir / label
+    metadata_path = output.with_suffix(output.suffix + ".json")
+    if output.is_file() and metadata_path.is_file():
+        try:
+            metadata = load_json(metadata_path)
+            if (
+                metadata.get("source_sha256") == source_sha
+                and metadata.get("output_sha256") == sha256_file(output)
+            ):
+                return metadata
+        except (OSError, ValueError, json.JSONDecodeError):
+            # A torn metadata write should be impossible after atomic_json,
+            # but manual edits or disk corruption must not pin the follower to
+            # fallback forever. Rebuild the cache entry from its hashed source.
+            pass
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    temporary = cache_dir / f".{label}.tmp.{os.getpid()}"
+    temporary.unlink(missing_ok=True)
+    command = [
+        str(converter_python),
+        str(converter_script),
+        "--to-torch",
+        str(source),
+        "--config",
+        str(config_path),
+        "--obs-size",
+        "2782",
+        "-o",
+        str(temporary),
+    ]
+    environment = dict(os.environ)
+    environment["CUDA_VISIBLE_DEVICES"] = ""
+    try:
+        completed = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=environment,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                "checkpoint conversion failed: "
+                f"{completed.stderr.strip() or completed.stdout.strip()}"
+            )
+        if not temporary.is_file() or temporary.stat().st_size <= expected_bytes:
+            raise RuntimeError(
+                f"converted checkpoint is missing or unexpectedly small: {temporary}"
+            )
+        stable_native(source, expected_bytes, 0)
+        final_source_sha = sha256_file(source)
+        if final_source_sha != source_sha:
+            raise RuntimeError(f"checkpoint changed during conversion: {source}")
+        output_sha = sha256_file(temporary)
+        os.replace(temporary, output)
+        metadata = {
+            "schema_version": 1,
+            "created_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "source": str(source),
+            "source_bytes": expected_bytes,
+            "source_sha256": source_sha,
+            "output": str(output),
+            "output_bytes": output.stat().st_size,
+            "output_sha256": output_sha,
+            "converter_command": command,
+            "converter_stdout": completed.stdout.strip(),
+        }
+        atomic_json(metadata_path, metadata)
+        return metadata
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def prepare_pair(args: argparse.Namespace) -> dict[str, Any]:
+    candidates = discover_candidates(args.checkpoint_root)
+    if not candidates:
+        raise RuntimeError("no stable post-bootstrap manifested checkpoint exists")
+    current = candidates[-1]
+    current_sha = sha256_file(current.native_path)
+    current_meta = convert_native(
+        current.native_path,
+        current.expected_bytes,
+        _conversion_label(current, current_sha),
+        args.cache_dir,
+        args.converter_python,
+        args.converter_script,
+        args.config,
+        args.stability_seconds,
+    )
+    baseline_sha = sha256_file(current.warm_path)
+    baseline_meta = convert_native(
+        current.warm_path,
+        current.expected_bytes,
+        _baseline_label(current, baseline_sha),
+        args.cache_dir,
+        args.converter_python,
+        args.converter_script,
+        args.config,
+        args.stability_seconds,
+    )
+    selection = {
+        "schema_version": 1,
+        "selected_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "mode": "latest_vs_frozen_warm",
+        "tag": current.tag,
+        "seed": current.seed,
+        "step": current.step,
+        "run_manifest": str(current.manifest_path),
+        "checkpoint_a": current_meta,
+        "checkpoint_b": baseline_meta,
+    }
+    atomic_json(args.state_dir / "selection.json", selection)
+    return selection
+
+
+def prune_cache(cache_dir: Path, selected: set[Path], keep: int) -> None:
+    checkpoints = sorted(
+        cache_dir.glob("*_torch.bin"),
+        key=lambda path: path.stat().st_mtime_ns,
+        reverse=True,
+    )
+    retained = 0
+    for checkpoint in checkpoints:
+        if checkpoint.resolve() in selected or retained < keep:
+            retained += 1
+            continue
+        checkpoint.unlink(missing_ok=True)
+        checkpoint.with_suffix(checkpoint.suffix + ".json").unlink(missing_ok=True)
+
+
+def server_command(
+    args: argparse.Namespace, checkpoint_a: Path, checkpoint_b: Path
+) -> list[str]:
+    return [
+        str(args.server_python),
+        str(args.server_script),
+        "--ckpt-a",
+        str(checkpoint_a),
+        "--ckpt-b",
+        str(checkpoint_b),
+        "--port",
+        str(args.port),
+        "--pace",
+        str(args.pace),
+        "--max-games",
+        str(args.games_per_cycle),
+    ]
+
+
+def run_forever(args: argparse.Namespace) -> int:
+    args.state_dir.mkdir(parents=True, exist_ok=True)
+    args.cache_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = args.state_dir / ".follow_latest.lock"
+    with lock_path.open("w") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print(f"another BBTV follower holds {lock_path}", file=sys.stderr)
+            return 2
+
+        last_pair: tuple[Path, Path] | None = None
+        failures = 0
+        while True:
+            try:
+                selection = prepare_pair(args)
+                pair = (
+                    Path(selection["checkpoint_a"]["output"]),
+                    Path(selection["checkpoint_b"]["output"]),
+                )
+                last_pair = pair
+                failures = 0
+            except Exception as exc:
+                print(f"BBTV discovery/conversion warning: {exc}", file=sys.stderr)
+                pair = last_pair
+                if pair is None and args.fallback_a and args.fallback_b:
+                    pair = (args.fallback_a, args.fallback_b)
+                if pair is None:
+                    failures += 1
+                    time.sleep(min(args.retry_seconds * failures, 60))
+                    continue
+
+            command = server_command(args, *pair)
+            status = {
+                "schema_version": 1,
+                "started_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+                "checkpoint_a": str(pair[0]),
+                "checkpoint_b": str(pair[1]),
+                "server_command": command,
+            }
+            atomic_json(args.state_dir / "server_status.json", status)
+            print("BBTV FOLLOW " + json.dumps(status, sort_keys=True), flush=True)
+            completed = subprocess.run(
+                command,
+                cwd=args.server_script.parent,
+                check=False,
+            )
+            status["completed_utc"] = dt.datetime.now(dt.timezone.utc).isoformat()
+            status["exit_code"] = completed.returncode
+            atomic_json(args.state_dir / "server_status.json", status)
+            selected = {path.resolve() for path in pair}
+            prune_cache(args.cache_dir, selected, args.keep_converted)
+            if completed.returncode != 0:
+                failures += 1
+                print(
+                    f"BBTV server exited {completed.returncode}; retaining last "
+                    f"known-good pair and retrying",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                time.sleep(min(args.retry_seconds * failures, 60))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint-root", type=Path, required=True)
+    parser.add_argument("--state-dir", type=Path, required=True)
+    parser.add_argument("--cache-dir", type=Path)
+    parser.add_argument("--converter-python", type=Path, required=True)
+    parser.add_argument("--converter-script", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--server-python", type=Path, required=True)
+    parser.add_argument("--server-script", type=Path, required=True)
+    parser.add_argument("--fallback-a", type=Path)
+    parser.add_argument("--fallback-b", type=Path)
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--pace", type=float, default=0.6)
+    parser.add_argument("--games-per-cycle", type=int, default=2)
+    parser.add_argument("--stability-seconds", type=float, default=1.0)
+    parser.add_argument("--retry-seconds", type=float, default=5.0)
+    parser.add_argument("--keep-converted", type=int, default=24)
+    parser.add_argument(
+        "--select-only",
+        action="store_true",
+        help="prepare and print one selection without launching server.py",
+    )
+    args = parser.parse_args(argv)
+    args.checkpoint_root = args.checkpoint_root.expanduser().resolve()
+    args.state_dir = args.state_dir.expanduser().resolve()
+    args.cache_dir = (
+        args.cache_dir.expanduser().resolve()
+        if args.cache_dir
+        else args.state_dir / "converted"
+    )
+    for name in ("converter_python", "server_python"):
+        # Preserve venv launcher symlinks. resolve() turns ``.venv/bin/python``
+        # into the bare uv-managed interpreter and silently loses site-packages.
+        path = getattr(args, name).expanduser().absolute()
+        if not path.is_file():
+            parser.error(f"--{name.replace('_', '-')} does not exist: {path}")
+        setattr(args, name, path)
+    for name in ("converter_script", "config", "server_script"):
+        path = getattr(args, name).expanduser().resolve()
+        if not path.is_file():
+            parser.error(f"--{name.replace('_', '-')} does not exist: {path}")
+        setattr(args, name, path)
+    for name in ("fallback_a", "fallback_b"):
+        path = getattr(args, name)
+        if path is not None:
+            path = path.expanduser().resolve()
+            if not path.is_file():
+                parser.error(f"--{name.replace('_', '-')} does not exist: {path}")
+            setattr(args, name, path)
+    if (args.fallback_a is None) != (args.fallback_b is None):
+        parser.error("--fallback-a and --fallback-b must be provided together")
+    if not 1 <= args.port <= 65535:
+        parser.error("--port must be in 1..65535")
+    if args.pace <= 0 or args.games_per_cycle <= 0:
+        parser.error("--pace and --games-per-cycle must be positive")
+    if args.stability_seconds < 0 or args.keep_converted < 2:
+        parser.error("stability must be non-negative and cache must keep >=2")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.select_only:
+        try:
+            selection = prepare_pair(args)
+        except Exception as exc:
+            print(f"BBTV selection failed: {exc}", file=sys.stderr)
+            return 2
+        print(json.dumps(selection, indent=2, sort_keys=True, allow_nan=False))
+        return 0
+    return run_forever(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stream_backend/run_follow_latest.sh
+++ b/stream_backend/run_follow_latest.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# BBTV production launcher for the RTX 2070. The follower only consumes
+# complete checkpoints from manifested reward-screen runs and never writes to
+# the trainer's checkpoint tree.
+ROOT=${BBTV_ROOT:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"}
+AUDIT_ROOT=${BBTV_AUDIT_ROOT:-"$(dirname "$ROOT")/bloodbowl-rl-audit"}
+VIEWER_ROOT=${BBTV_VIEWER_ROOT:-"$(dirname "$ROOT")/bloodbowl-rl-bbtv/vendor/PufferLib"}
+
+# Keep inference subordinate to the live trainer. The old static BBTV process
+# ran at normal priority; nice/idle I/O makes the replacement less intrusive.
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}
+# shellcheck source=/dev/null
+source "$ROOT/rig-env.sh"
+export PYTHONPATH="$VIEWER_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+
+exec nice -n 19 ionice -c 3 \
+  "$ROOT/vendor/PufferLib/.venv/bin/python" \
+  "$ROOT/stream_backend/follow_latest.py" \
+  --checkpoint-root "$AUDIT_ROOT/vendor/PufferLib/checkpoints/bloodbowl" \
+  --state-dir "$AUDIT_ROOT/runs/bbtv-follow" \
+  --converter-python "$ROOT/vendor/PufferLib/.venv/bin/python" \
+  --converter-script "$AUDIT_ROOT/training/convert_checkpoint.py" \
+  --config "$AUDIT_ROOT/puffer/config/bloodbowl.ini" \
+  --server-python "$VIEWER_ROOT/.venv/bin/python" \
+  --server-script "$ROOT/stream_backend/server.py" \
+  --fallback-a "$ROOT/training/league9_torch.bin" \
+  --fallback-b "$ROOT/training/league8_torch.bin" \
+  --port "${BBTV_PORT:-8787}" \
+  --pace "${BBTV_PACE:-0.6}" \
+  --games-per-cycle "${BBTV_GAMES_PER_CYCLE:-2}" \
+  --stability-seconds "${BBTV_STABILITY_SECONDS:-1}" \
+  --keep-converted "${BBTV_KEEP_CONVERTED:-24}"

--- a/stream_backend/test_follow_latest.py
+++ b/stream_backend/test_follow_latest.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+import json
+import tempfile
+import time
+import unittest
+from unittest import mock
+from pathlib import Path
+
+import follow_latest
+
+
+def write_manifest(run, *, tag, seed, warm, expected=16, rollout=4):
+    (run / "RUN_MANIFEST.json").write_text(json.dumps({
+        "mode": "native_static_pool_reward_ablation",
+        "tag": tag,
+        "seed": str(seed),
+        "expected_checkpoint_bytes": str(expected),
+        "rollout_quantum": str(rollout),
+        "warm": str(warm),
+    }), encoding="utf-8")
+
+
+class FollowLatestTests(unittest.TestCase):
+    def test_discovery_is_manifested_full_size_and_post_bootstrap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            warm = root / "warm.bin"
+            warm.write_bytes(b"w" * 16)
+            run = root / "run-1"
+            run.mkdir()
+            write_manifest(run, tag="arm-a", seed=42, warm=warm)
+            (run / "0000000000000004.bin").write_bytes(b"i" * 16)
+            (run / "0000000000000008.bin").write_bytes(b"a" * 15)
+            first = run / "0000000000000012.bin"
+            first.write_bytes(b"b" * 16)
+            time.sleep(0.002)
+            second = run / "0000000000000016.bin"
+            second.write_bytes(b"c" * 16)
+            unmanifested = root / "run-2"
+            unmanifested.mkdir()
+            (unmanifested / "0000000000000099.bin").write_bytes(b"d" * 16)
+
+            candidates = follow_latest.discover_candidates(root)
+
+        self.assertEqual([candidate.step for candidate in candidates], [12, 16])
+        self.assertEqual(candidates[-1].tag, "arm-a")
+        self.assertEqual(candidates[-1].seed, 42)
+
+    def test_discovery_prefers_latest_mtime_across_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            warm = root / "warm.bin"
+            warm.write_bytes(b"w" * 16)
+            old = root / "old"
+            old.mkdir()
+            write_manifest(old, tag="old-arm", seed=42, warm=warm)
+            (old / "0000000000000100.bin").write_bytes(b"a" * 16)
+            time.sleep(0.002)
+            new = root / "new"
+            new.mkdir()
+            write_manifest(new, tag="new-arm", seed=43, warm=warm)
+            (new / "0000000000000050.bin").write_bytes(b"b" * 16)
+
+            candidates = follow_latest.discover_candidates(root)
+
+        self.assertEqual(candidates[-1].tag, "new-arm")
+        self.assertEqual(candidates[-1].step, 50)
+
+    def test_stability_gate_rejects_wrong_size(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "checkpoint.bin"
+            path.write_bytes(b"x" * 15)
+            with self.assertRaisesRegex(RuntimeError, "incomplete"):
+                follow_latest.stable_native(path, 16, 0)
+
+    def test_corrupt_cache_metadata_is_rebuilt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "native.bin"
+            source.write_bytes(b"n" * 16)
+            cache = root / "cache"
+            cache.mkdir()
+            output = cache / "policy_torch.bin"
+            output.write_bytes(b"bad" * 8)
+            output.with_suffix(".bin.json").write_text("{", encoding="utf-8")
+
+            def fake_run(command, **_kwargs):
+                Path(command[-1]).write_bytes(b"t" * 17)
+                return mock.Mock(returncode=0, stdout="converted", stderr="")
+
+            with mock.patch.object(follow_latest.subprocess, "run", fake_run):
+                metadata = follow_latest.convert_native(
+                    source,
+                    16,
+                    output.name,
+                    cache,
+                    Path("python"),
+                    Path("convert.py"),
+                    Path("config.ini"),
+                    0,
+                )
+
+            rebuilt_source_sha = follow_latest.sha256_file(source)
+
+        self.assertEqual(metadata["source_sha256"], rebuilt_source_sha)
+        self.assertEqual(metadata["output_bytes"], 17)
+
+    def test_safe_label_removes_path_characters(self):
+        self.assertEqual(
+            follow_latest.safe_label("arm / seed 42:_torch.bin"),
+            "arm-seed-42-_torch.bin",
+        )
+
+    def test_parser_preserves_virtualenv_python_symlink(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            real_python = root / "python-real"
+            real_python.write_text("", encoding="utf-8")
+            venv_python = root / "python-venv"
+            venv_python.symlink_to(real_python)
+            script = root / "script.py"
+            script.write_text("", encoding="utf-8")
+            checkpoint_root = root / "checkpoints"
+            checkpoint_root.mkdir()
+            with mock.patch.object(
+                    follow_latest.argparse.ArgumentParser, "error",
+                    side_effect=AssertionError):
+                args = follow_latest.parse_args([
+                    "--checkpoint-root", str(checkpoint_root),
+                    "--state-dir", str(root / "state"),
+                    "--converter-python", str(venv_python),
+                    "--converter-script", str(script),
+                    "--config", str(script),
+                    "--server-python", str(venv_python),
+                    "--server-script", str(script),
+                ])
+        self.assertEqual(args.converter_python, venv_python.absolute())
+        self.assertNotEqual(args.converter_python, real_python.resolve())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- follow only complete, stable checkpoints from manifested reward-screen runs
- convert checkpoints atomically outside the trainer tree and compare newest policy to its frozen warm start
- add a low-priority production launcher, static fallback, reversible systemd override, tests, and operations guide

## Verification
- 5 focused follower tests
- Ruff, py_compile, shellcheck, bash syntax, whitespace checks
- shadow stream advanced automatically from 100.0M to 149.9M
- public page and wss://bbtv.seconds0.com/ws verified
- isolated viewer module and training integrity verified

Already deployed on the RTX 2070 through the documented reversible override.