### PR TITLE
Fix reward aggregation and BBTV checkpoint safety

### DIFF
--- a/docs/bbtv-latest-checkpoint.md
+++ b/docs/bbtv-latest-checkpoint.md
@@ -14,6 +14,8 @@ The public page remains <https://bbtv.seconds0.com>. The WebSocket remains at
 
 - considers only checkpoint directories with `RUN_MANIFEST.json` and mode
   `native_static_pool_reward_ablation`;
+- requires the manifest's schema, frozen-warm byte count, and frozen-warm
+  SHA-256 to match the live baseline before and after conversion;
 - ignores bootstrap checkpoints and files whose byte size differs from the
   manifest's expected checkpoint size;
 - requires size and timestamps to remain stable before reading a checkpoint;
@@ -21,12 +23,22 @@ The public page remains <https://bbtv.seconds0.com>. The WebSocket remains at
   conversion;
 - writes converted Torch policies and metadata atomically under
   `runs/bbtv-follow`, never in the trainer's checkpoint tree;
+- selects the greatest checkpoint step from the greatest numeric run ID, so
+  touching or restoring an older checkpoint cannot roll the stream backward;
+- fingerprints the converter and environment config in every cache entry and
+  rebuilds when either changes;
 - uses a separate, float-built Puffer environment at
   `/home/rache/bloodbowl-rl-bbtv/vendor/PufferLib`, so it cannot rebuild or
   replace the native module imported by the live trainer;
 - falls back to the prior league9-vs-league8 stream if discovery or conversion
   fails; and
 - runs at nice level 19 and idle I/O priority.
+
+A new pairing becomes “last successful” only after the server completes its
+bounded match cycle. A load/runtime failure quarantines that exact converted
+pair and restores the previous successful pairing (or the static fallback).
+Conversion and match cycles also have finite timeouts, so a wedged child cannot
+leave the follower alive but permanently stalled.
 
 The follower rechecks after every two streamed games. Home and away are swapped
 between those games by the existing match runner. A just-finished checkpoint can

--- a/puffer/bloodbowl/binding.c
+++ b/puffer/bloodbowl/binding.c
@@ -228,7 +228,7 @@ void my_log(Log* log, Dict* out) {
     //
     // CAPACITY: vec_log (src/bindings_cpu.cpp / bindings.cu) must hand us a
     // dict large enough for these keys plus the vecenv-appended "n". We emit
-    // 82. Growing past the call-site capacity is SILENT HEAP CORRUPTION
+    // 86. Growing past the call-site capacity is SILENT HEAP CORRUPTION
     // upstream (assert compiles out under NDEBUG); our vendored dict_set
     // aborts loudly instead (training/puffer_dict_capacity.patch).
     // History: key count hit 37 vs capacity 32 when slot scores + demo
@@ -242,11 +242,25 @@ void my_log(Log* log, Dict* out) {
     dict_set(out, "episode_return", log->episode_return);
     dict_set(out, "episode_length", log->episode_length);
     dict_set(out, "statmatch_term", log->statmatch_term);
-    dict_set(out, "reward_clip_frac", log->reward_clip_frac);
-    dict_set(out, "reward_clip_frac_nonzero", log->reward_clip_frac_nonzero);
+    float clip_frac = log->reward_samples > 0.0f
+        ? log->reward_clipped_samples / log->reward_samples : 0.0f;
+    float clip_frac_nonzero = log->reward_nonzero_samples > 0.0f
+        ? log->reward_clipped_samples / log->reward_nonzero_samples : 0.0f;
+    float nonfinite_frac = log->reward_samples > 0.0f
+        ? log->reward_nonfinite_samples / log->reward_samples : 0.0f;
+    dict_set(out, "reward_clip_frac", clip_frac);
+    dict_set(out, "reward_clip_frac_nonzero", clip_frac_nonzero);
     dict_set(out, "reward_clip_excess", log->reward_clip_excess);
-    dict_set(out, "reward_abs_max", log->reward_abs_max);
-    dict_set(out, "reward_nonfinite_frac", log->reward_nonfinite_frac);
+    dict_set(out, "reward_episode_abs_max_mean",
+             log->reward_episode_abs_max_mean);
+    dict_set(out, "reward_nonfinite_frac", nonfinite_frac);
+    dict_set(out, "reward_samples_per_episode", log->reward_samples);
+    dict_set(out, "reward_nonzero_samples_per_episode",
+             log->reward_nonzero_samples);
+    dict_set(out, "reward_clipped_samples_per_episode",
+             log->reward_clipped_samples);
+    dict_set(out, "reward_nonfinite_samples_per_episode",
+             log->reward_nonfinite_samples);
     dict_set(out, "reward_clip_episodes", log->reward_clip_episodes);
     dict_set(out, "reward_nonfinite_episodes", log->reward_nonfinite_episodes);
     dict_set(out, "illegal_frac", log->illegal_frac);

--- a/puffer/bloodbowl/bloodbowl.h
+++ b/puffer/bloodbowl/bloodbowl.h
@@ -163,11 +163,16 @@ typedef struct {
     float statmatch_term;
     // PPO clamps each emitted agent reward to [-1,1]. These aggregates expose
     // any difference between raw env return and the learner's reward stream.
-    float reward_clip_frac;
-    float reward_clip_frac_nonzero;
+    // Raw emission counters. Vec aggregation sums these and divides each by
+    // the same episode count; my_log forms ratios afterward, preserving exact
+    // emission weighting across short curriculum and full-game episodes.
+    float reward_samples;
+    float reward_nonzero_samples;
+    float reward_clipped_samples;
+    float reward_nonfinite_samples;
     float reward_clip_excess;
-    float reward_abs_max;
-    float reward_nonfinite_frac;
+    // Sum of each episode's maximum; after vec /n this is explicitly a mean.
+    float reward_episode_abs_max_mean;
     // Episode indicators; after vec-log normalization these are the fraction
     // of completed episodes with at least one clipped/non-finite emission.
     float reward_clip_episodes;
@@ -2117,19 +2122,12 @@ static void bbe_finish_episode(Bloodbowl* env) {
     // Record only after every terminal component—including statmatch—has
     // stacked. This is exactly the raw emission PPO clamps before GAE.
     bbe_record_reward_emission(env);
-    if (env->ep_reward_samples > 0) {
-        float nreward = (float)env->ep_reward_samples;
-        env->log.reward_clip_frac +=
-            (float)env->ep_reward_clipped / nreward;
-        env->log.reward_nonfinite_frac +=
-            (float)env->ep_reward_nonfinite / nreward;
-    }
-    if (env->ep_reward_nonzero > 0) {
-        env->log.reward_clip_frac_nonzero +=
-            (float)env->ep_reward_clipped / (float)env->ep_reward_nonzero;
-    }
+    env->log.reward_samples += (float)env->ep_reward_samples;
+    env->log.reward_nonzero_samples += (float)env->ep_reward_nonzero;
+    env->log.reward_clipped_samples += (float)env->ep_reward_clipped;
+    env->log.reward_nonfinite_samples += (float)env->ep_reward_nonfinite;
     env->log.reward_clip_excess += env->ep_reward_clip_excess;
-    env->log.reward_abs_max += env->ep_reward_abs_max;
+    env->log.reward_episode_abs_max_mean += env->ep_reward_abs_max;
     env->log.reward_clip_episodes += env->ep_reward_clipped > 0;
     env->log.reward_nonfinite_episodes += env->ep_reward_nonfinite > 0;
     env->log.statmatch_term += statmatch;
@@ -2613,6 +2611,7 @@ static void c_step(Bloodbowl* env) {
         // opponent turn and return to the original active team; touchdowns
         // unwind TEAM_TURN without flipping active_team at all. Both cases
         // made the old flip detector silently lose possession/turnover data.
+        int completed_delta[2] = {0, 0};
         for (int t = 0; t < 2; t++) {
             int completed = (int)m->turns_completed[t] -
                             (int)turns_completed_pre[t];
@@ -2621,6 +2620,7 @@ static void c_step(Bloodbowl* env) {
             int turnovers = (int)m->turnovers_completed[t] -
                             (int)turnovers_completed_pre[t];
             env->ep_turns[t] += completed;
+            completed_delta[t] = completed;
             env->ep_turns_with_ball[t] += held;
             env->ep_turnovers[t] += turnovers;
 
@@ -2636,11 +2636,16 @@ static void c_step(Bloodbowl* env) {
                 env->ep_return[1 - t] -= r;
             }
         }
-        // Possession-rate bookkeeping: when the active team flips, the
-        // remaining positional hooks evaluate the just-ended board.
-        if ((int)m->active_team != env->prev_active_team) {
-            int t = env->prev_active_team & 1;
-            if (pre_in_team_turn && m->ball.state == BB_BALL_HELD &&
+        // Every positional turn-end hook follows the same monotonic boundary
+        // signal as possession bookkeeping. One advance can compress an empty
+        // opponent turn and return to the original active team, while a TD can
+        // unwind TEAM_TURN without flipping active_team at all. In both cases
+        // the acting team's completed counter is the authoritative boundary.
+        int t = env->prev_active_team & 1;
+        bool genuine_own_turn_end =
+            pre_in_team_turn && completed_delta[t] > 0;
+        if (genuine_own_turn_end) {
+            if (m->ball.state == BB_BALL_HELD &&
                 m->ball.carrier < BB_NUM_PLAYERS &&
                 BB_TEAM_OF(m->ball.carrier) != t) {
                 bbe_measure_defensive_canary(env, t);
@@ -2667,7 +2672,7 @@ static void c_step(Bloodbowl* env) {
             // only the best non-adjacent movement threat is pooled as the
             // single blitz. Rewards are positive-positive with constant sum
             // k*T_max; raw uncapped T is logged for visibility.
-            if (pre_in_team_turn && env->reward_carrier_threat != 0.0f &&
+            if (env->reward_carrier_threat != 0.0f &&
                 m->ball.state == BB_BALL_HELD) {
                 bb_carrier_threat_breakdown th;
                 float tc = bb_carrier_threat_eval(m, &th);
@@ -2694,16 +2699,14 @@ static void c_step(Bloodbowl* env) {
                     bb_team_contact_favorability(m, 0),
                     bb_team_contact_favorability(m, 1)
                 };
-                if (pre_in_team_turn) {
-                    float d0 = fav[0] - env->prev_contact_fav[0];
-                    float d1 = fav[1] - env->prev_contact_fav[1];
-                    float r0 = env->reward_k_assist * (d0 - d1);
-                    env->reward_ptr[0][0] += r0;
-                    env->reward_ptr[1][0] -= r0;
-                    env->ep_return[0] += r0;
-                    env->ep_return[1] -= r0;
-                    env->ep_contact_fav += fav[0] + fav[1];
-                }
+                float d0 = fav[0] - env->prev_contact_fav[0];
+                float d1 = fav[1] - env->prev_contact_fav[1];
+                float r0 = env->reward_k_assist * (d0 - d1);
+                env->reward_ptr[0][0] += r0;
+                env->reward_ptr[1][0] -= r0;
+                env->ep_return[0] += r0;
+                env->ep_return[1] -= r0;
+                env->ep_contact_fav += fav[0] + fav[1];
                 env->prev_contact_fav[0] = fav[0];
                 env->prev_contact_fav[1] = fav[1];
             }
@@ -2719,9 +2722,8 @@ static void c_step(Bloodbowl* env) {
             // still inside its BB_PROC_TEAM_TURN. This filters the setup->kickoff
             // flip and kickoff Charge! active-team changes (ball off-pitch,
             // counters 0/0) that the bare active_team-flip hook also catches.
-            if (pre_in_team_turn &&
-                (env->reward_defensive_threat != 0.0f ||
-                 env->reward_defensive_threat_soft != 0.0f)) {
+            if (env->reward_defensive_threat != 0.0f ||
+                env->reward_defensive_threat_soft != 0.0f) {
                 bb_def_threat dt = bb_def_threat_eval(m, t);
                 int hard_true = dt.n_threats_1turn;
                 int soft_true = dt.n_threats_2turn - dt.n_threats_1turn;
@@ -2747,6 +2749,8 @@ static void c_step(Bloodbowl* env) {
                 env->ep_def_threats_1t += hard_true;
                 env->ep_def_threats_2t += dt.n_threats_2turn;
             }
+        }
+        if ((int)m->active_team != env->prev_active_team) {
             env->prev_active_team = (int)m->active_team;
         }
         bbe_count_knockdowns(env, was_standing, agent, carrier_pre_down_mask);

--- a/puffer/bloodbowl/test_reward_send_off.c
+++ b/puffer/bloodbowl/test_reward_send_off.c
@@ -23,6 +23,21 @@ static void check_float(float got, float want) {
     BB_CHECK(d < 0.00001f);
 }
 
+static float reward_clip_frac(const Log* log) {
+    return log->reward_samples > 0.0f
+        ? log->reward_clipped_samples / log->reward_samples : 0.0f;
+}
+
+static float reward_clip_frac_nonzero(const Log* log) {
+    return log->reward_nonzero_samples > 0.0f
+        ? log->reward_clipped_samples / log->reward_nonzero_samples : 0.0f;
+}
+
+static float reward_nonfinite_frac(const Log* log) {
+    return log->reward_samples > 0.0f
+        ? log->reward_nonfinite_samples / log->reward_samples : 0.0f;
+}
+
 static void setup_env_buffers(RewardFixture* f) {
     memset(f, 0, sizeof(*f));
     Bloodbowl* env = &f->env;
@@ -461,9 +476,9 @@ BB_TEST(puffer_final_turn_touchdown_stacks_objective_without_possession_clip) {
     // The scoring turn enters the possession metric, but its annuity coupon is
     // suppressed because the TD already priced this boundary.
     check_float(f.env.log.possession_rate, 1.0f);
-    check_float(f.env.log.reward_clip_frac, 0.0f);
+    check_float(reward_clip_frac(&f.env.log), 0.0f);
     check_float(f.env.log.reward_clip_episodes, 0.0f);
-    check_float(f.env.log.reward_abs_max, 1.0f);
+    check_float(f.env.log.reward_episode_abs_max_mean, 1.0f);
 }
 
 BB_TEST(puffer_possession_bookkeeping_survives_auto_empty_opponent_turn) {
@@ -471,6 +486,7 @@ BB_TEST(puffer_possession_bookkeeping_survives_auto_empty_opponent_turn) {
     setup_env_buffers(&f);
     Bloodbowl* env = &f.env;
     env->reward_possession = 0.03f;
+    env->reward_carrier_threat = 0.05f;
 
     fx_match_midturn(&env->match, BB_HOME, 0);
     int carrier = fx_lineman(&env->match, BB_HOME, 0, 5, 5);
@@ -498,8 +514,12 @@ BB_TEST(puffer_possession_bookkeeping_survives_auto_empty_opponent_turn) {
     BB_CHECK_EQ(env->ep_turns[BB_AWAY], 1);
     BB_CHECK_EQ(env->ep_turns_with_ball[BB_HOME], 1);
     BB_CHECK_EQ(env->ep_turns_with_ball[BB_AWAY], 0);
-    check_float(f.rewards[BB_HOME], 0.03f);
+    // The original HOME boundary must also fire positional hooks even though
+    // the playerless AWAY turn was compressed and active_team returned HOME.
+    check_float(f.rewards[BB_HOME],
+                0.03f + 0.05f * BB_CARRIER_THREAT_T_MAX);
     check_float(f.rewards[BB_AWAY], -0.03f);
+    check_float(env->ep_carrier_threat, 0.0f);
 }
 
 BB_TEST(puffer_turnover_bookkeeping_counts_failure_created_by_action) {
@@ -593,12 +613,12 @@ BB_TEST(puffer_reward_clip_telemetry_sees_terminal_stack) {
 
     bbe_finish_episode(&f.env);
 
-    check_float(f.env.log.reward_clip_frac, 1.0f);
+    check_float(reward_clip_frac(&f.env.log), 1.0f);
     check_float(f.env.log.reward_clip_episodes, 1.0f);
     check_float(f.env.log.reward_nonfinite_episodes, 0.0f);
     check_float(f.env.log.reward_clip_excess, 0.4f);
-    check_float(f.env.log.reward_abs_max, 1.2f);
-    check_float(f.env.log.reward_nonfinite_frac, 0.0f);
+    check_float(f.env.log.reward_episode_abs_max_mean, 1.2f);
+    check_float(reward_nonfinite_frac(&f.env.log), 0.0f);
 }
 
 BB_TEST(puffer_reward_clip_telemetry_includes_statmatch_terminal_term) {
@@ -610,9 +630,9 @@ BB_TEST(puffer_reward_clip_telemetry_includes_statmatch_terminal_term) {
     bbe_finish_episode(&f.env);
 
     BB_CHECK(f.env.log.statmatch_term < -1.0f);
-    check_float(f.env.log.reward_clip_frac, 1.0f);
+    check_float(reward_clip_frac(&f.env.log), 1.0f);
     check_float(f.env.log.reward_clip_episodes, 1.0f);
-    BB_CHECK(f.env.log.reward_abs_max > 1.0f);
+    BB_CHECK(f.env.log.reward_episode_abs_max_mean > 1.0f);
     BB_CHECK(f.env.log.reward_clip_excess > 0.0f);
 }
 
@@ -631,8 +651,8 @@ BB_TEST(puffer_reward_clip_nonzero_fraction_is_not_diluted_by_sparse_zeros) {
 
     bbe_finish_episode(&f.env);
 
-    check_float(f.env.log.reward_clip_frac, 2.0f / 202.0f);
-    check_float(f.env.log.reward_clip_frac_nonzero, 1.0f);
+    check_float(reward_clip_frac(&f.env.log), 2.0f / 202.0f);
+    check_float(reward_clip_frac_nonzero(&f.env.log), 1.0f);
 }
 
 BB_TEST(puffer_reward_nonfinite_telemetry_sees_raw_nan_and_infinity) {
@@ -644,11 +664,11 @@ BB_TEST(puffer_reward_nonfinite_telemetry_sees_raw_nan_and_infinity) {
 
     bbe_finish_episode(&f.env);
 
-    check_float(f.env.log.reward_nonfinite_frac, 1.0f);
+    check_float(reward_nonfinite_frac(&f.env.log), 1.0f);
     check_float(f.env.log.reward_nonfinite_episodes, 1.0f);
-    check_float(f.env.log.reward_clip_frac, 0.0f);
+    check_float(reward_clip_frac(&f.env.log), 0.0f);
     check_float(f.env.log.reward_clip_episodes, 0.0f);
-    check_float(f.env.log.reward_abs_max, 0.0f);
+    check_float(f.env.log.reward_episode_abs_max_mean, 0.0f);
 }
 
 BB_TEST(puffer_reward_clip_threshold_is_strictly_above_one) {
@@ -658,9 +678,9 @@ BB_TEST(puffer_reward_clip_threshold_is_strictly_above_one) {
     exact.rewards[BB_HOME] = 1.0f;
     exact.rewards[BB_AWAY] = -1.0f;
     bbe_finish_episode(&exact.env);
-    check_float(exact.env.log.reward_clip_frac, 0.0f);
+    check_float(reward_clip_frac(&exact.env.log), 0.0f);
     check_float(exact.env.log.reward_clip_episodes, 0.0f);
-    check_float(exact.env.log.reward_abs_max, 1.0f);
+    check_float(exact.env.log.reward_episode_abs_max_mean, 1.0f);
 
     RewardFixture over;
     setup_env_buffers(&over);
@@ -669,8 +689,34 @@ BB_TEST(puffer_reward_clip_threshold_is_strictly_above_one) {
     over.rewards[BB_HOME] = just_over;
     over.rewards[BB_AWAY] = -just_over;
     bbe_finish_episode(&over.env);
-    check_float(over.env.log.reward_clip_frac, 1.0f);
+    check_float(reward_clip_frac(&over.env.log), 1.0f);
     check_float(over.env.log.reward_clip_episodes, 1.0f);
     BB_CHECK(over.env.log.reward_clip_excess > 0.0f);
-    check_float(over.env.log.reward_abs_max, just_over);
+    check_float(over.env.log.reward_episode_abs_max_mean, just_over);
+}
+
+BB_TEST(puffer_reward_clip_fraction_is_emission_weighted_across_episodes) {
+    RewardFixture f;
+    setup_env_buffers(&f);
+    f.env.reward_configured = 1;
+    for (int i = 0; i < 100; i++) {
+        f.rewards[BB_HOME] = f.rewards[BB_AWAY] = 0.0f;
+        bbe_record_reward_emission(&f.env);
+    }
+    f.env.reward_win = 0.8f;
+    f.env.match.score[BB_HOME] = 1;
+    f.rewards[BB_HOME] = 0.4f;
+    f.rewards[BB_AWAY] = -0.4f;
+    bbe_finish_episode(&f.env);
+
+    // A second two-sample unclipped episode must contribute by emission
+    // count, not receive equal weight with the preceding 202-sample episode.
+    f.env.reward_win = 0.0f;
+    f.rewards[BB_HOME] = f.rewards[BB_AWAY] = 0.0f;
+    bbe_finish_episode(&f.env);
+
+    check_float(f.env.log.n, 2.0f);
+    check_float(f.env.log.reward_samples, 204.0f);
+    check_float(f.env.log.reward_clipped_samples, 2.0f);
+    check_float(reward_clip_frac(&f.env.log), 2.0f / 204.0f);
 }

--- a/stream_backend/follow_latest.py
+++ b/stream_backend/follow_latest.py
@@ -39,7 +39,9 @@ class Candidate:
     rollout_quantum: int
     expected_bytes: int
     warm_path: Path
-    mtime_ns: int
+    warm_bytes: int
+    warm_sha256: str
+    run_order: int
 
 
 def sha256_file(path: Path) -> str:
@@ -79,16 +81,31 @@ def _manifest_candidate(
     try:
         if manifest.get("mode") != "native_static_pool_reward_ablation":
             return None
+        if int(manifest["schema_version"]) != 1:
+            return None
         expected = int(manifest["expected_checkpoint_bytes"])
         rollout = int(manifest["rollout_quantum"])
         step = int(native_path.stem)
         stat = native_path.stat()
         warm = Path(str(manifest["warm"])).expanduser().resolve()
+        warm_bytes = int(manifest["warm_bytes"])
+        warm_sha = str(manifest["warm_sha256"]).lower()
+        run_order = int(manifest_path.parent.name)
+        warm_size = warm.stat().st_size
         tag = str(manifest["tag"])
         seed = int(manifest["seed"])
     except (KeyError, TypeError, ValueError, OSError):
         return None
-    if stat.st_size != expected or step <= rollout or not warm.is_file():
+    if (
+        stat.st_size != expected
+        or step <= rollout
+        or expected <= 0
+        or warm_bytes <= 0
+        or run_order < 0
+        or not warm.is_file()
+        or warm_size != warm_bytes
+        or not re.fullmatch(r"[0-9a-f]{64}", warm_sha)
+    ):
         return None
     return Candidate(
         native_path=native_path.resolve(),
@@ -99,7 +116,9 @@ def _manifest_candidate(
         rollout_quantum=rollout,
         expected_bytes=expected,
         warm_path=warm,
-        mtime_ns=stat.st_mtime_ns,
+        warm_bytes=warm_bytes,
+        warm_sha256=warm_sha,
+        run_order=run_order,
     )
 
 
@@ -117,7 +136,10 @@ def discover_candidates(checkpoint_root: Path) -> list[Candidate]:
             candidate = _manifest_candidate(manifest_path, native_path, manifest)
             if candidate is not None:
                 candidates.append(candidate)
-    return sorted(candidates, key=lambda item: (item.mtime_ns, item.step))
+    # Run directories are launcher-generated monotonic numeric IDs. Select the
+    # newest run by that immutable identity, then its greatest completed step;
+    # copying/touching an old checkpoint must never roll BBTV backward.
+    return sorted(candidates, key=lambda item: (item.run_order, item.step))
 
 
 def stable_native(path: Path, expected_bytes: int, seconds: float) -> os.stat_result:
@@ -162,17 +184,25 @@ def convert_native(
     converter_script: Path,
     config_path: Path,
     stability_seconds: float,
+    timeout_seconds: float,
 ) -> dict[str, Any]:
     stable_native(source, expected_bytes, stability_seconds)
     source_sha = sha256_file(source)
     output = cache_dir / label
     metadata_path = output.with_suffix(output.suffix + ".json")
+    conversion_identity = {
+        "schema_version": 1,
+        "obs_size": 2782,
+        "converter_sha256": sha256_file(converter_script),
+        "config_sha256": sha256_file(config_path),
+    }
     if output.is_file() and metadata_path.is_file():
         try:
             metadata = load_json(metadata_path)
             if (
                 metadata.get("source_sha256") == source_sha
                 and metadata.get("output_sha256") == sha256_file(output)
+                and metadata.get("conversion_identity") == conversion_identity
             ):
                 return metadata
         except (OSError, ValueError, json.JSONDecodeError):
@@ -206,6 +236,7 @@ def convert_native(
             stderr=subprocess.PIPE,
             env=environment,
             check=False,
+            timeout=timeout_seconds,
         )
         if completed.returncode != 0:
             raise RuntimeError(
@@ -231,6 +262,7 @@ def convert_native(
             "output": str(output),
             "output_bytes": output.stat().st_size,
             "output_sha256": output_sha,
+            "conversion_identity": conversion_identity,
             "converter_command": command,
             "converter_stdout": completed.stdout.strip(),
         }
@@ -245,6 +277,13 @@ def prepare_pair(args: argparse.Namespace) -> dict[str, Any]:
     if not candidates:
         raise RuntimeError("no stable post-bootstrap manifested checkpoint exists")
     current = candidates[-1]
+    stable_native(current.warm_path, current.warm_bytes, args.stability_seconds)
+    baseline_sha = sha256_file(current.warm_path)
+    if baseline_sha != current.warm_sha256:
+        raise RuntimeError(
+            "frozen warm-start hash does not match run manifest: "
+            f"{current.warm_path} ({baseline_sha} != {current.warm_sha256})"
+        )
     current_sha = sha256_file(current.native_path)
     current_meta = convert_native(
         current.native_path,
@@ -255,18 +294,21 @@ def prepare_pair(args: argparse.Namespace) -> dict[str, Any]:
         args.converter_script,
         args.config,
         args.stability_seconds,
+        args.conversion_timeout_seconds,
     )
-    baseline_sha = sha256_file(current.warm_path)
     baseline_meta = convert_native(
         current.warm_path,
-        current.expected_bytes,
+        current.warm_bytes,
         _baseline_label(current, baseline_sha),
         args.cache_dir,
         args.converter_python,
         args.converter_script,
         args.config,
         args.stability_seconds,
+        args.conversion_timeout_seconds,
     )
+    if baseline_meta.get("source_sha256") != current.warm_sha256:
+        raise RuntimeError("frozen warm-start changed during conversion")
     selection = {
         "schema_version": 1,
         "selected_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
@@ -316,6 +358,18 @@ def server_command(
     ]
 
 
+def choose_stream_pair(
+    prepared: tuple[Path, Path] | None,
+    last_successful: tuple[Path, Path] | None,
+    quarantined: set[tuple[Path, Path]],
+    fallback: tuple[Path, Path] | None,
+) -> tuple[Path, Path] | None:
+    """Prefer an unquarantined candidate, then a proven pair, then fallback."""
+    if prepared is not None and prepared not in quarantined:
+        return prepared
+    return last_successful or fallback
+
+
 def run_forever(args: argparse.Namespace) -> int:
     args.state_dir.mkdir(parents=True, exist_ok=True)
     args.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -327,26 +381,35 @@ def run_forever(args: argparse.Namespace) -> int:
             print(f"another BBTV follower holds {lock_path}", file=sys.stderr)
             return 2
 
-        last_pair: tuple[Path, Path] | None = None
+        last_successful_pair: tuple[Path, Path] | None = None
+        quarantined_pairs: set[tuple[Path, Path]] = set()
         failures = 0
         while True:
+            prepared_pair: tuple[Path, Path] | None = None
             try:
                 selection = prepare_pair(args)
-                pair = (
+                prepared_pair = (
                     Path(selection["checkpoint_a"]["output"]),
                     Path(selection["checkpoint_b"]["output"]),
                 )
-                last_pair = pair
-                failures = 0
             except Exception as exc:
                 print(f"BBTV discovery/conversion warning: {exc}", file=sys.stderr)
-                pair = last_pair
-                if pair is None and args.fallback_a and args.fallback_b:
-                    pair = (args.fallback_a, args.fallback_b)
-                if pair is None:
-                    failures += 1
-                    time.sleep(min(args.retry_seconds * failures, 60))
-                    continue
+
+            fallback = (
+                (args.fallback_a, args.fallback_b)
+                if args.fallback_a and args.fallback_b
+                else None
+            )
+            pair = choose_stream_pair(
+                prepared_pair,
+                last_successful_pair,
+                quarantined_pairs,
+                fallback,
+            )
+            if pair is None:
+                failures += 1
+                time.sleep(min(args.retry_seconds * failures, 60))
+                continue
 
             command = server_command(args, *pair)
             status = {
@@ -358,25 +421,40 @@ def run_forever(args: argparse.Namespace) -> int:
             }
             atomic_json(args.state_dir / "server_status.json", status)
             print("BBTV FOLLOW " + json.dumps(status, sort_keys=True), flush=True)
-            completed = subprocess.run(
-                command,
-                cwd=args.server_script.parent,
-                check=False,
-            )
+            try:
+                completed = subprocess.run(
+                    command,
+                    cwd=args.server_script.parent,
+                    check=False,
+                    timeout=args.server_timeout_seconds,
+                )
+                return_code = completed.returncode
+            except subprocess.TimeoutExpired:
+                return_code = 124
+                print(
+                    "BBTV server exceeded its cycle timeout; child was "
+                    "terminated",
+                    file=sys.stderr,
+                    flush=True,
+                )
             status["completed_utc"] = dt.datetime.now(dt.timezone.utc).isoformat()
-            status["exit_code"] = completed.returncode
+            status["exit_code"] = return_code
             atomic_json(args.state_dir / "server_status.json", status)
             selected = {path.resolve() for path in pair}
             prune_cache(args.cache_dir, selected, args.keep_converted)
-            if completed.returncode != 0:
+            if return_code != 0:
+                quarantined_pairs.add(pair)
                 failures += 1
                 print(
-                    f"BBTV server exited {completed.returncode}; retaining last "
-                    f"known-good pair and retrying",
+                    f"BBTV server exited {return_code}; quarantining "
+                    "that pair and reverting to the last successful stream",
                     file=sys.stderr,
                     flush=True,
                 )
                 time.sleep(min(args.retry_seconds * failures, 60))
+            else:
+                last_successful_pair = pair
+                failures = 0
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -396,6 +474,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--games-per-cycle", type=int, default=2)
     parser.add_argument("--stability-seconds", type=float, default=1.0)
     parser.add_argument("--retry-seconds", type=float, default=5.0)
+    parser.add_argument("--conversion-timeout-seconds", type=float, default=300.0)
+    parser.add_argument("--server-timeout-seconds", type=float, default=7200.0)
     parser.add_argument("--keep-converted", type=int, default=24)
     parser.add_argument(
         "--select-only",
@@ -433,8 +513,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         parser.error("--fallback-a and --fallback-b must be provided together")
     if not 1 <= args.port <= 65535:
         parser.error("--port must be in 1..65535")
-    if args.pace <= 0 or args.games_per_cycle <= 0:
-        parser.error("--pace and --games-per-cycle must be positive")
+    if (
+        args.pace <= 0
+        or args.games_per_cycle <= 0
+        or args.conversion_timeout_seconds <= 0
+        or args.server_timeout_seconds <= 0
+    ):
+        parser.error("pace, cycle size, and subprocess timeouts must be positive")
     if args.stability_seconds < 0 or args.keep_converted < 2:
         parser.error("stability must be non-negative and cache must keep >=2")
     return args

--- a/stream_backend/follow_latest.py
+++ b/stream_backend/follow_latest.py
@@ -365,9 +365,10 @@ def choose_stream_pair(
     fallback: tuple[Path, Path] | None,
 ) -> tuple[Path, Path] | None:
     """Prefer an unquarantined candidate, then a proven pair, then fallback."""
-    if prepared is not None and prepared not in quarantined:
-        return prepared
-    return last_successful or fallback
+    for pair in (prepared, last_successful, fallback):
+        if pair is not None and pair not in quarantined:
+            return pair
+    return None
 
 
 def run_forever(args: argparse.Namespace) -> int:
@@ -444,6 +445,8 @@ def run_forever(args: argparse.Namespace) -> int:
             prune_cache(args.cache_dir, selected, args.keep_converted)
             if return_code != 0:
                 quarantined_pairs.add(pair)
+                if pair == last_successful_pair:
+                    last_successful_pair = None
                 failures += 1
                 print(
                     f"BBTV server exited {return_code}; quarantining "

--- a/stream_backend/test_follow_latest.py
+++ b/stream_backend/test_follow_latest.py
@@ -208,6 +208,32 @@ class FollowLatestTests(unittest.TestCase):
             fallback,
         )
 
+    def test_quarantined_last_successful_reverts_to_fallback(self):
+        prepared = (Path("prepared-a"), Path("prepared-b"))
+        previous = (Path("previous-a"), Path("previous-b"))
+        fallback = (Path("fallback-a"), Path("fallback-b"))
+
+        self.assertEqual(
+            follow_latest.choose_stream_pair(
+                prepared, previous, {prepared, previous}, fallback
+            ),
+            fallback,
+        )
+
+    def test_all_quarantined_pairs_are_not_relaunched(self):
+        prepared = (Path("prepared-a"), Path("prepared-b"))
+        previous = (Path("previous-a"), Path("previous-b"))
+        fallback = (Path("fallback-a"), Path("fallback-b"))
+
+        self.assertIsNone(
+            follow_latest.choose_stream_pair(
+                prepared,
+                previous,
+                {prepared, previous, fallback},
+                fallback,
+            )
+        )
+
     def test_safe_label_removes_path_characters(self):
         self.assertEqual(
             follow_latest.safe_label("arm / seed 42:_torch.bin"),

--- a/stream_backend/test_follow_latest.py
+++ b/stream_backend/test_follow_latest.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import json
+import hashlib
 import tempfile
 import time
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 from pathlib import Path
 
@@ -11,13 +13,17 @@ import follow_latest
 
 
 def write_manifest(run, *, tag, seed, warm, expected=16, rollout=4):
+    warm_sha = hashlib.sha256(warm.read_bytes()).hexdigest()
     (run / "RUN_MANIFEST.json").write_text(json.dumps({
+        "schema_version": 1,
         "mode": "native_static_pool_reward_ablation",
         "tag": tag,
         "seed": str(seed),
         "expected_checkpoint_bytes": str(expected),
         "rollout_quantum": str(rollout),
         "warm": str(warm),
+        "warm_bytes": warm.stat().st_size,
+        "warm_sha256": warm_sha,
     }), encoding="utf-8")
 
 
@@ -27,7 +33,7 @@ class FollowLatestTests(unittest.TestCase):
             root = Path(tmp)
             warm = root / "warm.bin"
             warm.write_bytes(b"w" * 16)
-            run = root / "run-1"
+            run = root / "1001"
             run.mkdir()
             write_manifest(run, tag="arm-a", seed=42, warm=warm)
             (run / "0000000000000004.bin").write_bytes(b"i" * 16)
@@ -37,7 +43,7 @@ class FollowLatestTests(unittest.TestCase):
             time.sleep(0.002)
             second = run / "0000000000000016.bin"
             second.write_bytes(b"c" * 16)
-            unmanifested = root / "run-2"
+            unmanifested = root / "1002"
             unmanifested.mkdir()
             (unmanifested / "0000000000000099.bin").write_bytes(b"d" * 16)
 
@@ -47,20 +53,22 @@ class FollowLatestTests(unittest.TestCase):
         self.assertEqual(candidates[-1].tag, "arm-a")
         self.assertEqual(candidates[-1].seed, 42)
 
-    def test_discovery_prefers_latest_mtime_across_runs(self):
+    def test_discovery_prefers_newest_run_then_greatest_step(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             warm = root / "warm.bin"
             warm.write_bytes(b"w" * 16)
-            old = root / "old"
+            old = root / "1001"
             old.mkdir()
             write_manifest(old, tag="old-arm", seed=42, warm=warm)
             (old / "0000000000000100.bin").write_bytes(b"a" * 16)
-            time.sleep(0.002)
-            new = root / "new"
+            new = root / "1002"
             new.mkdir()
             write_manifest(new, tag="new-arm", seed=43, warm=warm)
             (new / "0000000000000050.bin").write_bytes(b"b" * 16)
+            # Touching/restoring the old run must not roll BBTV backward.
+            time.sleep(0.002)
+            (old / "0000000000000100.bin").touch()
 
             candidates = follow_latest.discover_candidates(root)
 
@@ -84,6 +92,10 @@ class FollowLatestTests(unittest.TestCase):
             output = cache / "policy_torch.bin"
             output.write_bytes(b"bad" * 8)
             output.with_suffix(".bin.json").write_text("{", encoding="utf-8")
+            converter = root / "convert.py"
+            converter.write_text("# converter", encoding="utf-8")
+            config = root / "config.ini"
+            config.write_text("[env]", encoding="utf-8")
 
             def fake_run(command, **_kwargs):
                 Path(command[-1]).write_bytes(b"t" * 17)
@@ -96,15 +108,105 @@ class FollowLatestTests(unittest.TestCase):
                     output.name,
                     cache,
                     Path("python"),
-                    Path("convert.py"),
-                    Path("config.ini"),
+                    converter,
+                    config,
                     0,
+                    30,
                 )
 
             rebuilt_source_sha = follow_latest.sha256_file(source)
 
         self.assertEqual(metadata["source_sha256"], rebuilt_source_sha)
         self.assertEqual(metadata["output_bytes"], 17)
+
+    def test_warm_hash_must_match_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            warm = root / "warm.bin"
+            warm.write_bytes(b"w" * 16)
+            run = root / "1001"
+            run.mkdir()
+            write_manifest(run, tag="arm-a", seed=42, warm=warm)
+            (run / "0000000000000012.bin").write_bytes(b"n" * 16)
+            manifest_path = run / "RUN_MANIFEST.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["warm_sha256"] = "0" * 64
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            args = SimpleNamespace(
+                checkpoint_root=root,
+                state_dir=root / "state",
+                cache_dir=root / "cache",
+                stability_seconds=0,
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "does not match"):
+                follow_latest.prepare_pair(args)
+
+    def test_conversion_cache_invalidates_when_config_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "native.bin"
+            source.write_bytes(b"n" * 16)
+            converter = root / "convert.py"
+            converter.write_text("# v1", encoding="utf-8")
+            config = root / "config.ini"
+            config.write_text("v=1", encoding="utf-8")
+            calls = []
+
+            def fake_run(command, **_kwargs):
+                calls.append(command)
+                Path(command[-1]).write_bytes(b"t" * 17)
+                return mock.Mock(returncode=0, stdout="converted", stderr="")
+
+            with mock.patch.object(follow_latest.subprocess, "run", fake_run):
+                for _ in range(2):
+                    follow_latest.convert_native(
+                        source, 16, "policy_torch.bin", root / "cache",
+                        Path("python"), converter, config, 0, 30,
+                    )
+                config.write_text("v=2", encoding="utf-8")
+                follow_latest.convert_native(
+                    source, 16, "policy_torch.bin", root / "cache",
+                    Path("python"), converter, config, 0, 30,
+                )
+
+        self.assertEqual(len(calls), 2)
+
+    def test_conversion_rejects_source_mutation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "native.bin"
+            source.write_bytes(b"n" * 16)
+            converter = root / "convert.py"
+            converter.write_text("# converter", encoding="utf-8")
+            config = root / "config.ini"
+            config.write_text("[env]", encoding="utf-8")
+
+            def fake_run(command, **_kwargs):
+                Path(command[-1]).write_bytes(b"t" * 17)
+                source.write_bytes(b"m" * 16)
+                return mock.Mock(returncode=0, stdout="converted", stderr="")
+
+            with mock.patch.object(follow_latest.subprocess, "run", fake_run):
+                with self.assertRaisesRegex(RuntimeError, "changed during"):
+                    follow_latest.convert_native(
+                        source, 16, "policy_torch.bin", root / "cache",
+                        Path("python"), converter, config, 0, 30,
+                    )
+
+    def test_quarantined_candidate_reverts_to_last_successful_pair(self):
+        bad = (Path("bad-a"), Path("bad-b"))
+        good = (Path("good-a"), Path("good-b"))
+        fallback = (Path("fallback-a"), Path("fallback-b"))
+
+        self.assertEqual(
+            follow_latest.choose_stream_pair(bad, good, {bad}, fallback),
+            good,
+        )
+        self.assertEqual(
+            follow_latest.choose_stream_pair(bad, None, {bad}, fallback),
+            fallback,
+        )
 
     def test_safe_label_removes_path_characters(self):
         self.assertEqual(

--- a/tools/install_puffer_env.sh
+++ b/tools/install_puffer_env.sh
@@ -114,13 +114,13 @@ if [ -f "$ROOT/validation/states/bank.bbs" ]; then
     echo "staged:    $PUFFER/resources/bloodbowl/state_bank.bbs"
 fi
 
-# Blood Bowl's my_log currently emits 82 keys, and vecenv appends "n" after
+# Blood Bowl's my_log currently emits 86 keys, and vecenv appends "n" after
 # the env binding returns. Keep the vendored dict allocations comfortably above
 # that so adding telemetry does not resurrect the historical heap overflow.
 for f in "$PUFFER/src/bindings.cu" "$PUFFER/src/bindings_cpu.cpp" "$PUFFER/src/pufferlib.cu"; do
     [ -f "$f" ] || continue
     perl -0pi -e \
-        's/create_dict\((32|64)\)(\s*;\s*\/\/ bloodbowl my_log emits )[^\n]*/create_dict(96)$2 82 keys + "n"; keep headroom/g;
+        's/create_dict\((32|64)\)(\s*;\s*\/\/ bloodbowl my_log emits )[^\n]*/create_dict(96)$2 86 keys + "n"; keep headroom/g;
          s/create_dict\((32|64)\);/create_dict(96);/g' "$f"
 done
 


### PR DESCRIPTION
## Summary
- make positional turn-end rewards follow monotonic completed-turn counters, including compressed empty opponent turns
- report reward clipping/nonfinite telemetry from raw emission counts instead of macro-averaging episode ratios
- harden BBTV checkpoint selection with manifest hash validation, numeric run ordering, cache identity, timeouts, quarantine, and success-only promotion
- add regression coverage for all corrected behaviors

## Verification
- `make test` (392 engine, 25 reward, 2 contact-bot tests)
- `make asan` (392 engine, 25 reward, 2 contact-bot tests)
- `PYTHONPATH=stream_backend python3 -m unittest stream_backend.test_follow_latest` (12 tests)
- `python3 -m py_compile stream_backend/follow_latest.py stream_backend/test_follow_latest.py`
- `ruff check stream_backend/follow_latest.py stream_backend/test_follow_latest.py`
- `shellcheck tools/install_puffer_env.sh`
- `bash -n tools/install_puffer_env.sh`
- `git diff --check`

## Deployment scope
After merge, deploy only the BBTV follower into the isolated production viewer tree. Do not rebuild or replace the reward module loaded by the active multi-day training run.