### PR TITLE
Add fail-closed vacation experiment autopilot

### DIFF
--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -173,7 +173,9 @@ Freeze the plan before service start and retain its SHA in atomic queue state.
 Require disk, job-runtime, progress, sustained-temperature, and output-validator
 guards. Use typed command/validator/environment values, recursive tree pins for
 directory inputs, and explicit mutable/predecessor-artifact paths; recheck every
-declared pin and use the allowlisted plan environment. Test interruption
+declared pin and use the allowlisted plan environment. Every invocation is a
+pinned executable plus pinned runner; literal values are only numbers,
+lowercase SHA-256 digests, or long flags. Test interruption
 recovery, completed-artifact drift, and fail-closed suppression of later jobs
 before handoff. `Restart=on-failure` recovers a runner crash; a deliberate
 queue halt must exit normally and remain stopped for inspection. Recheck linger,

--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -171,11 +171,16 @@ For a multi-day unattended queue, use the tracked
 `training/systemd/experiment-queue@.service` in the lingering user manager.
 Freeze the plan before service start and retain its SHA in atomic queue state.
 Require disk, job-runtime, progress, sustained-temperature, and output-validator
-guards. Test both interruption recovery and fail-closed suppression of later
+guards; pin every declared executable/input and use the explicit plan
+environment. Test both interruption recovery and fail-closed suppression of later
 jobs before handoff. `Restart=on-failure` recovers a runner crash; a deliberate
 queue halt must exit normally and remain stopped for inspection. Recheck linger,
 Tailscale online/key-expiry state, enabled BBTV services, disk/inodes, journal
 size, and GPU thresholds immediately before departure.
+
+A persisted queue halt is terminal across restart and reboot. Do not edit its
+state to resume it. Preserve the evidence and deploy a new reviewed queue
+ID/plan/state after diagnosis if the user-authorized experiment should continue.
 
 ## Checkpoints and transfer
 

--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -171,9 +171,11 @@ For a multi-day unattended queue, use the tracked
 `training/systemd/experiment-queue@.service` in the lingering user manager.
 Freeze the plan before service start and retain its SHA in atomic queue state.
 Require disk, job-runtime, progress, sustained-temperature, and output-validator
-guards; pin every declared executable/input and use the explicit plan
-environment. Test both interruption recovery and fail-closed suppression of later
-jobs before handoff. `Restart=on-failure` recovers a runner crash; a deliberate
+guards. Use typed command/validator/environment values, recursive tree pins for
+directory inputs, and explicit mutable/predecessor-artifact paths; recheck every
+declared pin and use the allowlisted plan environment. Test interruption
+recovery, completed-artifact drift, and fail-closed suppression of later jobs
+before handoff. `Restart=on-failure` recovers a runner crash; a deliberate
 queue halt must exit normally and remain stopped for inspection. Recheck linger,
 Tailscale online/key-expiry state, enabled BBTV services, disk/inodes, journal
 size, and GPU thresholds immediately before departure.

--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -167,6 +167,16 @@ For a long-running user-directed goal, send a concise progress update about ever
 30 minutes, including active arm, steps/games, integrity state, disk, ETA, and any
 decision needed. Monitoring does not authorize modifying production.
 
+For a multi-day unattended queue, use the tracked
+`training/systemd/experiment-queue@.service` in the lingering user manager.
+Freeze the plan before service start and retain its SHA in atomic queue state.
+Require disk, job-runtime, progress, sustained-temperature, and output-validator
+guards. Test both interruption recovery and fail-closed suppression of later
+jobs before handoff. `Restart=on-failure` recovers a runner crash; a deliberate
+queue halt must exit normally and remain stopped for inspection. Recheck linger,
+Tailscale online/key-expiry state, enabled BBTV services, disk/inodes, journal
+size, and GPU thresholds immediately before departure.
+
 ## Checkpoints and transfer
 
 Select checkpoints by embedded step plus manifest/hash, not newest mtime. Verify

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -477,9 +477,12 @@ from live metrics. Before an unattended window, resolve every branch that can be
 resolved, then freeze literal commands and expected artifacts in a schema-1
 `tools/experiment_queue.py` plan. Every job needs a maximum runtime and success
 validator; long jobs need a progress artifact and short jobs need an explicit
-progress exemption reason. Pin and recheck every executable and referenced
-input by byte size and SHA-256, and use only the plan's explicit base
-environment. The queue root must be the
+progress exemption reason (the exemption is capped at 30 minutes). Use typed
+command/validator/environment values: literal values cannot carry paths;
+immutable file and directory-tree inputs are pinned; output paths are declared
+mutable; generated inputs link to an earlier job's recorded artifact. Pin and
+recheck every executable and transitive input by byte size and SHA-256/tree
+identity, and use only the plan's allowlisted base environment. The queue root must be the
 isolated audit checkout, and the service must use `KillMode=control-group`.
 
 `resume_safe` means the job's own runner validates a frozen manifest and every

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -484,6 +484,8 @@ mutable; generated inputs link to an earlier job's recorded artifact. Pin and
 recheck every executable and transitive input by byte size and SHA-256/tree
 identity, and use only the plan's allowlisted base environment. The queue root must be the
 isolated audit checkout, and the service must use `KillMode=control-group`.
+Inline interpreter/shell code is not a queue command; put logic in a reviewed,
+hash-pinned runner file.
 
 `resume_safe` means the job's own runner validates a frozen manifest and every
 partial/completed artifact before continuing. It does not mean “probably okay

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -470,6 +470,23 @@ Work the queue top-down. Do not reorder without writing a ledger entry justifyin
   the corrected module only in an isolated experiment checkout for the next
   manifested run, then require the full promotion gates before any default.
 
+### Unattended multi-day execution
+
+Do not encode the priority list as an adaptive agent that chooses its next arm
+from live metrics. Before an unattended window, resolve every branch that can be
+resolved, then freeze literal commands and expected artifacts in a schema-1
+`tools/experiment_queue.py` plan. Every job needs a maximum runtime and success
+validator; long jobs need a progress artifact. The queue root must be the
+isolated audit checkout, and the service must use `KillMode=control-group`.
+
+`resume_safe` means the job's own runner validates a frozen manifest and every
+partial/completed artifact before continuing. It does not mean “probably okay
+to rerun.” A plan drift, failed gate, missing/stale progress file, disk limit,
+sustained thermal limit, or invalid success artifact halts the queue and leaves
+later work pending. An unattended queue may produce evidence but may never
+promote a reward or production default. Use
+`docs/vacation-autonomy-2026-07.md` as the operational checklist.
+
 ---
 
 ## 12. Session checklist

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -484,8 +484,10 @@ mutable; generated inputs link to an earlier job's recorded artifact. Pin and
 recheck every executable and transitive input by byte size and SHA-256/tree
 identity, and use only the plan's allowlisted base environment. The queue root must be the
 isolated audit checkout, and the service must use `KillMode=control-group`.
-Inline interpreter/shell code is not a queue command; put logic in a reviewed,
-hash-pinned runner file.
+Every queue invocation is a pinned executable plus a reviewed, hash-pinned
+runner file. Literal arguments are limited to numbers, lowercase SHA-256
+digests, and long flags; categorical/free-form strings belong in the pinned
+runner or config.
 
 `resume_safe` means the job's own runner validates a frozen manifest and every
 partial/completed artifact before continuing. It does not mean “probably okay

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -476,7 +476,10 @@ Do not encode the priority list as an adaptive agent that chooses its next arm
 from live metrics. Before an unattended window, resolve every branch that can be
 resolved, then freeze literal commands and expected artifacts in a schema-1
 `tools/experiment_queue.py` plan. Every job needs a maximum runtime and success
-validator; long jobs need a progress artifact. The queue root must be the
+validator; long jobs need a progress artifact and short jobs need an explicit
+progress exemption reason. Pin and recheck every executable and referenced
+input by byte size and SHA-256, and use only the plan's explicit base
+environment. The queue root must be the
 isolated audit checkout, and the service must use `KillMode=control-group`.
 
 `resume_safe` means the job's own runner validates a frozen manifest and every
@@ -486,6 +489,10 @@ sustained thermal limit, or invalid success artifact halts the queue and leaves
 later work pending. An unattended queue may produce evidence but may never
 promote a reward or production default. Use
 `docs/vacation-autonomy-2026-07.md` as the operational checklist.
+
+A persisted halt is terminal. Do not restart it in place after editing state or
+artifacts. Preserve the halted evidence and create a newly reviewed queue
+ID/plan/state if human diagnosis authorizes follow-up work.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
       - name: Reward, replay, and analyzer contracts
         run: |
           PYTHONPATH=tools python3 -m unittest \
+            tools.test_analyze_reward_candidate_transfer \
             tools.test_analyze_reward_screen \
             tools.test_analyze_reward_transfer \
             tools.test_bbp_behavior_audit \
             tools.test_experiment_contracts \
+            tools.test_experiment_queue \
             tools.test_game_stats \
             tools.test_human_possession \
             tools.test_replay_corpus_audit \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
             tools.test_game_stats \
             tools.test_human_possession \
             tools.test_replay_corpus_audit \
-            tools.test_reward_manifest
+            tools.test_reward_manifest \
+            tools.test_run_reward_candidate_transfer
           for manifest in puffer/config/rewards/*.json; do
             python3 tools/reward_manifest.py "$manifest" --json >/dev/null
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,8 @@ Queue commands and environments use typed values: pin immutable files and
 directory trees, declare audit-root output paths mutable, and link generated
 inputs to an earlier job's recorded success artifact. Long jobs always expose a
 progress file; completed evidence drift halts rather than rerunning training.
+Every invocation uses a pinned executable followed by a pinned runner; literals
+are restricted to numbers, lowercase SHA-256 digests, and long flags.
 
 ## Replay and BC contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,10 @@ progress, thermal, artifact, and validator gates. Mark a job `resume_safe` only
 when its own immutable runner validates partial/completed artifacts. A halted
 job must leave every later job pending. See
 `docs/vacation-autonomy-2026-07.md` for the first deployed contract.
+Queue commands and environments use typed values: pin immutable files and
+directory trees, declare audit-root output paths mutable, and link generated
+inputs to an earlier job's recorded success artifact. Long jobs always expose a
+progress file; completed evidence drift halts rather than rerunning training.
 
 ## Replay and BC contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,15 @@ Use `tools/run_reward_screen.sh`, `tools/reward_manifest.py`,
 `tools/analyze_reward_screen.py`, and `tools/analyze_reward_transfer.py` for the
 audited path. Preserve immutable manifests and completion records.
 
+For unattended multi-day work, use `tools/experiment_queue.py` and the tracked
+`experiment-queue@.service` template. Freeze a literal JSON command queue after
+the preceding evidence chooses its inputs; do not let a running process invent
+branches or promote a reward. Require plan hashes, bounded runtimes, disk,
+progress, thermal, artifact, and validator gates. Mark a job `resume_safe` only
+when its own immutable runner validates partial/completed artifacts. A halted
+job must leave every later job pending. See
+`docs/vacation-autonomy-2026-07.md` for the first deployed contract.
+
 ## Replay and BC contract
 
 - Filter by the embedded replay `rulesVersion`; filenames, directory names, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,11 @@ newer evidence wins.
   rebuild the trainer's Puffer tree or read a checkpoint still being written.
 - Unattended vacation runs use a literal hash-pinned queue, not an adaptive
   experiment-generating agent. `tools/experiment_queue.py` must halt on plan
-  drift, failed validation, stale/absent progress, runtime, disk, or sustained
+  drift, failed validation, stale/absent progress, runtime, disk/inodes, or sustained
   thermal limits; only explicitly restart-validating jobs are `resume_safe`.
+  Commands, validators, and job environment inputs use typed literal/pinned/
+  mutable/predecessor-artifact values; replay-pool directories require recursive
+  tree pins. Never encode a path in a literal or use an untyped environment path.
   Never change a production default from unattended evidence. Operational
   details and the departure smoke gate are in
   `docs/vacation-autonomy-2026-07.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,9 @@ newer evidence wins.
   Commands, validators, and job environment inputs use typed literal/pinned/
   mutable/predecessor-artifact values; replay-pool directories require recursive
   tree pins. Never encode a path in a literal or use an untyped environment path.
-  Inline interpreter/shell code modes are forbidden; use a pinned runner file.
+  Every invocation is a pinned executable plus pinned runner file. Literals are
+  only numbers, lowercase SHA-256 digests, or long flags; put other strings in
+  a pinned runner/config.
   Never change a production default from unattended evidence. Operational
   details and the departure smoke gate are in
   `docs/vacation-autonomy-2026-07.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ newer evidence wins.
   Commands, validators, and job environment inputs use typed literal/pinned/
   mutable/predecessor-artifact values; replay-pool directories require recursive
   tree pins. Never encode a path in a literal or use an untyped environment path.
+  Inline interpreter/shell code modes are forbidden; use a pinned runner file.
   Never change a production default from unattended evidence. Operational
   details and the departure smoke gate are in
   `docs/vacation-autonomy-2026-07.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,13 @@ newer evidence wins.
   checkpoint against that run's frozen warm start. Use the isolated float viewer
   and reversible service override in `docs/bbtv-latest-checkpoint.md`; never
   rebuild the trainer's Puffer tree or read a checkpoint still being written.
+- Unattended vacation runs use a literal hash-pinned queue, not an adaptive
+  experiment-generating agent. `tools/experiment_queue.py` must halt on plan
+  drift, failed validation, stale/absent progress, runtime, disk, or sustained
+  thermal limits; only explicitly restart-validating jobs are `resume_safe`.
+  Never change a production default from unattended evidence. Operational
+  details and the departure smoke gate are in
+  `docs/vacation-autonomy-2026-07.md`.
 
 ### Engine / rules / oracles (stable since v1)
 - PufferLib 4.0 (`vendor/PufferLib`, branch 4.0) uses `src/vecenv.h` macros — the online `env_binding.h` ABI is dead 3.0. `ocean/chess/` is the template; `ocean/convert/` is stale.

--- a/docs/vacation-autonomy-2026-07.md
+++ b/docs/vacation-autonomy-2026-07.md
@@ -40,10 +40,10 @@ The frozen queue uses the July audit's priority order:
 2. Evaluate both policies against frozen learned anchors in both orientations,
    using equal cell weights. Scripted-bot results remain a separate stratum.
 3. Reproduce the paired confirmation from the frozen `league9` second ancestry.
-4. Only if both lineages pass the predeclared non-inferiority and integrity
-   gates, run the matched `4B x 2` final reproduction. Otherwise spend the
-   remaining budget on additional control/candidate seeds and held-out anchor
-   games, not on a new reward recipe.
+4. Run a predeclared gate job. It succeeds only if both lineages pass the
+   non-inferiority and integrity contract; on rejection it halts the literal
+   queue for inspection. Only success unlocks the already-declared matched
+   `4B x 2` final reproduction. There is no dynamic “otherwise” branch.
 5. Stop cleanly when the declared jobs finish. Unused GPU time is preferable to
    an unreviewed objective, backend, opponent, roster, or replay-distribution
    change.
@@ -56,19 +56,28 @@ local/remote smoke; it is never improvised by the running service.
 
 `tools/experiment_queue.py` enforces:
 
-- a singleton file lock and immutable plan SHA-256;
-- absolute paths constrained to the declared audit root;
+- a singleton file lock, immutable plan SHA-256, and a closed schema that
+  rejects unknown or misspelled guard fields;
+- mutable working/log/status/artifact paths constrained to the audit root;
+- an explicit minimal base environment plus size/SHA-256 records for every
+  declared executable, script, checkpoint, config, manifest, and validator,
+  rechecked before and after every job;
 - minimum free disk before and during every job;
-- a maximum job runtime;
-- progress-file staleness, including a file that never appears;
+- a mandatory maximum runtime for every job;
+- mandatory progress-file staleness for long jobs, including a file that never
+  appears, or an explicit reason why a bounded short job needs no progress file;
 - three consecutive over-temperature polls before terminating a process group;
-- exact success artifact SHA-256 and/or a declared validator command;
+- a mandatory bounded validator for every success artifact, plus an expected
+  artifact SHA-256 when it can be known before execution;
 - atomic queue state and per-job logs; and
 - retry after interruption only when that job is explicitly `resume_safe`.
 
 The user service uses `KillMode=control-group`, so a service stop cannot leave a
 trainer child behind. `Restart=on-failure` covers a runner crash; a deliberate
-fail-closed queue halt exits normally and stays stopped for inspection.
+fail-closed queue halt exits normally and is terminal across service restarts
+and reboots. There is intentionally no in-place “acknowledge and continue”
+switch. After diagnosis, recovery requires a newly reviewed queue ID/plan/state;
+the halted evidence remains immutable.
 
 The RTX host currently has systemd user lingering enabled, Tailscale running
 without key expiry, and the BBTV services enabled. These are host facts to
@@ -82,7 +91,9 @@ Do not leave the queue unattended until all of the following are true:
 - local CI and focused queue/transfer tests pass;
 - remote installed-source check passes and GPU identity is recorded;
 - the plan, every referenced input, and every validator are hash-recorded;
-- a deliberate service interruption demonstrates the advertised recovery path;
+- a deliberate interruption demonstrates process-group cleanup and terminal
+  halt for a non-resume-safe job; a separate synthetic resume-safe job
+  demonstrates validated artifact recovery;
 - a synthetic failure demonstrates that later jobs do not start;
 - disk/inode use, journal size, Tailscale, linger, BBTV, and GPU temperature are
   healthy;

--- a/docs/vacation-autonomy-2026-07.md
+++ b/docs/vacation-autonomy-2026-07.md
@@ -59,18 +59,33 @@ local/remote smoke; it is never improvised by the running service.
 - a singleton file lock, immutable plan SHA-256, and a closed schema that
   rejects unknown or misspelled guard fields;
 - mutable working/log/status/artifact paths constrained to the audit root;
-- an explicit minimal base environment plus size/SHA-256 records for every
-  declared executable, script, checkpoint, config, manifest, and validator,
-  rechecked before and after every job;
-- minimum free disk before and during every job;
+- an allowlisted minimal base environment and typed command, validator, and job
+  environment values: literals cannot be path-bearing, immutable paths must be
+  declared pins, mutable paths must be declared under the audit root, and a
+  generated input must name an earlier job's exact success artifact;
+- size/SHA-256 records for every declared executable, script, checkpoint,
+  config, manifest, and validator, plus recursive file-count/byte/tree hashes
+  for directory inputs such as the replay pool, rechecked before and after every
+  job;
+- minimum free bytes and inodes before and during every job, checked on every
+  distinct filesystem used by its mutable paths;
 - a mandatory maximum runtime for every job;
-- mandatory progress-file staleness for long jobs, including a file that never
-  appears, or an explicit reason why a bounded short job needs no progress file;
-- three consecutive over-temperature polls before terminating a process group;
+- mandatory progress-file staleness for jobs longer than 30 minutes, including
+  a file that never appears, or an explicit reason why a job bounded to at most
+  30 minutes needs no progress file;
+- a mandatory GPU temperature ceiling and three consecutive over-temperature
+  polls before terminating a process group;
 - a mandatory bounded validator for every success artifact, plus an expected
   artifact SHA-256 when it can be known before execution;
 - atomic queue state and per-job logs; and
 - retry after interruption only when that job is explicitly `resume_safe`.
+
+A completed job whose recorded success artifact is later missing, changed, or
+invalid halts permanently; it is never silently rerun. `pinned_inputs` is also
+the explicit transitive dependency declaration reviewed with the plan. The
+typed interface blocks ordinary undeclared path arguments and environment
+inputs, while each approved Blood Bowl runner's own frozen manifest validates
+the files it discovers internally.
 
 The user service uses `KillMode=control-group`, so a service stop cannot leave a
 trainer child behind. `Restart=on-failure` covers a runner crash; a deliberate

--- a/docs/vacation-autonomy-2026-07.md
+++ b/docs/vacation-autonomy-2026-07.md
@@ -60,12 +60,14 @@ local/remote smoke; it is never improvised by the running service.
   rejects unknown or misspelled guard fields;
 - mutable working/log/status/artifact paths constrained to the audit root;
 - an allowlisted minimal base environment and typed command, validator, and job
-  environment values: literals cannot be path-bearing, immutable paths must be
+  environment values: literals are restricted to numbers, lowercase SHA-256
+  digests, and long flags; all other strings live in a pinned runner/config;
+  immutable paths must be
   declared pins, mutable paths must be declared under the audit root, and a
   generated input must name an earlier job's exact success artifact;
-- inline interpreter/shell code modes are forbidden; executable logic lives in
-  a hash-pinned runner, and existing relative filesystem names are rejected as
-  literals;
+- every invocation has a pinned executable followed by a pinned runner file;
+  inline code/evaluator modes and relative filesystem literals are impossible
+  regardless of executable name or whether the path exists at plan freeze;
 - size/SHA-256 records for every declared executable, script, checkpoint,
   config, manifest, and validator, plus recursive file-count/byte/tree hashes
   for directory inputs such as the replay pool, rechecked before and after every

--- a/docs/vacation-autonomy-2026-07.md
+++ b/docs/vacation-autonomy-2026-07.md
@@ -20,8 +20,10 @@ from running.
    two training seeds, both available scripted styles, and both team sides.
 3. Select at most one simplification candidate for confirmation. This is only
    a routing decision; scripted bots cannot promote a reward.
-4. Run the longer `1B x 2` confirmation against R0, retaining all four arms if
-   schedule time permits so an early transfer choice cannot hide an interaction.
+4. Freeze the selected candidate and run the longer paired `1B x 2`
+   confirmation against R0. The preceding four-arm factorial remains the
+   interaction evidence; the confirmation spends compute only on the declared
+   reference and candidate.
 5. Freeze the six-day queue only after the screen and transfer artifacts decide
    its literal checkpoint/reward hashes. Review, merge, deploy, start, interrupt,
    and resume-smoke the service before departure.

--- a/docs/vacation-autonomy-2026-07.md
+++ b/docs/vacation-autonomy-2026-07.md
@@ -1,0 +1,96 @@
+# RTX 2070 vacation autonomy plan — July 2026
+
+## Objective and boundary
+
+Use the otherwise-idle RTX 2070 for six days of decision-relevant Blood Bowl
+reward research without allowing an unattended process to invent experiments,
+change production defaults, or continue after ambiguous evidence. BBTV remains
+the visual progress surface and follows only complete manifested checkpoints.
+
+This is an experiment queue, not autonomous reward promotion. Every command,
+input, output, time bound, success validator, and recovery policy is frozen in
+`QUEUE_PLAN.json`; its SHA-256 is copied into `QUEUE_STATE.json`. Changing the
+plan after first start halts the queue. A failed job prevents every later job
+from running.
+
+## The 24 hours before departure
+
+1. Finish and atomically analyze the active `500M x 2` possession/gain screen.
+2. Run all four arms through the 32-cell scripted-opponent transfer matrix:
+   two training seeds, both available scripted styles, and both team sides.
+3. Select at most one simplification candidate for confirmation. This is only
+   a routing decision; scripted bots cannot promote a reward.
+4. Run the longer `1B x 2` confirmation against R0, retaining all four arms if
+   schedule time permits so an early transfer choice cannot hide an interaction.
+5. Freeze the six-day queue only after the screen and transfer artifacts decide
+   its literal checkpoint/reward hashes. Review, merge, deploy, start, interrupt,
+   and resume-smoke the service before departure.
+
+If the pre-departure evidence is incomplete, inconsistent, or rejects every
+simplification, the vacation queue retains R0 as the experimental control. It
+does not guess a candidate.
+
+## Six-day queue order
+
+The frozen queue uses the July audit's priority order:
+
+1. Complete or validate the `1B x 2` R0-versus-candidate confirmation.
+2. Evaluate both policies against frozen learned anchors in both orientations,
+   using equal cell weights. Scripted-bot results remain a separate stratum.
+3. Reproduce the paired confirmation from the frozen `league9` second ancestry.
+4. Only if both lineages pass the predeclared non-inferiority and integrity
+   gates, run the matched `4B x 2` final reproduction. Otherwise spend the
+   remaining budget on additional control/candidate seeds and held-out anchor
+   games, not on a new reward recipe.
+5. Stop cleanly when the declared jobs finish. Unused GPU time is preferable to
+   an unreviewed objective, backend, opponent, roster, or replay-distribution
+   change.
+
+The exact queue may be shorter if the repository lacks a verified launcher for
+a proposed cell. A new launcher is deployed only after focused tests and a
+local/remote smoke; it is never improvised by the running service.
+
+## Runtime safety and recovery
+
+`tools/experiment_queue.py` enforces:
+
+- a singleton file lock and immutable plan SHA-256;
+- absolute paths constrained to the declared audit root;
+- minimum free disk before and during every job;
+- a maximum job runtime;
+- progress-file staleness, including a file that never appears;
+- three consecutive over-temperature polls before terminating a process group;
+- exact success artifact SHA-256 and/or a declared validator command;
+- atomic queue state and per-job logs; and
+- retry after interruption only when that job is explicitly `resume_safe`.
+
+The user service uses `KillMode=control-group`, so a service stop cannot leave a
+trainer child behind. `Restart=on-failure` covers a runner crash; a deliberate
+fail-closed queue halt exits normally and stays stopped for inspection.
+
+The RTX host currently has systemd user lingering enabled, Tailscale running
+without key expiry, and the BBTV services enabled. These are host facts to
+recheck immediately before departure, not assumptions embedded in the queue.
+
+## Departure gate
+
+Do not leave the queue unattended until all of the following are true:
+
+- repository PR merged and the audit checkout is exactly the merged commit;
+- local CI and focused queue/transfer tests pass;
+- remote installed-source check passes and GPU identity is recorded;
+- the plan, every referenced input, and every validator are hash-recorded;
+- a deliberate service interruption demonstrates the advertised recovery path;
+- a synthetic failure demonstrates that later jobs do not start;
+- disk/inode use, journal size, Tailscale, linger, BBTV, and GPU temperature are
+  healthy;
+- BBTV visibly advances to a newly completed manifested checkpoint; and
+- no production reward or production trainer/evaluator was changed.
+
+## Monitoring readout
+
+Each status update reports the current job/arm, completed and requested steps,
+train or eval phase, completed full games, integrity counters, GPU memory/load/
+temperature, free disk, BBTV selection, and estimated completion. Evidence is
+read from the queue state and immutable per-run artifacts; a process name or a
+stale final dashboard line is never treated as proof of liveness or success.

--- a/docs/vacation-autonomy-2026-07.md
+++ b/docs/vacation-autonomy-2026-07.md
@@ -63,6 +63,9 @@ local/remote smoke; it is never improvised by the running service.
   environment values: literals cannot be path-bearing, immutable paths must be
   declared pins, mutable paths must be declared under the audit root, and a
   generated input must name an earlier job's exact success artifact;
+- inline interpreter/shell code modes are forbidden; executable logic lives in
+  a hash-pinned runner, and existing relative filesystem names are rejected as
+  literals;
 - size/SHA-256 records for every declared executable, script, checkpoint,
   config, manifest, and validator, plus recursive file-count/byte/tree hashes
   for directory inputs such as the replay pool, rechecked before and after every
@@ -77,6 +80,8 @@ local/remote smoke; it is never improvised by the running service.
   polls before terminating a process group;
 - a mandatory bounded validator for every success artifact, plus an expected
   artifact SHA-256 when it can be known before execution;
+- validator process-group cleanup, thermal/capacity supervision, and a 10 MiB
+  output cap written on the monitored queue filesystem;
 - atomic queue state and per-job logs; and
 - retry after interruption only when that job is explicitly `resume_safe`.
 

--- a/tools/analyze_reward_candidate_transfer.py
+++ b/tools/analyze_reward_candidate_transfer.py
@@ -24,8 +24,10 @@ from game_stats import dashboard_windows, weighted_dashboard
 
 MANIFEST_PREFIX = "BB_EVAL_MANIFEST "
 INTEGRITY = (
-    "reward_clip_episodes", "reward_nonfinite_episodes", "error_episodes",
-    "demo_episodes", "demo_fallbacks",
+    "reward_clip_frac", "reward_clip_frac_nonzero", "reward_clip_excess",
+    "reward_nonfinite_frac", "reward_clip_episodes",
+    "reward_nonfinite_episodes", "error_episodes", "demo_episodes",
+    "demo_fallbacks",
 )
 METRICS = (
     "champion_score", "win_rate", "draw_rate", "loss_rate",
@@ -137,12 +139,14 @@ def _validate_plan(directory: Path) -> dict[str, Any]:
     bot_teams = _int_list(plan.get("bot_teams"), "bot_teams", {0, 1})
     settings = plan.get("settings")
     implementation = plan.get("implementation")
+    orchestration = plan.get("orchestration_files")
     checkpoints = plan.get("checkpoints")
     gates = plan.get("gates")
     if not all(isinstance(item, dict) for item in (
-            settings, implementation, checkpoints, gates)):
+            settings, implementation, orchestration, checkpoints, gates)):
         raise TransferError(
-            "settings, implementation, checkpoints, and gates must be objects")
+            "settings, implementation, orchestration_files, checkpoints, and "
+            "gates must be objects")
     for key in ("requested_train_steps", "eval_episodes", "min_eval_games"):
         _positive_int(settings.get(key), f"settings.{key}")
     for key in (
@@ -150,6 +154,20 @@ def _validate_plan(directory: Path) -> dict[str, Any]:
         "launcher_sha256",
     ):
         _sha(implementation.get(key), f"implementation.{key}")
+    if not orchestration:
+        raise TransferError("orchestration_files must not be empty")
+    for path_value, expected_sha in orchestration.items():
+        if not isinstance(path_value, str) or not Path(path_value).is_absolute():
+            raise TransferError("orchestration file paths must be absolute")
+        _sha(expected_sha, f"orchestration_files[{path_value!r}]")
+        path = Path(path_value)
+        if not path.is_file():
+            raise TransferError(f"missing orchestration file: {path}")
+        observed_sha = _sha256(path)
+        if observed_sha != expected_sha:
+            raise TransferError(
+                f"orchestration file hash drift: {path}: "
+                f"{observed_sha} != {expected_sha}")
     for arm in (reference, *candidates):
         by_seed = checkpoints.get(arm)
         if not isinstance(by_seed, dict):
@@ -237,8 +255,15 @@ def _validate_cell(
     games = _finite(values.get("n"), f"{path.name} games")
     if games < settings["min_eval_games"]:
         raise TransferError(f"{path.name}: sample too small")
-    bad = {key: values.get(key, 0) for key in INTEGRITY
-           if values.get(key, 0) != 0}
+    missing_integrity = [key for key in INTEGRITY if key not in values]
+    if missing_integrity:
+        raise TransferError(
+            f"{path.name}: missing integrity counters: {missing_integrity}")
+    integrity_values = {
+        key: _finite(values[key], f"{path.name} {key}")
+        for key in INTEGRITY
+    }
+    bad = {key: value for key, value in integrity_values.items() if value != 0}
     if bad:
         raise TransferError(f"{path.name}: integrity counters nonzero: {bad}")
     perspective = bot_perspective(values, bot_team)

--- a/tools/analyze_reward_candidate_transfer.py
+++ b/tools/analyze_reward_candidate_transfer.py
@@ -121,8 +121,8 @@ def _option(command: list[Any], name: str) -> str:
 
 
 def _validate_plan(directory: Path) -> dict[str, Any]:
-    path = directory / "TRANSFER_MANIFEST.json"
-    plan = _load_object(path, "transfer manifest")
+    manifest_path = directory / "TRANSFER_MANIFEST.json"
+    plan = _load_object(manifest_path, "transfer manifest")
     if plan.get("schema_version") != 1:
         raise TransferError("transfer manifest schema_version must be 1")
     reference = plan.get("reference_arm")
@@ -160,13 +160,14 @@ def _validate_plan(directory: Path) -> dict[str, Any]:
         if not isinstance(path_value, str) or not Path(path_value).is_absolute():
             raise TransferError("orchestration file paths must be absolute")
         _sha(expected_sha, f"orchestration_files[{path_value!r}]")
-        path = Path(path_value)
-        if not path.is_file():
-            raise TransferError(f"missing orchestration file: {path}")
-        observed_sha = _sha256(path)
+        orchestration_path = Path(path_value)
+        if not orchestration_path.is_file():
+            raise TransferError(
+                f"missing orchestration file: {orchestration_path}")
+        observed_sha = _sha256(orchestration_path)
         if observed_sha != expected_sha:
             raise TransferError(
-                f"orchestration file hash drift: {path}: "
+                f"orchestration file hash drift: {orchestration_path}: "
                 f"{observed_sha} != {expected_sha}")
     for arm in (reference, *candidates):
         by_seed = checkpoints.get(arm)
@@ -184,8 +185,8 @@ def _validate_plan(directory: Path) -> dict[str, Any]:
         _finite(gates.get(key), f"gates.{key}")
     return {
         **plan,
-        "_path": str(path),
-        "_sha256": _sha256(path),
+        "_path": str(manifest_path),
+        "_sha256": _sha256(manifest_path),
         "_arms": [reference, *candidates],
         "_seeds": seeds,
         "_bot_types": bot_types,
@@ -327,6 +328,8 @@ def analyze(directory: str | Path) -> dict[str, Any]:
         arm: _summary([row for row in rows if row["arm"] == arm])
         for arm in plan["_arms"]
     }
+
+
     reference = plan["reference_arm"]
     contrasts: dict[str, Any] = {}
     for candidate in plan["candidate_arms"]:
@@ -401,6 +404,70 @@ def analyze(directory: str | Path) -> dict[str, Any]:
             "not learned-opponent, roster-grid, confidence-interval, or reward-"
             "promotion evidence."
         ),
+    }
+
+
+def validate_completion_evidence(
+    complete_path: str | Path,
+    *,
+    expected_complete_sha: str,
+    expected_candidate: str,
+) -> dict[str, str]:
+    """Validate the complete semantic and byte-level transfer evidence chain."""
+    complete_path = Path(complete_path).expanduser().resolve()
+    _sha(expected_complete_sha, "expected transfer completion SHA-256")
+    if _sha256(complete_path) != expected_complete_sha:
+        raise TransferError(
+            "transfer completion SHA-256 does not match expectation")
+    complete = _load_object(complete_path, "transfer completion")
+    if complete.get("schema_version") != 1:
+        raise TransferError("unsupported transfer completion schema")
+    if complete.get("recommended_confirmation_arm") != expected_candidate:
+        raise TransferError(
+            "candidate differs from transfer completion recommendation")
+    analysis_path = complete_path.parent / "ANALYSIS.json"
+    manifest_path = complete_path.parent / "TRANSFER_MANIFEST.json"
+    analysis_sha = _sha(
+        complete.get("analysis_sha256"), "completion analysis_sha256")
+    manifest_sha = _sha(
+        complete.get("transfer_manifest_sha256"),
+        "completion transfer_manifest_sha256",
+    )
+    if _sha256(analysis_path) != analysis_sha:
+        raise TransferError("transfer analysis hash chain is invalid")
+    if _sha256(manifest_path) != manifest_sha:
+        raise TransferError("transfer manifest hash chain is invalid")
+    analysis = _load_object(analysis_path, "transfer analysis")
+    if analysis.get("schema_version") != 1:
+        raise TransferError("unsupported transfer analysis schema")
+    recommendation = analysis.get("recommendation")
+    if (not isinstance(recommendation, dict) or
+            recommendation.get("arm") != expected_candidate):
+        raise TransferError(
+            "transfer analysis recommendation differs from candidate")
+    recorded_manifest = analysis.get("transfer_manifest")
+    if (not isinstance(recorded_manifest, dict) or
+            recorded_manifest.get("sha256") != manifest_sha):
+        raise TransferError(
+            "transfer analysis records the wrong transfer manifest")
+    runs = analysis.get("runs")
+    completion_cells = complete.get("cells")
+    if not isinstance(runs, list) or not isinstance(completion_cells, list):
+        raise TransferError("transfer analysis/completion cells must be arrays")
+    analysis_cells = [
+        {"log": row.get("log"), "sha256": row.get("log_sha256")}
+        for row in runs if isinstance(row, dict)
+    ]
+    if len(analysis_cells) != len(runs) or analysis_cells != completion_cells:
+        raise TransferError(
+            "transfer completion cells differ from transfer analysis")
+    return {
+        "transfer_complete": str(complete_path),
+        "transfer_complete_sha256": expected_complete_sha,
+        "analysis": str(analysis_path),
+        "analysis_sha256": analysis_sha,
+        "transfer_manifest": str(manifest_path),
+        "transfer_manifest_sha256": manifest_sha,
     }
 
 

--- a/tools/analyze_reward_candidate_transfer.py
+++ b/tools/analyze_reward_candidate_transfer.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Verify a manifested multi-candidate scripted-opponent transfer matrix.
+
+This is a conservative gate between a self-play reward screen and longer
+confirmation. It can select a candidate for *further testing*, never promote a
+reward. All cells are equal-weighted and the limitations of deterministic bots
+remain explicit in the output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+from contact_bot_stats import bot_perspective
+from game_stats import dashboard_windows, weighted_dashboard
+
+
+MANIFEST_PREFIX = "BB_EVAL_MANIFEST "
+INTEGRITY = (
+    "reward_clip_episodes", "reward_nonfinite_episodes", "error_episodes",
+    "demo_episodes", "demo_fallbacks",
+)
+METRICS = (
+    "champion_score", "win_rate", "draw_rate", "loss_rate",
+    "champion_tds", "bot_tds", "champion_blocks", "bot_blocks",
+)
+
+
+class TransferError(ValueError):
+    pass
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TransferError(f"invalid {label}: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise TransferError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def _finite(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TransferError(f"{label} must be numeric")
+    value = float(value)
+    if not math.isfinite(value):
+        raise TransferError(f"{label} must be finite")
+    return value
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise TransferError(f"{label} must be a positive integer")
+    return value
+
+
+def _int_list(value: Any, label: str, allowed: set[int] | None = None) -> list[int]:
+    if (not isinstance(value, list) or not value or
+            not all(isinstance(item, int) and not isinstance(item, bool)
+                    for item in value) or len(set(value)) != len(value)):
+        raise TransferError(f"{label} must contain unique integers")
+    if allowed is not None and not set(value) <= allowed:
+        raise TransferError(f"{label} contains unsupported values")
+    return value
+
+
+def _arms(value: Any, label: str) -> list[str]:
+    if (not isinstance(value, list) or not value or
+            not all(isinstance(item, str) and item for item in value) or
+            len(set(value)) != len(value)):
+        raise TransferError(f"{label} must contain unique nonempty strings")
+    return value
+
+
+def _sha(value: Any, label: str) -> str:
+    if (not isinstance(value, str) or len(value) != 64 or
+            any(char not in "0123456789abcdef" for char in value)):
+        raise TransferError(f"{label} must be a lowercase SHA-256")
+    return value
+
+
+def _eval_manifest(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(errors="ignore", encoding="utf-8") as handle:
+            first = handle.readline().rstrip("\n")
+    except OSError as exc:
+        raise TransferError(f"cannot read transfer cell {path}: {exc}") from exc
+    if not first.startswith(MANIFEST_PREFIX):
+        raise TransferError(f"{path.name}: missing first-line eval manifest")
+    try:
+        value = json.loads(first[len(MANIFEST_PREFIX):])
+    except json.JSONDecodeError as exc:
+        raise TransferError(f"{path.name}: invalid eval manifest: {exc}") from exc
+    if not isinstance(value, dict):
+        raise TransferError(f"{path.name}: eval manifest must be an object")
+    return value
+
+
+def _option(command: list[Any], name: str) -> str:
+    indices = [index for index, value in enumerate(command) if value == name]
+    if len(indices) != 1 or indices[0] + 1 >= len(command):
+        raise TransferError(f"command must contain exactly one {name}")
+    value = command[indices[0] + 1]
+    if not isinstance(value, str):
+        raise TransferError(f"command value for {name} must be a string")
+    return value
+
+
+def _validate_plan(directory: Path) -> dict[str, Any]:
+    path = directory / "TRANSFER_MANIFEST.json"
+    plan = _load_object(path, "transfer manifest")
+    if plan.get("schema_version") != 1:
+        raise TransferError("transfer manifest schema_version must be 1")
+    reference = plan.get("reference_arm")
+    if not isinstance(reference, str) or not reference:
+        raise TransferError("reference_arm must be a nonempty string")
+    candidates = _arms(plan.get("candidate_arms"), "candidate_arms")
+    if reference in candidates:
+        raise TransferError("reference_arm cannot also be a candidate")
+    preference = _arms(plan.get("preference_order"), "preference_order")
+    if set(preference) != set(candidates):
+        raise TransferError("preference_order must contain every candidate exactly once")
+    seeds = _int_list(plan.get("seeds"), "seeds")
+    bot_types = _int_list(plan.get("bot_types"), "bot_types", {0, 1})
+    bot_teams = _int_list(plan.get("bot_teams"), "bot_teams", {0, 1})
+    settings = plan.get("settings")
+    implementation = plan.get("implementation")
+    checkpoints = plan.get("checkpoints")
+    gates = plan.get("gates")
+    if not all(isinstance(item, dict) for item in (
+            settings, implementation, checkpoints, gates)):
+        raise TransferError(
+            "settings, implementation, checkpoints, and gates must be objects")
+    for key in ("requested_train_steps", "eval_episodes", "min_eval_games"):
+        _positive_int(settings.get(key), f"settings.{key}")
+    for key in (
+        "config_sha256", "compiled_module_sha256", "pufferl_sha256",
+        "launcher_sha256",
+    ):
+        _sha(implementation.get(key), f"implementation.{key}")
+    for arm in (reference, *candidates):
+        by_seed = checkpoints.get(arm)
+        if not isinstance(by_seed, dict):
+            raise TransferError(f"missing checkpoint map for {arm}")
+        for seed in seeds:
+            record = by_seed.get(str(seed))
+            if not isinstance(record, dict):
+                raise TransferError(f"missing checkpoint for {arm}/seed {seed}")
+            _sha(record.get("torch_sha256"), f"{arm}/seed {seed} torch_sha256")
+    for key in (
+        "mean_score_delta_min", "cell_score_delta_min",
+        "max_champion_td_relative_drop", "max_bot_td_relative_rise",
+    ):
+        _finite(gates.get(key), f"gates.{key}")
+    return {
+        **plan,
+        "_path": str(path),
+        "_sha256": _sha256(path),
+        "_arms": [reference, *candidates],
+        "_seeds": seeds,
+        "_bot_types": bot_types,
+        "_bot_teams": bot_teams,
+    }
+
+
+def _validate_cell(
+    path: Path, plan: dict[str, Any], arm: str, seed: int,
+    bot_type: int, bot_team: int,
+) -> dict[str, Any]:
+    if not path.is_file():
+        raise TransferError(f"missing transfer cell: {path}")
+    manifest = _eval_manifest(path)
+    settings = plan["settings"]
+    expected = {
+        "schema_version": 1,
+        "mode": "scripted_bot_frozen",
+        "checkpoint_sha256": plan["checkpoints"][arm][str(seed)]["torch_sha256"],
+        "requested_train_steps": settings["requested_train_steps"],
+        "seed": seed,
+        "bot_type": bot_type,
+        "bot_team": bot_team,
+        "eval_episodes": settings["eval_episodes"],
+        "min_eval_games": settings["min_eval_games"],
+        **plan["implementation"],
+    }
+    for key, value in expected.items():
+        if manifest.get(key) != value:
+            raise TransferError(
+                f"{path.name}: manifest {key}={manifest.get(key)!r}, "
+                f"expected {value!r}")
+    command = manifest.get("command")
+    if (not isinstance(command, list) or
+            not all(isinstance(value, str) for value in command)):
+        raise TransferError(f"{path.name}: manifest command must be strings")
+    for name, value in (
+        ("--train.total-timesteps", settings["requested_train_steps"]),
+        ("--eval-episodes", settings["eval_episodes"]),
+        ("--seed", seed), ("--train.seed", seed), ("--env.seed", seed),
+        ("--env.scripted-opponent-type", bot_type),
+        ("--env.scripted-opponent-team", bot_team),
+    ):
+        if _option(command, name) != str(value):
+            raise TransferError(f"{path.name}: command mismatch for {name}")
+
+    windows = dashboard_windows(path)
+    if not windows:
+        raise TransferError(f"{path.name}: no telemetry windows")
+    if any(int(window.get("_puffer_schema", 0)) < 2 for window in windows):
+        raise TransferError(f"{path.name}: pre-schema-2 telemetry")
+    finals = [
+        window for window in windows
+        if window.get("_puffer_final_reprint", 0) > 0
+        and window.get("_puffer_phase_eval", 0) > 0
+    ]
+    if len(finals) != 1:
+        raise TransferError(
+            f"{path.name}: expected one final eval reprint, got {len(finals)}")
+    completed = _finite(
+        finals[0].get("_puffer_eval_episodes_completed"),
+        f"{path.name} cumulative eval games",
+    )
+    if completed < settings["min_eval_games"]:
+        raise TransferError(f"{path.name}: cumulative game gate failed")
+    values = weighted_dashboard(path)
+    games = _finite(values.get("n"), f"{path.name} games")
+    if games < settings["min_eval_games"]:
+        raise TransferError(f"{path.name}: sample too small")
+    bad = {key: values.get(key, 0) for key in INTEGRITY
+           if values.get(key, 0) != 0}
+    if bad:
+        raise TransferError(f"{path.name}: integrity counters nonzero: {bad}")
+    perspective = bot_perspective(values, bot_team)
+    score = _finite(perspective["champion_score"], f"{path.name} score")
+    draw = _finite(values.get("draw_rate"), f"{path.name} draw rate")
+    win = score - 0.5 * draw
+    loss = 1.0 - win - draw
+    if min(win, draw, loss) < -1e-6 or max(win, draw, loss) > 1 + 1e-6:
+        raise TransferError(f"{path.name}: impossible derived W/D/L")
+    return {
+        "arm": arm, "seed": seed, "bot_type": bot_type,
+        "bot_team": bot_team, "games": games,
+        "eval_episodes_completed": completed, "log": path.name,
+        "log_sha256": _sha256(path),
+        "checkpoint_sha256": expected["checkpoint_sha256"],
+        "champion_score": score, "win_rate": win, "draw_rate": draw,
+        "loss_rate": loss,
+        "champion_tds": _finite(
+            perspective["champion_tds"], f"{path.name} champion TDs"),
+        "bot_tds": _finite(perspective["bot_tds"], f"{path.name} bot TDs"),
+        "champion_blocks": _finite(
+            perspective["champion_blocks"], f"{path.name} champion blocks"),
+        "bot_blocks": _finite(
+            perspective["bot_blocks"], f"{path.name} bot blocks"),
+    }
+
+
+def _summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        metric: {
+            "mean": statistics.fmean(row[metric] for row in rows),
+            "sample_sd": statistics.stdev(row[metric] for row in rows)
+            if len(rows) > 1 else 0.0,
+            "min": min(row[metric] for row in rows),
+            "max": max(row[metric] for row in rows),
+        }
+        for metric in METRICS
+    }
+
+
+def _relative_delta(candidate: float, reference: float) -> float:
+    if reference <= 0:
+        raise TransferError("relative gate reference must be positive")
+    return (candidate - reference) / reference
+
+
+def analyze(directory: str | Path) -> dict[str, Any]:
+    directory = Path(directory).expanduser().resolve()
+    if not directory.is_dir():
+        raise TransferError(f"transfer directory does not exist: {directory}")
+    plan = _validate_plan(directory)
+    rows = []
+    for arm in plan["_arms"]:
+        for seed in plan["_seeds"]:
+            for bot_type in plan["_bot_types"]:
+                for bot_team in plan["_bot_teams"]:
+                    path = directory / f"{arm}-s{seed}-b{bot_type}-t{bot_team}.log"
+                    rows.append(_validate_cell(
+                        path, plan, arm, seed, bot_type, bot_team))
+    summaries = {
+        arm: _summary([row for row in rows if row["arm"] == arm])
+        for arm in plan["_arms"]
+    }
+    reference = plan["reference_arm"]
+    contrasts: dict[str, Any] = {}
+    for candidate in plan["candidate_arms"]:
+        paired = []
+        for seed in plan["_seeds"]:
+            for bot_type in plan["_bot_types"]:
+                for bot_team in plan["_bot_teams"]:
+                    key = (seed, bot_type, bot_team)
+                    cells = {
+                        row["arm"]: row for row in rows
+                        if (row["seed"], row["bot_type"], row["bot_team"]) == key
+                        and row["arm"] in (reference, candidate)
+                    }
+                    paired.append({
+                        "seed": seed, "bot_type": bot_type, "bot_team": bot_team,
+                        **{metric: cells[candidate][metric] - cells[reference][metric]
+                           for metric in METRICS},
+                    })
+        summary = _summary(paired)
+        gates = plan["gates"]
+        candidate_summary = summaries[candidate]
+        reference_summary = summaries[reference]
+        td_drop = -_relative_delta(
+            candidate_summary["champion_tds"]["mean"],
+            reference_summary["champion_tds"]["mean"],
+        )
+        bot_td_rise = _relative_delta(
+            candidate_summary["bot_tds"]["mean"],
+            reference_summary["bot_tds"]["mean"],
+        )
+        failures = []
+        if summary["champion_score"]["mean"] < gates["mean_score_delta_min"]:
+            failures.append("mean_score_delta")
+        if summary["champion_score"]["min"] < gates["cell_score_delta_min"]:
+            failures.append("cell_score_delta")
+        if td_drop > gates["max_champion_td_relative_drop"]:
+            failures.append("champion_td_relative_drop")
+        if bot_td_rise > gates["max_bot_td_relative_rise"]:
+            failures.append("bot_td_relative_rise")
+        contrasts[candidate] = {
+            "cells": paired,
+            "summary": summary,
+            "champion_td_relative_drop": td_drop,
+            "bot_td_relative_rise": bot_td_rise,
+            "eligible": not failures,
+            "gate_failures": failures,
+        }
+    eligible = [arm for arm in plan["preference_order"]
+                if contrasts[arm]["eligible"]]
+    selected = eligible[0] if eligible else reference
+    return {
+        "schema_version": 1,
+        "analysis": "reward_candidate_scripted_transfer",
+        "directory": str(directory),
+        "transfer_manifest": {
+            "path": plan["_path"], "sha256": plan["_sha256"],
+        },
+        "reference_arm": reference,
+        "candidate_arms": plan["candidate_arms"],
+        "cell_count": len(rows),
+        "total_games": sum(row["games"] for row in rows),
+        "runs": rows,
+        "arm_summaries": summaries,
+        "candidate_contrasts": contrasts,
+        "recommendation": {
+            "arm": selected,
+            "eligible_candidates_in_preference_order": eligible,
+            "purpose": "candidate for longer confirmation only",
+        },
+        "warning": (
+            "Deterministic scripted opponents are a conservative transfer gate, "
+            "not learned-opponent, roster-grid, confidence-interval, or reward-"
+            "promotion evidence."
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        report = analyze(args.directory)
+    except (OSError, TransferError, ValueError) as exc:
+        print(f"candidate-transfer analysis failed: {exc}", file=sys.stderr)
+        return 2
+    rendered = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        temporary = args.output.with_suffix(args.output.suffix + ".tmp")
+        temporary.write_text(rendered, encoding="utf-8")
+        temporary.replace(args.output)
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/analyze_reward_candidate_transfer.py
+++ b/tools/analyze_reward_candidate_transfer.py
@@ -440,6 +440,10 @@ def validate_completion_evidence(
     analysis = _load_object(analysis_path, "transfer analysis")
     if analysis.get("schema_version") != 1:
         raise TransferError("unsupported transfer analysis schema")
+    regenerated = analyze(complete_path.parent)
+    if analysis != regenerated:
+        raise TransferError(
+            "stored transfer analysis differs from regenerated cell evidence")
     recommendation = analysis.get("recommendation")
     if (not isinstance(recommendation, dict) or
             recommendation.get("arm") != expected_candidate):

--- a/tools/analyze_reward_screen.py
+++ b/tools/analyze_reward_screen.py
@@ -133,6 +133,8 @@ POSSESSION_GAIN_EFFECT_DEFINITIONS = {
     ),
 }
 
+PAIRED_CANDIDATES = ("possession_only", "gain_only", "neither")
+
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 
 
@@ -206,6 +208,34 @@ def _screen_spec(contract: dict[str, Any]) -> dict[str, Any]:
             "reward_sha256": POSSESSION_GAIN_REWARD_SHA256,
             "factors": POSSESSION_GAIN_FACTORS,
             "effect_definitions": POSSESSION_GAIN_EFFECT_DEFINITIONS,
+        }
+    if profile == "paired-confirmation":
+        candidate = contract.get("candidate_arm")
+        if candidate not in PAIRED_CANDIDATES:
+            raise AnalysisError(
+                "paired-confirmation candidate_arm must be one of "
+                + ", ".join(PAIRED_CANDIDATES)
+            )
+        return {
+            "profile": profile,
+            "candidate_arm": candidate,
+            "schedule": (
+                ("both", 42), (candidate, 42),
+                (candidate, 43), ("both", 43),
+            ),
+            "reward_sha256": {
+                arm: POSSESSION_GAIN_REWARD_SHA256[arm]
+                for arm in ("both", candidate)
+            },
+            "factors": {
+                "both": {"candidate": False},
+                candidate: {"candidate": True},
+            },
+            "effect_definitions": {
+                "candidate_minus_both": (
+                    f"{candidate} - both; positive favors the simpler candidate"
+                ),
+            },
         }
     raise AnalysisError(f"unsupported reward-screen profile: {profile!r}")
 
@@ -371,7 +401,8 @@ def _validate_completion(
         raise AnalysisError("completion proof belongs to another screen plan")
     entries = complete.get("results")
     if not isinstance(entries, list) or len(entries) != len(schedule):
-        raise AnalysisError("completion proof must contain all eight results")
+        raise AnalysisError(
+            f"completion proof must contain all {len(schedule)} results")
 
     for expected, recorded in zip(schedule, entries):
         if not isinstance(recorded, dict):
@@ -430,6 +461,12 @@ def _factorial_effects(
             "interaction": r0 - r1 - r2 + r3,
         }
     both = cells["both"]
+    if profile == "paired-confirmation":
+        candidates = [arm for arm in cells if arm != "both"]
+        if len(candidates) != 1:
+            raise AnalysisError(
+                "paired-confirmation requires exactly one candidate cell")
+        return {"candidate_minus_both": cells[candidates[0]] - both}
     possession = cells["possession_only"]
     gain = cells["gain_only"]
     neither = cells["neither"]
@@ -541,7 +578,7 @@ def analyze_screen(
     else:
         completion = {"present": False}
         warnings.append(
-            "SCREEN_COMPLETE.json is absent: eight accepted results were "
+            f"SCREEN_COMPLETE.json is absent: {len(schedule)} accepted results were "
             "verified, but the atomic screen completion proof is unavailable."
         )
 
@@ -590,6 +627,7 @@ def analyze_screen(
             "directory": str(directory),
             "prefix": prefix,
             "profile": spec["profile"],
+            "candidate_arm": spec.get("candidate_arm"),
             "manifest_file": manifest_path.name,
             "manifest_sha256": manifest_sha,
             "requested_steps": contract.get("requested_steps"),
@@ -641,7 +679,11 @@ def render_text(report: dict[str, Any]) -> str:
         )
 
     lines.append("")
-    lines.append("Per-seed 2x2 effects")
+    lines.append(
+        "Per-seed paired contrasts"
+        if screen["profile"] == "paired-confirmation"
+        else "Per-seed 2x2 effects"
+    )
     for seed in ("42", "43"):
         lines.append(f"  seed {seed}")
         for metric in report["metrics"]:

--- a/tools/analyze_reward_screen.py
+++ b/tools/analyze_reward_screen.py
@@ -622,7 +622,11 @@ def analyze_screen(
 
     return {
         "schema_version": 1,
-        "analysis": "paired_reward_screen_2x2",
+        "analysis": (
+            "paired_reward_confirmation"
+            if spec["profile"] == "paired-confirmation"
+            else "paired_reward_screen_2x2"
+        ),
         "screen": {
             "directory": str(directory),
             "prefix": prefix,

--- a/tools/eval_vs_contact_bot.sh
+++ b/tools/eval_vs_contact_bot.sh
@@ -189,10 +189,15 @@ games = values.get("n", 0)
 if games < minimum:
     raise SystemExit(f"scripted eval sample too small: {games:g} < {minimum}")
 integrity = (
-    "reward_clip_episodes", "reward_nonfinite_episodes", "error_episodes",
-    "demo_episodes", "demo_fallbacks",
+    "reward_clip_frac", "reward_clip_frac_nonzero", "reward_clip_excess",
+    "reward_nonfinite_frac", "reward_clip_episodes",
+    "reward_nonfinite_episodes", "error_episodes", "demo_episodes",
+    "demo_fallbacks",
 )
-bad = {key: values.get(key, 0) for key in integrity if values.get(key, 0) != 0}
+missing = [key for key in integrity if key not in values]
+if missing:
+    raise SystemExit(f"scripted eval missing integrity counters: {missing}")
+bad = {key: values[key] for key in integrity if values[key] != 0}
 if bad:
     raise SystemExit(f"scripted eval integrity gate failed: {bad}")
 print(f"validated scripted eval: {games:.0f} games; cumulative gate {completed:.0f}")

--- a/tools/experiment_queue.py
+++ b/tools/experiment_queue.py
@@ -29,6 +29,22 @@ class QueueError(ValueError):
     pass
 
 
+PLAN_KEYS = {
+    "schema_version", "queue_id", "root", "min_free_bytes", "poll_seconds",
+    "max_gpu_temperature_c", "base_env", "pinned_files", "jobs",
+}
+JOB_KEYS = {
+    "id", "command", "cwd", "log", "success", "env", "resume_safe",
+    "max_runtime_seconds", "progress", "progress_not_required_reason",
+    "pinned_inputs",
+}
+SUCCESS_KEYS = {
+    "path", "sha256", "validator", "validator_timeout_seconds",
+}
+PROGRESS_KEYS = {"path", "max_stale_seconds"}
+PIN_KEYS = {"path", "bytes", "sha256", "role"}
+
+
 def utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat()
 
@@ -75,8 +91,22 @@ def _absolute(value: Any, label: str, root: Path) -> Path:
     return resolved
 
 
-def validate_plan(path: Path) -> tuple[dict[str, Any], Path]:
-    plan = load_object(path, "queue plan")
+def _unknown(mapping: dict[str, Any], allowed: set[str], label: str) -> None:
+    unexpected = sorted(set(mapping) - allowed)
+    if unexpected:
+        raise QueueError(f"unknown {label} fields: {', '.join(unexpected)}")
+
+
+def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
+    try:
+        raw = path.read_bytes()
+        plan = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise QueueError(f"invalid queue plan {path}: {exc}") from exc
+    if not isinstance(plan, dict):
+        raise QueueError(f"queue plan must be a JSON object: {path}")
+    plan_sha = hashlib.sha256(raw).hexdigest()
+    _unknown(plan, PLAN_KEYS, "queue plan")
     if plan.get("schema_version") != 1:
         raise QueueError("queue plan schema_version must be 1")
     queue_id = plan.get("queue_id")
@@ -91,9 +121,10 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path]:
     minimum = plan.get("min_free_bytes")
     if isinstance(minimum, bool) or not isinstance(minimum, int) or minimum < 1:
         raise QueueError("min_free_bytes must be a positive integer")
-    poll = plan.get("poll_seconds", 30)
-    if isinstance(poll, bool) or not isinstance(poll, (int, float)) or poll <= 0:
-        raise QueueError("poll_seconds must be positive")
+    poll = plan.get("poll_seconds")
+    if (isinstance(poll, bool) or not isinstance(poll, (int, float)) or
+            not 0 < poll <= 60):
+        raise QueueError("poll_seconds must be in (0, 60]")
     maximum_temperature = plan.get("max_gpu_temperature_c")
     if maximum_temperature is not None and (
         isinstance(maximum_temperature, bool)
@@ -101,6 +132,35 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path]:
         or not 1 <= maximum_temperature <= 120
     ):
         raise QueueError("max_gpu_temperature_c must be in 1..120")
+    base_env = plan.get("base_env")
+    if (not isinstance(base_env, dict) or
+            not all(isinstance(key, str) and key and isinstance(value, str)
+                    for key, value in base_env.items())):
+        raise QueueError("base_env must map nonempty strings to strings")
+    pinned_files = plan.get("pinned_files")
+    if not isinstance(pinned_files, list) or not pinned_files:
+        raise QueueError("pinned_files must be a nonempty array")
+    pinned_paths: set[str] = set()
+    for index, pin in enumerate(pinned_files, 1):
+        if not isinstance(pin, dict):
+            raise QueueError(f"pinned file {index} must be an object")
+        _unknown(pin, PIN_KEYS, f"pinned file {index}")
+        pin_path = pin.get("path")
+        if not isinstance(pin_path, str) or not Path(pin_path).is_absolute():
+            raise QueueError(f"pinned file {index} path must be absolute")
+        resolved_pin = str(Path(pin_path).expanduser().resolve())
+        if resolved_pin in pinned_paths:
+            raise QueueError(f"duplicate pinned file path: {resolved_pin}")
+        pinned_paths.add(resolved_pin)
+        size = pin.get("bytes")
+        if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+            raise QueueError(f"pinned file {index} bytes must be nonnegative")
+        expected = pin.get("sha256")
+        if (not isinstance(expected, str) or len(expected) != 64 or
+                any(char not in "0123456789abcdef" for char in expected)):
+            raise QueueError(f"pinned file {index} sha256 is invalid")
+        if not isinstance(pin.get("role"), str) or not pin["role"]:
+            raise QueueError(f"pinned file {index} role must be nonempty")
     jobs = plan.get("jobs")
     if not isinstance(jobs, list) or not jobs:
         raise QueueError("jobs must be a nonempty array")
@@ -108,6 +168,7 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path]:
     for index, job in enumerate(jobs, 1):
         if not isinstance(job, dict):
             raise QueueError(f"job {index} must be an object")
+        _unknown(job, JOB_KEYS, f"job {index}")
         job_id = job.get("id")
         if not isinstance(job_id, str) or not job_id or job_id in seen:
             raise QueueError(f"job {index} has an invalid or duplicate id")
@@ -121,6 +182,7 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path]:
         success = job.get("success")
         if not isinstance(success, dict):
             raise QueueError(f"job {job_id} success must be an object")
+        _unknown(success, SUCCESS_KEYS, f"job {job_id} success")
         _absolute(success.get("path"), f"job {job_id} success path", root)
         expected_sha = success.get("sha256")
         if (expected_sha is not None and
@@ -128,38 +190,121 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path]:
                  any(char not in "0123456789abcdef" for char in expected_sha))):
             raise QueueError(f"job {job_id} success sha256 is invalid")
         validator = success.get("validator")
-        if (validator is not None and
-                (not isinstance(validator, list) or not validator or
-                 not all(isinstance(item, str) and item for item in validator))):
+        if (not isinstance(validator, list) or not validator or
+                not all(isinstance(item, str) and item for item in validator)):
             raise QueueError(f"job {job_id} validator must be nonempty strings")
+        validator_timeout = success.get("validator_timeout_seconds")
+        if (isinstance(validator_timeout, bool) or
+                not isinstance(validator_timeout, (int, float)) or
+                validator_timeout <= 0):
+            raise QueueError(
+                f"job {job_id} validator_timeout_seconds must be positive")
         env = job.get("env", {})
         if (not isinstance(env, dict) or
                 not all(isinstance(k, str) and isinstance(v, str)
                         for k, v in env.items())):
             raise QueueError(f"job {job_id} env must map strings to strings")
-        resume_safe = job.get("resume_safe", False)
+        job_pins = job.get("pinned_inputs")
+        if (not isinstance(job_pins, list) or not job_pins or
+                not all(isinstance(value, str) and Path(value).is_absolute()
+                        for value in job_pins)):
+            raise QueueError(
+                f"job {job_id} pinned_inputs must be nonempty absolute paths")
+        resolved_job_pins = {
+            str(Path(value).expanduser().resolve()) for value in job_pins
+        }
+        if len(resolved_job_pins) != len(job_pins):
+            raise QueueError(f"job {job_id} pinned_inputs contains duplicates")
+        if not resolved_job_pins <= pinned_paths:
+            missing_pins = sorted(resolved_job_pins - pinned_paths)
+            raise QueueError(
+                f"job {job_id} references undeclared pins: {missing_pins}")
+        resume_safe = job.get("resume_safe")
         if not isinstance(resume_safe, bool):
             raise QueueError(f"job {job_id} resume_safe must be boolean")
         max_runtime = job.get("max_runtime_seconds")
-        if max_runtime is not None and (
+        if (
             isinstance(max_runtime, bool)
             or not isinstance(max_runtime, (int, float))
-            or max_runtime <= 0
+            or max_runtime < 2 * poll
         ):
             raise QueueError(
-                f"job {job_id} max_runtime_seconds must be positive"
+                f"job {job_id} max_runtime_seconds must be at least two polls"
             )
         progress = job.get("progress")
+        no_progress_reason = job.get("progress_not_required_reason")
+        if (progress is None) == (no_progress_reason is None):
+            raise QueueError(
+                f"job {job_id} must declare exactly one of progress or "
+                "progress_not_required_reason")
+        if no_progress_reason is not None and (
+            not isinstance(no_progress_reason, str) or not no_progress_reason.strip()
+        ):
+            raise QueueError(
+                f"job {job_id} progress_not_required_reason must be nonempty")
         if progress is not None:
             if not isinstance(progress, dict):
                 raise QueueError(f"job {job_id} progress must be an object")
+            _unknown(progress, PROGRESS_KEYS, f"job {job_id} progress")
             _absolute(progress.get("path"), f"job {job_id} progress path", root)
             stale = progress.get("max_stale_seconds")
             if (isinstance(stale, bool) or not isinstance(stale, (int, float)) or
-                    stale <= 0):
+                    stale < 2 * poll):
                 raise QueueError(
-                    f"job {job_id} max_stale_seconds must be positive")
-    return plan, root
+                    f"job {job_id} max_stale_seconds must be at least two polls")
+        for executable, label in (
+            (command[0], "command executable"),
+            (validator[0], "validator executable"),
+        ):
+            if not Path(executable).is_absolute():
+                raise QueueError(f"job {job_id} {label} must be absolute")
+            resolved_executable = str(Path(executable).expanduser().resolve())
+            if resolved_executable not in pinned_paths:
+                raise QueueError(
+                    f"job {job_id} {label} is not pinned: {resolved_executable}")
+            if resolved_executable not in resolved_job_pins:
+                raise QueueError(
+                    f"job {job_id} {label} is not in pinned_inputs: "
+                    f"{resolved_executable}")
+        referenced_values = [*command, *validator, *env.values()]
+        mutable_paths = {
+            str(_absolute(job["log"], f"job {job_id} log", root)),
+            str(_absolute(success["path"], f"job {job_id} success path", root)),
+        }
+        if progress is not None:
+            mutable_paths.add(str(_absolute(
+                progress["path"], f"job {job_id} progress path", root)))
+        for value in referenced_values:
+            candidate = Path(value).expanduser()
+            if candidate.is_absolute() and candidate.is_file():
+                resolved_candidate = str(candidate.resolve())
+                if resolved_candidate in mutable_paths:
+                    continue
+                if resolved_candidate not in resolved_job_pins:
+                    raise QueueError(
+                        f"job {job_id} file argument is not in pinned_inputs: "
+                        f"{resolved_candidate}")
+    return plan, root, plan_sha
+
+
+def pinned_files_error(plan: dict[str, Any]) -> str | None:
+    for pin in plan["pinned_files"]:
+        path = Path(pin["path"]).expanduser().resolve()
+        if not path.is_file():
+            return f"pinned {pin['role']} is missing: {path}"
+        observed_size = path.stat().st_size
+        if observed_size != pin["bytes"]:
+            return (
+                f"pinned {pin['role']} size drift: "
+                f"{observed_size} != {pin['bytes']}: {path}"
+            )
+        observed_sha = sha256(path)
+        if observed_sha != pin["sha256"]:
+            return (
+                f"pinned {pin['role']} SHA-256 drift: "
+                f"{observed_sha} != {pin['sha256']}: {path}"
+            )
+    return None
 
 
 def gpu_temperature() -> float:
@@ -199,7 +344,9 @@ def gpu_temperature() -> float:
     return max(temperatures)
 
 
-def success_error(job: dict[str, Any], root: Path) -> str | None:
+def success_error(
+    job: dict[str, Any], root: Path, base_env: dict[str, str],
+) -> str | None:
     success = job["success"]
     path = _absolute(success["path"], f"job {job['id']} success path", root)
     if not path.is_file():
@@ -211,18 +358,30 @@ def success_error(job: dict[str, Any], root: Path) -> str | None:
             return f"success SHA-256 mismatch: {observed} != {expected}"
     validator = success.get("validator")
     if validator:
-        result = subprocess.run(
-            validator,
-            cwd=_absolute(job["cwd"], f"job {job['id']} cwd", root),
-            env={**os.environ, **job.get("env", {})},
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            check=False,
-        )
+        timeout = float(success["validator_timeout_seconds"])
+        try:
+            result = subprocess.run(
+                validator,
+                cwd=_absolute(job["cwd"], f"job {job['id']} cwd", root),
+                env={**base_env, **job.get("env", {})},
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return f"validator timed out after {timeout:g}s"
         if result.returncode != 0:
             output = result.stdout.strip()[-2000:]
             return f"validator exited {result.returncode}: {output}"
+        if expected is not None:
+            observed_after = sha256(path)
+            if observed_after != expected:
+                return (
+                    "validator mutated success artifact: "
+                    f"{observed_after} != {expected}"
+                )
     return None
 
 
@@ -277,7 +436,8 @@ def monitor_process(
 ) -> str | None:
     """Monitor one process and terminate its group when a guard fails."""
     started_monotonic = time.monotonic()
-    started_wall_time = time.time()
+    progress_signature: tuple[int, int, int] | None = None
+    progress_changed_monotonic = started_monotonic
     hot_polls = 0
     while process.poll() is None:
         try:
@@ -323,14 +483,19 @@ def monitor_process(
                     root,
                 )
                 if progress_path.exists():
-                    modified = progress_path.stat().st_mtime
-                    # A restart-validating runner may inherit an old status file.
-                    # Give it one normal staleness window to publish fresh state.
-                    age = (
-                        time.time() - modified
-                        if modified >= started_wall_time
-                        else elapsed
-                    )
+                    if not progress_path.is_file():
+                        raise QueueError(
+                            f"progress artifact is not a regular file: {progress_path}")
+                    stat = progress_path.stat()
+                    observed_signature = (
+                        stat.st_ino, stat.st_size, stat.st_mtime_ns)
+                    if progress_signature is None:
+                        progress_signature = observed_signature
+                        progress_changed_monotonic = time.monotonic()
+                    elif observed_signature != progress_signature:
+                        progress_signature = observed_signature
+                        progress_changed_monotonic = time.monotonic()
+                    age = time.monotonic() - progress_changed_monotonic
                 else:
                     age = elapsed
                 if age > float(progress["max_stale_seconds"]):
@@ -351,13 +516,12 @@ def monitor_process(
 def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
     plan_path = Path(plan_path).expanduser().resolve()
     state_path = Path(state_path).expanduser().resolve()
-    plan, root = validate_plan(plan_path)
+    plan, root, plan_sha = validate_plan(plan_path)
     for path, label in ((plan_path, "plan path"), (state_path, "state path")):
         try:
             path.relative_to(root)
         except ValueError as exc:
             raise QueueError(f"{label} escapes queue root {root}: {path}") from exc
-    plan_sha = sha256(plan_path)
     lock_path = state_path.with_suffix(state_path.suffix + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("a+") as lock:
@@ -375,7 +539,7 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                 )
             if state.get("queue_id") != plan["queue_id"]:
                 return halt(state_path, state, "queue_id changed")
-            if state.get("state") == "complete":
+            if state.get("state") in ("complete", "halted"):
                 return 0
         else:
             state = new_state(plan, plan_sha)
@@ -384,6 +548,9 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
         if len(state.get("jobs", [])) != len(plan["jobs"]):
             return halt(state_path, state, "state job count differs from plan")
 
+        pin_error = pinned_files_error(plan)
+        if pin_error is not None:
+            return halt(state_path, state, pin_error)
         publish(state_path, state, state="running", message="queue running")
         poll_seconds = float(plan.get("poll_seconds", 30))
         maximum_temperature = plan.get("max_gpu_temperature_c")
@@ -401,8 +568,34 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
             if job_state.get("id") != job["id"]:
                 return halt(state_path, state, "state job order differs from plan")
 
-            artifact_error = success_error(job, root)
+            if sha256(plan_path) != plan_sha:
+                return halt(state_path, state, "queue plan changed during execution")
+            pin_error = pinned_files_error(plan)
+            if pin_error is not None:
+                return halt(state_path, state, pin_error)
+
+            prior = job_state.get("state")
+            if prior in ("failed", "halted"):
+                return halt(
+                    state_path, state,
+                    f"job {job['id']} has terminal prior state {prior}",
+                )
+            if prior in ("launching", "running") and not job["resume_safe"]:
+                return halt(
+                    state_path, state,
+                    f"job {job['id']} was interrupted and is not resume-safe",
+                )
+
+            artifact_error = success_error(job, root, plan["base_env"])
             if artifact_error is None:
+                if sha256(plan_path) != plan_sha:
+                    return halt(
+                        state_path, state,
+                        "queue plan changed during artifact validation",
+                    )
+                pin_error = pinned_files_error(plan)
+                if pin_error is not None:
+                    return halt(state_path, state, pin_error)
                 job_state.update({
                     "state": "complete",
                     "recovered_from_artifact": True,
@@ -413,13 +606,6 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                     message=f"validated existing success for {job['id']}",
                 )
                 continue
-
-            prior = job_state.get("state")
-            if prior == "running" and not job.get("resume_safe", False):
-                return halt(
-                    state_path, state,
-                    f"job {job['id']} was interrupted and is not resume-safe",
-                )
 
             free = shutil.disk_usage(root).free
             minimum = int(plan["min_free_bytes"])
@@ -432,42 +618,74 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
             log_path = _absolute(job["log"], f"job {job['id']} log", root)
             log_path.parent.mkdir(parents=True, exist_ok=True)
             cwd = _absolute(job["cwd"], f"job {job['id']} cwd", root)
-            env = {**os.environ, **job.get("env", {})}
+            env = {**plan["base_env"], **job.get("env", {})}
             with log_path.open("a", encoding="utf-8") as log:
                 log.write(
                     f"\nQUEUE JOB START {utc_now()} id={job['id']} "
                     f"plan_sha256={plan_sha}\n"
                 )
                 log.flush()
-                process = subprocess.Popen(
-                    job["command"], cwd=cwd, env=env,
-                    stdout=log, stderr=subprocess.STDOUT,
-                    start_new_session=True,
-                )
                 job_state.update({
-                    "state": "running",
-                    "pid": process.pid,
-                    "started_utc": utc_now(),
+                    "state": "launching",
+                    "launching_utc": utc_now(),
                     "recovered_from_artifact": False,
                 })
                 publish(
                     state_path, state,
-                    message=f"running job {job['id']}",
+                    message=f"launching job {job['id']}",
                     current_job=job["id"],
                 )
-                interrupted_reason = monitor_process(
-                    process,
-                    root=root,
-                    job=job,
-                    minimum_free_bytes=minimum,
-                    poll_seconds=poll_seconds,
-                    maximum_temperature=(
-                        float(maximum_temperature)
-                        if maximum_temperature is not None
-                        else None
-                    ),
-                )
-                exit_code = process.wait()
+                process: subprocess.Popen[Any] | None = None
+                previous_handlers = {
+                    signum: signal.getsignal(signum)
+                    for signum in (signal.SIGINT, signal.SIGTERM)
+                }
+
+                def interrupt_handler(signum: int, _frame: Any) -> None:
+                    raise KeyboardInterrupt(f"received signal {signum}")
+
+                for signum in previous_handlers:
+                    signal.signal(signum, interrupt_handler)
+                try:
+                    process = subprocess.Popen(
+                        job["command"], cwd=cwd, env=env,
+                        stdout=log, stderr=subprocess.STDOUT,
+                        start_new_session=True,
+                    )
+                    job_state.update({
+                        "state": "running",
+                        "pid": process.pid,
+                        "started_utc": utc_now(),
+                    })
+                    publish(
+                        state_path, state,
+                        message=f"running job {job['id']}",
+                        current_job=job["id"],
+                    )
+                    interrupted_reason = monitor_process(
+                        process,
+                        root=root,
+                        job=job,
+                        minimum_free_bytes=minimum,
+                        poll_seconds=poll_seconds,
+                        maximum_temperature=(
+                            float(maximum_temperature)
+                            if maximum_temperature is not None
+                            else None
+                        ),
+                    )
+                    exit_code = process.wait()
+                except KeyboardInterrupt as exc:
+                    if process is not None and process.poll() is None:
+                        _terminate_group(process)
+                    job_state["state"] = "halted"
+                    return halt(
+                        state_path, state,
+                        f"queue interrupted during {job['id']}: {exc}",
+                    )
+                finally:
+                    for signum, handler in previous_handlers.items():
+                        signal.signal(signum, handler)
 
             job_state["exit_code"] = exit_code
             job_state["ended_utc"] = utc_now()
@@ -480,13 +698,31 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                     state_path, state,
                     f"job {job['id']} exited {exit_code}; later jobs were not run",
                 )
-            artifact_error = success_error(job, root)
+            if sha256(plan_path) != plan_sha:
+                job_state["state"] = "failed"
+                return halt(
+                    state_path, state, "queue plan changed while job was running")
+            pin_error = pinned_files_error(plan)
+            if pin_error is not None:
+                job_state["state"] = "failed"
+                return halt(state_path, state, pin_error)
+            artifact_error = success_error(job, root, plan["base_env"])
             if artifact_error is not None:
                 job_state["state"] = "failed"
                 return halt(
                     state_path, state,
                     f"job {job['id']} success validation failed: {artifact_error}",
                 )
+            if sha256(plan_path) != plan_sha:
+                job_state["state"] = "failed"
+                return halt(
+                    state_path, state,
+                    "queue plan changed during success validation",
+                )
+            pin_error = pinned_files_error(plan)
+            if pin_error is not None:
+                job_state["state"] = "failed"
+                return halt(state_path, state, pin_error)
             job_state.update({"state": "complete", "completed_utc": utc_now()})
             publish(
                 state_path, state,

--- a/tools/experiment_queue.py
+++ b/tools/experiment_queue.py
@@ -49,6 +49,7 @@ ARG_KEYS = {"kind", "value", "path", "job"}
 ARG_KINDS = {"literal", "pinned", "mutable", "artifact"}
 MAX_PROGRESS_EXEMPT_SECONDS = 30 * 60
 MAX_VALIDATOR_SECONDS = 30 * 60
+MAX_VALIDATOR_OUTPUT_BYTES = 10 * 1024 * 1024
 BASE_ENV_KEYS = {
     "CUDA_VISIBLE_DEVICES", "HOME", "LANG", "LC_ALL", "LOGNAME", "PATH",
     "PYTHONHASHSEED", "PYTHONUNBUFFERED", "TZ", "USER",
@@ -139,6 +140,7 @@ def _validate_arg(
     *,
     label: str,
     root: Path,
+    cwd: Path,
     pinned_paths: set[str],
     job_pins: set[str],
     mutable_paths: set[str],
@@ -156,7 +158,14 @@ def _validate_arg(
         value = argument.get("value")
         if not isinstance(value, str) or not value:
             raise QueueError(f"{label} literal value must be a nonempty string")
-        if any(marker in value for marker in ("/", "\\", "$", "`", "~")):
+        candidate = cwd / value
+        if (
+            value in (".", "..", "-c", "-m")
+            or any(marker in value for marker in (
+                "/", "\\", "$", "`", "~", "=", ":"
+            ))
+            or candidate.exists()
+        ):
             raise QueueError(
                 f"{label} literal looks path-bearing or expandable; use a typed "
                 "pinned, mutable, or artifact argument")
@@ -307,7 +316,7 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
                 not all(isinstance(item, dict) for item in command)):
             raise QueueError(
                 f"job {job_id} command must be typed argument objects")
-        _absolute(job.get("cwd"), f"job {job_id} cwd", root)
+        cwd = _absolute(job.get("cwd"), f"job {job_id} cwd", root)
         _absolute(job.get("log"), f"job {job_id} log", root)
         success = job.get("success")
         if not isinstance(success, dict):
@@ -416,16 +425,33 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
             for position, argument in enumerate(values):
                 _validate_arg(
                     argument, label=f"job {job_id} {label}[{position}]",
-                    root=root, pinned_paths=pinned_paths,
+                    root=root, cwd=cwd, pinned_paths=pinned_paths,
                     job_pins=resolved_job_pins, mutable_paths=mutable_paths,
                     predecessor_artifacts=predecessor_artifacts,
                 )
             if values[0].get("kind") != "pinned":
                 raise QueueError(
                     f"job {job_id} {label} executable must be pinned")
+            executable_name = Path(values[0]["path"]).name.lower()
+            interpreter = (
+                executable_name.startswith("python")
+                or executable_name in {
+                    "bash", "sh", "zsh", "dash", "ksh", "perl", "ruby",
+                }
+            )
+            if executable_name == "env":
+                raise QueueError(
+                    f"job {job_id} {label} cannot use env as an executable")
+            if interpreter and (
+                len(values) < 2 or values[1].get("kind") != "pinned"
+            ):
+                raise QueueError(
+                    f"job {job_id} {label} interpreter requires a pinned "
+                    "runner file")
         for key, argument in env.items():
             _validate_arg(
                 argument, label=f"job {job_id} env[{key}]", root=root,
+                cwd=cwd,
                 pinned_paths=pinned_paths, job_pins=resolved_job_pins,
                 mutable_paths=mutable_paths,
                 predecessor_artifacts=predecessor_artifacts,
@@ -551,35 +577,50 @@ def success_error(
     path = _absolute(success["path"], f"job {job['id']} success path", root)
     if not path.is_file():
         return f"success artifact is missing: {path}"
+    observed_before = sha256(path)
     expected = success.get("sha256")
     if expected is not None:
-        observed = sha256(path)
-        if observed != expected:
-            return f"success SHA-256 mismatch: {observed} != {expected}"
+        if observed_before != expected:
+            return f"success SHA-256 mismatch: {observed_before} != {expected}"
     validator = success.get("validator")
     if validator:
         timeout = float(success["validator_timeout_seconds"])
         started = time.monotonic()
         hot_polls = 0
-        with tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as output:
+        with tempfile.TemporaryFile(mode="w+b", dir=root) as output:
             try:
                 process = subprocess.Popen(
-                render_args(validator),
-                cwd=_absolute(job["cwd"], f"job {job['id']} cwd", root),
-                env={**base_env, **render_env(job.get("env", {}))},
-                stdout=output,
-                stderr=subprocess.STDOUT,
-                text=True,
-                start_new_session=True,
+                    render_args(validator),
+                    cwd=_absolute(job["cwd"], f"job {job['id']} cwd", root),
+                    env={**base_env, **render_env(job.get("env", {}))},
+                    stdout=output,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
                 )
             except OSError as exc:
                 return f"validator launch failed: {exc}"
-            while process.poll() is None:
-                elapsed = time.monotonic() - started
-                if elapsed > timeout:
-                    _terminate_group(process)
-                    return f"validator timed out after {timeout:g}s"
-                try:
+            previous_handlers = {
+                signum: signal.getsignal(signum)
+                for signum in (signal.SIGINT, signal.SIGTERM)
+            }
+
+            def interrupt_handler(signum: int, _frame: Any) -> None:
+                raise KeyboardInterrupt(f"received signal {signum}")
+
+            for signum in previous_handlers:
+                signal.signal(signum, interrupt_handler)
+            try:
+                while process.poll() is None:
+                    elapsed = time.monotonic() - started
+                    if elapsed > timeout:
+                        _terminate_group(process)
+                        return f"validator timed out after {timeout:g}s"
+                    output_bytes = os.fstat(output.fileno()).st_size
+                    if output_bytes > MAX_VALIDATOR_OUTPUT_BYTES:
+                        _terminate_group(process)
+                        return (
+                            "validator output limit exceeded: "
+                            f"{output_bytes} > {MAX_VALIDATOR_OUTPUT_BYTES}")
                     capacity = capacity_error(
                         root, job, minimum_free_bytes=minimum_free_bytes,
                         minimum_free_inodes=minimum_free_inodes,
@@ -598,22 +639,63 @@ def success_error(
                             "validator thermal guard tripped: "
                             f"{observed_temperature:.0f}C > "
                             f"{maximum_temperature}C for {hot_polls} polls")
-                except (OSError, QueueError, ValueError) as exc:
+                    time.sleep(min(
+                        poll_seconds, max(timeout - elapsed, 0.001)))
+            except KeyboardInterrupt as exc:
+                _terminate_group(process)
+                return f"validator interrupted: {exc}"
+            except (OSError, QueueError, ValueError) as exc:
+                _terminate_group(process)
+                return f"validator monitor failed closed: {exc}"
+            finally:
+                if process.poll() is None:
                     _terminate_group(process)
-                    return f"validator monitor failed closed: {exc}"
-                time.sleep(min(poll_seconds, max(timeout - elapsed, 0.001)))
+                for signum, handler in previous_handlers.items():
+                    signal.signal(signum, handler)
             exit_code = process.wait()
-            output.seek(0)
-            rendered_output = output.read().strip()[-2000:]
+            output_size = os.fstat(output.fileno()).st_size
+            output.seek(max(0, output_size - 2000))
+            rendered_output = output.read(2000).decode(
+                "utf-8", errors="replace").strip()
         if exit_code != 0:
             return f"validator exited {exit_code}: {rendered_output}"
-        if expected is not None:
-            observed_after = sha256(path)
-            if observed_after != expected:
-                return (
-                    "validator mutated success artifact: "
-                    f"{observed_after} != {expected}"
-                )
+        observed_after = sha256(path)
+        if observed_after != observed_before:
+            return (
+                "validator mutated success artifact: "
+                f"{observed_after} != {observed_before}"
+            )
+    return None
+
+
+def completed_evidence_error(
+    plan: dict[str, Any], state: dict[str, Any], root: Path,
+    *, minimum_free_bytes: int, minimum_free_inodes: int,
+    maximum_temperature: float, poll_seconds: float,
+) -> str | None:
+    """Revalidate every completed predecessor and its recorded byte identity."""
+    for job, job_state in zip(plan["jobs"], state.get("jobs", [])):
+        if job_state.get("id") != job["id"]:
+            return "state job order differs from plan"
+        if job_state.get("state") != "complete":
+            continue
+        error = success_error(
+            job, root, plan["base_env"],
+            minimum_free_bytes=minimum_free_bytes,
+            minimum_free_inodes=minimum_free_inodes,
+            maximum_temperature=maximum_temperature,
+            poll_seconds=poll_seconds,
+        )
+        if error is not None:
+            return f"completed job {job['id']} evidence drifted: {error}"
+        path = _absolute(
+            job["success"]["path"], f"job {job['id']} success path", root)
+        observed = sha256(path)
+        recorded = job_state.get("success_sha256")
+        if recorded != observed:
+            return (
+                f"completed job {job['id']} success artifact drifted: "
+                f"{observed} != {recorded}")
     return None
 
 
@@ -772,7 +854,7 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                 )
             if state.get("queue_id") != plan["queue_id"]:
                 return halt(state_path, state, "queue_id changed")
-            if state.get("state") in ("complete", "halted"):
+            if state.get("state") == "halted":
                 return 0
         else:
             state = new_state(plan, plan_sha)
@@ -781,21 +863,40 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
         if len(state.get("jobs", [])) != len(plan["jobs"]):
             return halt(state_path, state, "state job count differs from plan")
 
+        poll_seconds = float(plan["poll_seconds"])
+        maximum_temperature = float(plan["max_gpu_temperature_c"])
+        minimum = int(plan["min_free_bytes"])
+        minimum_inodes = int(plan["min_free_inodes"])
         pin_error = pinned_files_error(plan)
         if pin_error is not None:
             return halt(state_path, state, pin_error)
-        publish(state_path, state, state="running", message="queue running")
-        poll_seconds = float(plan.get("poll_seconds", 30))
-        maximum_temperature = plan.get("max_gpu_temperature_c")
-        if maximum_temperature is not None:
-            observed_temperature = gpu_temperature()
-            if observed_temperature > float(maximum_temperature):
+        evidence_error = completed_evidence_error(
+            plan, state, root,
+            minimum_free_bytes=minimum,
+            minimum_free_inodes=minimum_inodes,
+            maximum_temperature=maximum_temperature,
+            poll_seconds=poll_seconds,
+        )
+        if evidence_error is not None:
+            return halt(state_path, state, evidence_error)
+        if state.get("state") == "complete":
+            if any(
+                job_state.get("state") != "complete"
+                for job_state in state["jobs"]
+            ):
                 return halt(
-                    state_path,
-                    state,
-                    "GPU temperature preflight failed: "
-                    f"{observed_temperature:.0f}C > {maximum_temperature}C",
-                )
+                    state_path, state,
+                    "complete queue contains a non-complete job state")
+            return 0
+        publish(state_path, state, state="running", message="queue running")
+        observed_temperature = gpu_temperature()
+        if observed_temperature > maximum_temperature:
+            return halt(
+                state_path,
+                state,
+                "GPU temperature preflight failed: "
+                f"{observed_temperature:.0f}C > {maximum_temperature}C",
+            )
         for index, job in enumerate(plan["jobs"]):
             job_state = state["jobs"][index]
             if job_state.get("id") != job["id"]:
@@ -823,7 +924,7 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                 job, root, plan["base_env"],
                 minimum_free_bytes=int(plan["min_free_bytes"]),
                 minimum_free_inodes=int(plan["min_free_inodes"]),
-                maximum_temperature=float(plan["max_gpu_temperature_c"]),
+                maximum_temperature=maximum_temperature,
                 poll_seconds=poll_seconds,
             )
             if prior == "complete" and artifact_error is not None:
@@ -865,8 +966,6 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                 )
                 continue
 
-            minimum = int(plan["min_free_bytes"])
-            minimum_inodes = int(plan["min_free_inodes"])
             capacity = capacity_error(
                 root, job, minimum_free_bytes=minimum,
                 minimum_free_inodes=minimum_inodes,
@@ -932,9 +1031,7 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                         minimum_free_inodes=minimum_inodes,
                         poll_seconds=poll_seconds,
                         maximum_temperature=(
-                            float(maximum_temperature)
-                            if maximum_temperature is not None
-                            else None
+                            maximum_temperature
                         ),
                     )
                     exit_code = process.wait()
@@ -975,7 +1072,7 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                 job, root, plan["base_env"],
                 minimum_free_bytes=minimum,
                 minimum_free_inodes=minimum_inodes,
-                maximum_temperature=float(maximum_temperature),
+                maximum_temperature=maximum_temperature,
                 poll_seconds=poll_seconds,
             )
             if artifact_error is not None:
@@ -1002,11 +1099,30 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                 "state": "complete", "completed_utc": utc_now(),
                 "success_sha256": sha256(artifact_path),
             })
+            evidence_error = completed_evidence_error(
+                plan, state, root,
+                minimum_free_bytes=minimum,
+                minimum_free_inodes=minimum_inodes,
+                maximum_temperature=maximum_temperature,
+                poll_seconds=poll_seconds,
+            )
+            if evidence_error is not None:
+                job_state["state"] = "failed"
+                return halt(state_path, state, evidence_error)
             publish(
                 state_path, state,
                 message=f"job {job['id']} completed and validated",
             )
 
+        evidence_error = completed_evidence_error(
+            plan, state, root,
+            minimum_free_bytes=minimum,
+            minimum_free_inodes=minimum_inodes,
+            maximum_temperature=maximum_temperature,
+            poll_seconds=poll_seconds,
+        )
+        if evidence_error is not None:
+            return halt(state_path, state, evidence_error)
         publish(
             state_path, state,
             state="complete", message="all queued jobs completed and validated",

--- a/tools/experiment_queue.py
+++ b/tools/experiment_queue.py
@@ -15,7 +15,9 @@ import datetime as dt
 import fcntl
 import hashlib
 import json
+import math
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -50,6 +52,8 @@ ARG_KINDS = {"literal", "pinned", "mutable", "artifact"}
 MAX_PROGRESS_EXEMPT_SECONDS = 30 * 60
 MAX_VALIDATOR_SECONDS = 30 * 60
 MAX_VALIDATOR_OUTPUT_BYTES = 10 * 1024 * 1024
+FLAG_PATTERN = re.compile(r"--[a-z][a-z0-9-]*")
+DIGEST_PATTERN = re.compile(r"[0-9a-f]{64}")
 BASE_ENV_KEYS = {
     "CUDA_VISIBLE_DEVICES", "HOME", "LANG", "LC_ALL", "LOGNAME", "PATH",
     "PYTHONHASHSEED", "PYTHONUNBUFFERED", "TZ", "USER",
@@ -140,7 +144,6 @@ def _validate_arg(
     *,
     label: str,
     root: Path,
-    cwd: Path,
     pinned_paths: set[str],
     job_pins: set[str],
     mutable_paths: set[str],
@@ -158,17 +161,20 @@ def _validate_arg(
         value = argument.get("value")
         if not isinstance(value, str) or not value:
             raise QueueError(f"{label} literal value must be a nonempty string")
-        candidate = cwd / value
-        if (
-            value in (".", "..", "-c", "-m")
-            or any(marker in value for marker in (
-                "/", "\\", "$", "`", "~", "=", ":"
-            ))
-            or candidate.exists()
-        ):
+        try:
+            numeric = math.isfinite(float(value))
+        except ValueError:
+            numeric = False
+        safe_literal = (
+            numeric
+            or DIGEST_PATTERN.fullmatch(value) is not None
+            or FLAG_PATTERN.fullmatch(value) is not None
+        )
+        if not safe_literal:
             raise QueueError(
-                f"{label} literal looks path-bearing or expandable; use a typed "
-                "pinned, mutable, or artifact argument")
+                f"{label} literal must be a number, lowercase SHA-256, or "
+                "long flag; strings and paths belong in a pinned runner/config "
+                "or a typed pinned, mutable, or artifact argument")
         return
     if kind in ("pinned", "mutable"):
         if set(argument) != {"kind", "path"}:
@@ -316,7 +322,7 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
                 not all(isinstance(item, dict) for item in command)):
             raise QueueError(
                 f"job {job_id} command must be typed argument objects")
-        cwd = _absolute(job.get("cwd"), f"job {job_id} cwd", root)
+        _absolute(job.get("cwd"), f"job {job_id} cwd", root)
         _absolute(job.get("log"), f"job {job_id} log", root)
         success = job.get("success")
         if not isinstance(success, dict):
@@ -425,7 +431,7 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
             for position, argument in enumerate(values):
                 _validate_arg(
                     argument, label=f"job {job_id} {label}[{position}]",
-                    root=root, cwd=cwd, pinned_paths=pinned_paths,
+                    root=root, pinned_paths=pinned_paths,
                     job_pins=resolved_job_pins, mutable_paths=mutable_paths,
                     predecessor_artifacts=predecessor_artifacts,
                 )
@@ -433,25 +439,16 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
                 raise QueueError(
                     f"job {job_id} {label} executable must be pinned")
             executable_name = Path(values[0]["path"]).name.lower()
-            interpreter = (
-                executable_name.startswith("python")
-                or executable_name in {
-                    "bash", "sh", "zsh", "dash", "ksh", "perl", "ruby",
-                }
-            )
             if executable_name == "env":
                 raise QueueError(
                     f"job {job_id} {label} cannot use env as an executable")
-            if interpreter and (
-                len(values) < 2 or values[1].get("kind") != "pinned"
-            ):
+            if len(values) < 2 or values[1].get("kind") != "pinned":
                 raise QueueError(
-                    f"job {job_id} {label} interpreter requires a pinned "
-                    "runner file")
+                    f"job {job_id} {label} requires a pinned runner as "
+                    "argument 1")
         for key, argument in env.items():
             _validate_arg(
                 argument, label=f"job {job_id} env[{key}]", root=root,
-                cwd=cwd,
                 pinned_paths=pinned_paths, job_pins=resolved_job_pins,
                 mutable_paths=mutable_paths,
                 predecessor_artifacts=predecessor_artifacts,

--- a/tools/experiment_queue.py
+++ b/tools/experiment_queue.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Run an explicit, immutable experiment queue with fail-closed recovery.
+
+The queue never invents a follow-up experiment. It executes command arrays from
+a hash-pinned JSON plan, validates each declared success artifact, and records
+all state atomically. A previously running job is retried only when its plan
+explicitly says ``resume_safe: true``; otherwise an interruption halts the queue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+class QueueError(ValueError):
+    pass
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise QueueError(f"invalid {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise QueueError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def _absolute(value: Any, label: str, root: Path) -> Path:
+    if not isinstance(value, str) or not value:
+        raise QueueError(f"{label} must be a nonempty absolute path")
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise QueueError(f"{label} must be absolute: {path}")
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise QueueError(f"{label} escapes queue root {root}: {resolved}") from exc
+    return resolved
+
+
+def validate_plan(path: Path) -> tuple[dict[str, Any], Path]:
+    plan = load_object(path, "queue plan")
+    if plan.get("schema_version") != 1:
+        raise QueueError("queue plan schema_version must be 1")
+    queue_id = plan.get("queue_id")
+    if not isinstance(queue_id, str) or not queue_id:
+        raise QueueError("queue_id must be a nonempty string")
+    root_value = plan.get("root")
+    if not isinstance(root_value, str) or not Path(root_value).is_absolute():
+        raise QueueError("root must be an absolute path")
+    root = Path(root_value).expanduser().resolve()
+    if not root.is_dir():
+        raise QueueError(f"queue root does not exist: {root}")
+    minimum = plan.get("min_free_bytes")
+    if isinstance(minimum, bool) or not isinstance(minimum, int) or minimum < 1:
+        raise QueueError("min_free_bytes must be a positive integer")
+    poll = plan.get("poll_seconds", 30)
+    if isinstance(poll, bool) or not isinstance(poll, (int, float)) or poll <= 0:
+        raise QueueError("poll_seconds must be positive")
+    maximum_temperature = plan.get("max_gpu_temperature_c")
+    if maximum_temperature is not None and (
+        isinstance(maximum_temperature, bool)
+        or not isinstance(maximum_temperature, (int, float))
+        or not 1 <= maximum_temperature <= 120
+    ):
+        raise QueueError("max_gpu_temperature_c must be in 1..120")
+    jobs = plan.get("jobs")
+    if not isinstance(jobs, list) or not jobs:
+        raise QueueError("jobs must be a nonempty array")
+    seen: set[str] = set()
+    for index, job in enumerate(jobs, 1):
+        if not isinstance(job, dict):
+            raise QueueError(f"job {index} must be an object")
+        job_id = job.get("id")
+        if not isinstance(job_id, str) or not job_id or job_id in seen:
+            raise QueueError(f"job {index} has an invalid or duplicate id")
+        seen.add(job_id)
+        command = job.get("command")
+        if (not isinstance(command, list) or not command or
+                not all(isinstance(item, str) and item for item in command)):
+            raise QueueError(f"job {job_id} command must be nonempty strings")
+        _absolute(job.get("cwd"), f"job {job_id} cwd", root)
+        _absolute(job.get("log"), f"job {job_id} log", root)
+        success = job.get("success")
+        if not isinstance(success, dict):
+            raise QueueError(f"job {job_id} success must be an object")
+        _absolute(success.get("path"), f"job {job_id} success path", root)
+        expected_sha = success.get("sha256")
+        if (expected_sha is not None and
+                (not isinstance(expected_sha, str) or len(expected_sha) != 64 or
+                 any(char not in "0123456789abcdef" for char in expected_sha))):
+            raise QueueError(f"job {job_id} success sha256 is invalid")
+        validator = success.get("validator")
+        if (validator is not None and
+                (not isinstance(validator, list) or not validator or
+                 not all(isinstance(item, str) and item for item in validator))):
+            raise QueueError(f"job {job_id} validator must be nonempty strings")
+        env = job.get("env", {})
+        if (not isinstance(env, dict) or
+                not all(isinstance(k, str) and isinstance(v, str)
+                        for k, v in env.items())):
+            raise QueueError(f"job {job_id} env must map strings to strings")
+        resume_safe = job.get("resume_safe", False)
+        if not isinstance(resume_safe, bool):
+            raise QueueError(f"job {job_id} resume_safe must be boolean")
+        max_runtime = job.get("max_runtime_seconds")
+        if max_runtime is not None and (
+            isinstance(max_runtime, bool)
+            or not isinstance(max_runtime, (int, float))
+            or max_runtime <= 0
+        ):
+            raise QueueError(
+                f"job {job_id} max_runtime_seconds must be positive"
+            )
+        progress = job.get("progress")
+        if progress is not None:
+            if not isinstance(progress, dict):
+                raise QueueError(f"job {job_id} progress must be an object")
+            _absolute(progress.get("path"), f"job {job_id} progress path", root)
+            stale = progress.get("max_stale_seconds")
+            if (isinstance(stale, bool) or not isinstance(stale, (int, float)) or
+                    stale <= 0):
+                raise QueueError(
+                    f"job {job_id} max_stale_seconds must be positive")
+    return plan, root
+
+
+def gpu_temperature() -> float:
+    """Return the hottest NVIDIA GPU temperature, failing closed."""
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=temperature.gpu",
+                "--format=csv,noheader,nounits",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise QueueError(f"NVIDIA temperature query failed: {exc}") from exc
+    if result.returncode != 0:
+        raise QueueError(
+            "NVIDIA temperature query exited "
+            f"{result.returncode}: {result.stdout.strip()[-1000:]}"
+        )
+    try:
+        temperatures = [
+            float(line.strip())
+            for line in result.stdout.splitlines()
+            if line.strip()
+        ]
+    except ValueError as exc:
+        raise QueueError(
+            f"NVIDIA temperature query was not numeric: {result.stdout!r}"
+        ) from exc
+    if not temperatures:
+        raise QueueError("NVIDIA temperature query returned no GPUs")
+    return max(temperatures)
+
+
+def success_error(job: dict[str, Any], root: Path) -> str | None:
+    success = job["success"]
+    path = _absolute(success["path"], f"job {job['id']} success path", root)
+    if not path.is_file():
+        return f"success artifact is missing: {path}"
+    expected = success.get("sha256")
+    if expected is not None:
+        observed = sha256(path)
+        if observed != expected:
+            return f"success SHA-256 mismatch: {observed} != {expected}"
+    validator = success.get("validator")
+    if validator:
+        result = subprocess.run(
+            validator,
+            cwd=_absolute(job["cwd"], f"job {job['id']} cwd", root),
+            env={**os.environ, **job.get("env", {})},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            output = result.stdout.strip()[-2000:]
+            return f"validator exited {result.returncode}: {output}"
+    return None
+
+
+def new_state(plan: dict[str, Any], plan_sha: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "queue_id": plan["queue_id"],
+        "plan_sha256": plan_sha,
+        "state": "pending",
+        "message": "queue has not started",
+        "created_utc": utc_now(),
+        "updated_utc": utc_now(),
+        "jobs": [
+            {"id": job["id"], "state": "pending"}
+            for job in plan["jobs"]
+        ],
+    }
+
+
+def publish(
+    state_path: Path, payload: dict[str, Any], **updates: Any
+) -> None:
+    payload.update(updates)
+    payload["updated_utc"] = utc_now()
+    atomic_json(state_path, payload)
+
+
+def halt(state_path: Path, state: dict[str, Any], message: str) -> int:
+    publish(state_path, state, state="halted", message=message)
+    return 0
+
+
+def _terminate_group(process: subprocess.Popen[Any]) -> None:
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=10)
+
+
+def monitor_process(
+    process: subprocess.Popen[Any],
+    *,
+    root: Path,
+    job: dict[str, Any],
+    minimum_free_bytes: int,
+    poll_seconds: float,
+    maximum_temperature: float | None,
+) -> str | None:
+    """Monitor one process and terminate its group when a guard fails."""
+    started_monotonic = time.monotonic()
+    started_wall_time = time.time()
+    hot_polls = 0
+    while process.poll() is None:
+        try:
+            free = shutil.disk_usage(root).free
+            if free < minimum_free_bytes:
+                reason = (
+                    f"disk guard tripped during {job['id']}: "
+                    f"{free} < {minimum_free_bytes}"
+                )
+                _terminate_group(process)
+                return reason
+            elapsed = time.monotonic() - started_monotonic
+            maximum_runtime = job.get("max_runtime_seconds")
+            if (
+                maximum_runtime is not None
+                and elapsed > float(maximum_runtime)
+            ):
+                reason = (
+                    f"runtime guard tripped during {job['id']}: "
+                    f"{elapsed:.0f}s > {maximum_runtime}s"
+                )
+                _terminate_group(process)
+                return reason
+            if maximum_temperature is not None:
+                observed_temperature = gpu_temperature()
+                if observed_temperature > maximum_temperature:
+                    hot_polls += 1
+                else:
+                    hot_polls = 0
+                if hot_polls >= 3:
+                    reason = (
+                        f"thermal guard tripped during {job['id']}: "
+                        f"{observed_temperature:.0f}C > "
+                        f"{maximum_temperature}C for {hot_polls} polls"
+                    )
+                    _terminate_group(process)
+                    return reason
+            progress = job.get("progress")
+            if progress:
+                progress_path = _absolute(
+                    progress["path"],
+                    f"job {job['id']} progress path",
+                    root,
+                )
+                if progress_path.exists():
+                    modified = progress_path.stat().st_mtime
+                    # A restart-validating runner may inherit an old status file.
+                    # Give it one normal staleness window to publish fresh state.
+                    age = (
+                        time.time() - modified
+                        if modified >= started_wall_time
+                        else elapsed
+                    )
+                else:
+                    age = elapsed
+                if age > float(progress["max_stale_seconds"]):
+                    presence = "stale" if progress_path.exists() else "absent"
+                    reason = (
+                        f"progress guard tripped during {job['id']}: "
+                        f"{progress_path} {presence} for {age:.0f}s"
+                    )
+                    _terminate_group(process)
+                    return reason
+        except (OSError, QueueError, ValueError) as exc:
+            _terminate_group(process)
+            return f"monitor failed closed during {job['id']}: {exc}"
+        time.sleep(poll_seconds)
+    return None
+
+
+def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
+    plan_path = Path(plan_path).expanduser().resolve()
+    state_path = Path(state_path).expanduser().resolve()
+    plan, root = validate_plan(plan_path)
+    for path, label in ((plan_path, "plan path"), (state_path, "state path")):
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise QueueError(f"{label} escapes queue root {root}: {path}") from exc
+    plan_sha = sha256(plan_path)
+    lock_path = state_path.with_suffix(state_path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise QueueError(f"another queue runner holds {lock_path}") from exc
+
+        if state_path.exists():
+            state = load_object(state_path, "queue state")
+            if state.get("plan_sha256") != plan_sha:
+                return halt(
+                    state_path, state,
+                    "plan SHA-256 changed after queue state was created",
+                )
+            if state.get("queue_id") != plan["queue_id"]:
+                return halt(state_path, state, "queue_id changed")
+            if state.get("state") == "complete":
+                return 0
+        else:
+            state = new_state(plan, plan_sha)
+            atomic_json(state_path, state)
+
+        if len(state.get("jobs", [])) != len(plan["jobs"]):
+            return halt(state_path, state, "state job count differs from plan")
+
+        publish(state_path, state, state="running", message="queue running")
+        poll_seconds = float(plan.get("poll_seconds", 30))
+        maximum_temperature = plan.get("max_gpu_temperature_c")
+        if maximum_temperature is not None:
+            observed_temperature = gpu_temperature()
+            if observed_temperature > float(maximum_temperature):
+                return halt(
+                    state_path,
+                    state,
+                    "GPU temperature preflight failed: "
+                    f"{observed_temperature:.0f}C > {maximum_temperature}C",
+                )
+        for index, job in enumerate(plan["jobs"]):
+            job_state = state["jobs"][index]
+            if job_state.get("id") != job["id"]:
+                return halt(state_path, state, "state job order differs from plan")
+
+            artifact_error = success_error(job, root)
+            if artifact_error is None:
+                job_state.update({
+                    "state": "complete",
+                    "recovered_from_artifact": True,
+                    "completed_utc": job_state.get("completed_utc", utc_now()),
+                })
+                publish(
+                    state_path, state,
+                    message=f"validated existing success for {job['id']}",
+                )
+                continue
+
+            prior = job_state.get("state")
+            if prior == "running" and not job.get("resume_safe", False):
+                return halt(
+                    state_path, state,
+                    f"job {job['id']} was interrupted and is not resume-safe",
+                )
+
+            free = shutil.disk_usage(root).free
+            minimum = int(plan["min_free_bytes"])
+            if free < minimum:
+                return halt(
+                    state_path, state,
+                    f"disk preflight failed before {job['id']}: {free} < {minimum}",
+                )
+
+            log_path = _absolute(job["log"], f"job {job['id']} log", root)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            cwd = _absolute(job["cwd"], f"job {job['id']} cwd", root)
+            env = {**os.environ, **job.get("env", {})}
+            with log_path.open("a", encoding="utf-8") as log:
+                log.write(
+                    f"\nQUEUE JOB START {utc_now()} id={job['id']} "
+                    f"plan_sha256={plan_sha}\n"
+                )
+                log.flush()
+                process = subprocess.Popen(
+                    job["command"], cwd=cwd, env=env,
+                    stdout=log, stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+                job_state.update({
+                    "state": "running",
+                    "pid": process.pid,
+                    "started_utc": utc_now(),
+                    "recovered_from_artifact": False,
+                })
+                publish(
+                    state_path, state,
+                    message=f"running job {job['id']}",
+                    current_job=job["id"],
+                )
+                interrupted_reason = monitor_process(
+                    process,
+                    root=root,
+                    job=job,
+                    minimum_free_bytes=minimum,
+                    poll_seconds=poll_seconds,
+                    maximum_temperature=(
+                        float(maximum_temperature)
+                        if maximum_temperature is not None
+                        else None
+                    ),
+                )
+                exit_code = process.wait()
+
+            job_state["exit_code"] = exit_code
+            job_state["ended_utc"] = utc_now()
+            if interrupted_reason is not None:
+                job_state["state"] = "halted"
+                return halt(state_path, state, interrupted_reason)
+            if exit_code != 0:
+                job_state["state"] = "failed"
+                return halt(
+                    state_path, state,
+                    f"job {job['id']} exited {exit_code}; later jobs were not run",
+                )
+            artifact_error = success_error(job, root)
+            if artifact_error is not None:
+                job_state["state"] = "failed"
+                return halt(
+                    state_path, state,
+                    f"job {job['id']} success validation failed: {artifact_error}",
+                )
+            job_state.update({"state": "complete", "completed_utc": utc_now()})
+            publish(
+                state_path, state,
+                message=f"job {job['id']} completed and validated",
+            )
+
+        publish(
+            state_path, state,
+            state="complete", message="all queued jobs completed and validated",
+            current_job=None, completed_utc=utc_now(),
+        )
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--state", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        return run_queue(args.plan, args.state)
+    except (OSError, QueueError, ValueError) as exc:
+        print(f"experiment queue failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/experiment_queue.py
+++ b/tools/experiment_queue.py
@@ -20,6 +20,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -30,19 +31,28 @@ class QueueError(ValueError):
 
 
 PLAN_KEYS = {
-    "schema_version", "queue_id", "root", "min_free_bytes", "poll_seconds",
-    "max_gpu_temperature_c", "base_env", "pinned_files", "jobs",
+    "schema_version", "queue_id", "root", "min_free_bytes",
+    "min_free_inodes", "poll_seconds", "max_gpu_temperature_c", "base_env",
+    "pinned_files", "jobs",
 }
 JOB_KEYS = {
     "id", "command", "cwd", "log", "success", "env", "resume_safe",
     "max_runtime_seconds", "progress", "progress_not_required_reason",
-    "pinned_inputs",
+    "pinned_inputs", "mutable_paths",
 }
 SUCCESS_KEYS = {
     "path", "sha256", "validator", "validator_timeout_seconds",
 }
 PROGRESS_KEYS = {"path", "max_stale_seconds"}
-PIN_KEYS = {"path", "bytes", "sha256", "role"}
+PIN_KEYS = {"kind", "path", "bytes", "files", "sha256", "role"}
+ARG_KEYS = {"kind", "value", "path", "job"}
+ARG_KINDS = {"literal", "pinned", "mutable", "artifact"}
+MAX_PROGRESS_EXEMPT_SECONDS = 30 * 60
+MAX_VALIDATOR_SECONDS = 30 * 60
+BASE_ENV_KEYS = {
+    "CUDA_VISIBLE_DEVICES", "HOME", "LANG", "LC_ALL", "LOGNAME", "PATH",
+    "PYTHONHASHSEED", "PYTHONUNBUFFERED", "TZ", "USER",
+}
 
 
 def utc_now() -> str:
@@ -55,6 +65,33 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def tree_identity(path: Path) -> tuple[int, int, str]:
+    """Return file count, byte count, and a deterministic recursive tree hash."""
+    if not path.is_dir():
+        raise QueueError(f"pinned tree is not a directory: {path}")
+    digest = hashlib.sha256()
+    count = 0
+    total_bytes = 0
+    for child in sorted(path.rglob("*")):
+        if child.is_symlink():
+            raise QueueError(f"pinned tree contains a symlink: {child}")
+        if child.is_dir():
+            continue
+        if not child.is_file():
+            raise QueueError(f"pinned tree contains a non-file: {child}")
+        relative = child.relative_to(path).as_posix()
+        size = child.stat().st_size
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(size).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(sha256(child).encode("ascii"))
+        digest.update(b"\n")
+        count += 1
+        total_bytes += size
+    return count, total_bytes, digest.hexdigest()
 
 
 def atomic_json(path: Path, payload: dict[str, Any]) -> None:
@@ -97,6 +134,77 @@ def _unknown(mapping: dict[str, Any], allowed: set[str], label: str) -> None:
         raise QueueError(f"unknown {label} fields: {', '.join(unexpected)}")
 
 
+def _validate_arg(
+    argument: Any,
+    *,
+    label: str,
+    root: Path,
+    pinned_paths: set[str],
+    job_pins: set[str],
+    mutable_paths: set[str],
+    predecessor_artifacts: dict[str, str],
+) -> None:
+    if not isinstance(argument, dict):
+        raise QueueError(f"{label} must be a typed argument object")
+    _unknown(argument, ARG_KEYS, label)
+    kind = argument.get("kind")
+    if kind not in ARG_KINDS:
+        raise QueueError(f"{label} kind must be one of {sorted(ARG_KINDS)}")
+    if kind == "literal":
+        if set(argument) != {"kind", "value"}:
+            raise QueueError(f"{label} literal must contain only kind and value")
+        value = argument.get("value")
+        if not isinstance(value, str) or not value:
+            raise QueueError(f"{label} literal value must be a nonempty string")
+        if any(marker in value for marker in ("/", "\\", "$", "`", "~")):
+            raise QueueError(
+                f"{label} literal looks path-bearing or expandable; use a typed "
+                "pinned, mutable, or artifact argument")
+        return
+    if kind in ("pinned", "mutable"):
+        if set(argument) != {"kind", "path"}:
+            raise QueueError(f"{label} {kind} must contain only kind and path")
+        path_value = argument.get("path")
+        if not isinstance(path_value, str) or not Path(path_value).is_absolute():
+            raise QueueError(f"{label} {kind} path must be absolute")
+        resolved = str(Path(path_value).expanduser().resolve())
+        if kind == "pinned":
+            if resolved not in pinned_paths or resolved not in job_pins:
+                raise QueueError(f"{label} pinned path is undeclared: {resolved}")
+        elif resolved not in mutable_paths:
+            raise QueueError(f"{label} mutable path is undeclared: {resolved}")
+        return
+    if set(argument) != {"kind", "job", "path"}:
+        raise QueueError(
+            f"{label} artifact must contain only kind, job, and path")
+    producer = argument.get("job")
+    path_value = argument.get("path")
+    if not isinstance(producer, str) or not producer:
+        raise QueueError(f"{label} artifact job must be nonempty")
+    if not isinstance(path_value, str) or not Path(path_value).is_absolute():
+        raise QueueError(f"{label} artifact path must be absolute")
+    resolved = str(Path(path_value).expanduser().resolve())
+    if predecessor_artifacts.get(producer) != resolved:
+        raise QueueError(
+            f"{label} is not the declared success artifact of an earlier job: "
+            f"{producer}:{resolved}")
+
+
+def render_args(arguments: list[dict[str, str]]) -> list[str]:
+    return [
+        argument["value"] if argument["kind"] == "literal"
+        else argument["path"]
+        for argument in arguments
+    ]
+
+
+def render_env(values: dict[str, dict[str, str]]) -> dict[str, str]:
+    return {
+        key: value["value"] if value["kind"] == "literal" else value["path"]
+        for key, value in values.items()
+    }
+
+
 def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
     try:
         raw = path.read_bytes()
@@ -121,12 +229,16 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
     minimum = plan.get("min_free_bytes")
     if isinstance(minimum, bool) or not isinstance(minimum, int) or minimum < 1:
         raise QueueError("min_free_bytes must be a positive integer")
+    minimum_inodes = plan.get("min_free_inodes")
+    if (isinstance(minimum_inodes, bool) or
+            not isinstance(minimum_inodes, int) or minimum_inodes < 1):
+        raise QueueError("min_free_inodes must be a positive integer")
     poll = plan.get("poll_seconds")
     if (isinstance(poll, bool) or not isinstance(poll, (int, float)) or
             not 0 < poll <= 60):
         raise QueueError("poll_seconds must be in (0, 60]")
     maximum_temperature = plan.get("max_gpu_temperature_c")
-    if maximum_temperature is not None and (
+    if maximum_temperature is None or (
         isinstance(maximum_temperature, bool)
         or not isinstance(maximum_temperature, (int, float))
         or not 1 <= maximum_temperature <= 120
@@ -137,6 +249,11 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
             not all(isinstance(key, str) and key and isinstance(value, str)
                     for key, value in base_env.items())):
         raise QueueError("base_env must map nonempty strings to strings")
+    unexpected_base_env = sorted(set(base_env) - BASE_ENV_KEYS)
+    if unexpected_base_env:
+        raise QueueError(
+            "base_env contains non-runtime keys; declare job values as typed "
+            f"arguments: {unexpected_base_env}")
     pinned_files = plan.get("pinned_files")
     if not isinstance(pinned_files, list) or not pinned_files:
         raise QueueError("pinned_files must be a nonempty array")
@@ -152,9 +269,20 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
         if resolved_pin in pinned_paths:
             raise QueueError(f"duplicate pinned file path: {resolved_pin}")
         pinned_paths.add(resolved_pin)
+        kind = pin.get("kind")
+        if kind not in ("file", "tree"):
+            raise QueueError(f"pinned file {index} kind must be file or tree")
         size = pin.get("bytes")
         if isinstance(size, bool) or not isinstance(size, int) or size < 0:
             raise QueueError(f"pinned file {index} bytes must be nonnegative")
+        files = pin.get("files")
+        if kind == "file" and files is not None:
+            raise QueueError(f"pinned file {index} file kind cannot set files")
+        if kind == "tree" and (
+            isinstance(files, bool) or not isinstance(files, int) or files < 0
+        ):
+            raise QueueError(
+                f"pinned file {index} tree files must be nonnegative")
         expected = pin.get("sha256")
         if (not isinstance(expected, str) or len(expected) != 64 or
                 any(char not in "0123456789abcdef" for char in expected)):
@@ -165,6 +293,7 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
     if not isinstance(jobs, list) or not jobs:
         raise QueueError("jobs must be a nonempty array")
     seen: set[str] = set()
+    predecessor_artifacts: dict[str, str] = {}
     for index, job in enumerate(jobs, 1):
         if not isinstance(job, dict):
             raise QueueError(f"job {index} must be an object")
@@ -175,8 +304,9 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
         seen.add(job_id)
         command = job.get("command")
         if (not isinstance(command, list) or not command or
-                not all(isinstance(item, str) and item for item in command)):
-            raise QueueError(f"job {job_id} command must be nonempty strings")
+                not all(isinstance(item, dict) for item in command)):
+            raise QueueError(
+                f"job {job_id} command must be typed argument objects")
         _absolute(job.get("cwd"), f"job {job_id} cwd", root)
         _absolute(job.get("log"), f"job {job_id} log", root)
         success = job.get("success")
@@ -191,19 +321,22 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
             raise QueueError(f"job {job_id} success sha256 is invalid")
         validator = success.get("validator")
         if (not isinstance(validator, list) or not validator or
-                not all(isinstance(item, str) and item for item in validator)):
-            raise QueueError(f"job {job_id} validator must be nonempty strings")
+                not all(isinstance(item, dict) for item in validator)):
+            raise QueueError(
+                f"job {job_id} validator must be typed argument objects")
         validator_timeout = success.get("validator_timeout_seconds")
         if (isinstance(validator_timeout, bool) or
                 not isinstance(validator_timeout, (int, float)) or
-                validator_timeout <= 0):
+                not 0 < validator_timeout <= MAX_VALIDATOR_SECONDS):
             raise QueueError(
-                f"job {job_id} validator_timeout_seconds must be positive")
+                f"job {job_id} validator_timeout_seconds must be in "
+                f"(0, {MAX_VALIDATOR_SECONDS}]")
         env = job.get("env", {})
         if (not isinstance(env, dict) or
-                not all(isinstance(k, str) and isinstance(v, str)
+                not all(isinstance(k, str) and k and isinstance(v, dict)
                         for k, v in env.items())):
-            raise QueueError(f"job {job_id} env must map strings to strings")
+            raise QueueError(
+                f"job {job_id} env must map names to typed argument objects")
         job_pins = job.get("pinned_inputs")
         if (not isinstance(job_pins, list) or not job_pins or
                 not all(isinstance(value, str) and Path(value).is_absolute()
@@ -219,6 +352,18 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
             missing_pins = sorted(resolved_job_pins - pinned_paths)
             raise QueueError(
                 f"job {job_id} references undeclared pins: {missing_pins}")
+        mutable_values = job.get("mutable_paths", [])
+        if (not isinstance(mutable_values, list) or
+                not all(isinstance(value, str) and Path(value).is_absolute()
+                        for value in mutable_values)):
+            raise QueueError(
+                f"job {job_id} mutable_paths must be absolute paths")
+        resolved_mutable = {
+            str(_absolute(value, f"job {job_id} mutable path", root))
+            for value in mutable_values
+        }
+        if len(resolved_mutable) != len(mutable_values):
+            raise QueueError(f"job {job_id} mutable_paths contains duplicates")
         resume_safe = job.get("resume_safe")
         if not isinstance(resume_safe, bool):
             raise QueueError(f"job {job_id} resume_safe must be boolean")
@@ -242,6 +387,11 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
         ):
             raise QueueError(
                 f"job {job_id} progress_not_required_reason must be nonempty")
+        if (no_progress_reason is not None and
+                max_runtime > MAX_PROGRESS_EXEMPT_SECONDS):
+            raise QueueError(
+                f"job {job_id} exceeds the {MAX_PROGRESS_EXEMPT_SECONDS}s "
+                "progress-exemption limit")
         if progress is not None:
             if not isinstance(progress, dict):
                 raise QueueError(f"job {job_id} progress must be an object")
@@ -252,53 +402,63 @@ def validate_plan(path: Path) -> tuple[dict[str, Any], Path, str]:
                     stale < 2 * poll):
                 raise QueueError(
                     f"job {job_id} max_stale_seconds must be at least two polls")
-        for executable, label in (
-            (command[0], "command executable"),
-            (validator[0], "validator executable"),
-        ):
-            if not Path(executable).is_absolute():
-                raise QueueError(f"job {job_id} {label} must be absolute")
-            resolved_executable = str(Path(executable).expanduser().resolve())
-            if resolved_executable not in pinned_paths:
-                raise QueueError(
-                    f"job {job_id} {label} is not pinned: {resolved_executable}")
-            if resolved_executable not in resolved_job_pins:
-                raise QueueError(
-                    f"job {job_id} {label} is not in pinned_inputs: "
-                    f"{resolved_executable}")
-        referenced_values = [*command, *validator, *env.values()]
         mutable_paths = {
             str(_absolute(job["log"], f"job {job_id} log", root)),
             str(_absolute(success["path"], f"job {job_id} success path", root)),
+            *resolved_mutable,
         }
         if progress is not None:
             mutable_paths.add(str(_absolute(
                 progress["path"], f"job {job_id} progress path", root)))
-        for value in referenced_values:
-            candidate = Path(value).expanduser()
-            if candidate.is_absolute() and candidate.is_file():
-                resolved_candidate = str(candidate.resolve())
-                if resolved_candidate in mutable_paths:
-                    continue
-                if resolved_candidate not in resolved_job_pins:
-                    raise QueueError(
-                        f"job {job_id} file argument is not in pinned_inputs: "
-                        f"{resolved_candidate}")
+        for label, values in (
+            ("command", command), ("validator", validator),
+        ):
+            for position, argument in enumerate(values):
+                _validate_arg(
+                    argument, label=f"job {job_id} {label}[{position}]",
+                    root=root, pinned_paths=pinned_paths,
+                    job_pins=resolved_job_pins, mutable_paths=mutable_paths,
+                    predecessor_artifacts=predecessor_artifacts,
+                )
+            if values[0].get("kind") != "pinned":
+                raise QueueError(
+                    f"job {job_id} {label} executable must be pinned")
+        for key, argument in env.items():
+            _validate_arg(
+                argument, label=f"job {job_id} env[{key}]", root=root,
+                pinned_paths=pinned_paths, job_pins=resolved_job_pins,
+                mutable_paths=mutable_paths,
+                predecessor_artifacts=predecessor_artifacts,
+            )
+        predecessor_artifacts[job_id] = str(_absolute(
+            success["path"], f"job {job_id} success path", root))
     return plan, root, plan_sha
 
 
 def pinned_files_error(plan: dict[str, Any]) -> str | None:
     for pin in plan["pinned_files"]:
         path = Path(pin["path"]).expanduser().resolve()
-        if not path.is_file():
-            return f"pinned {pin['role']} is missing: {path}"
-        observed_size = path.stat().st_size
+        if pin["kind"] == "file":
+            if not path.is_file():
+                return f"pinned {pin['role']} is missing: {path}"
+            observed_size = path.stat().st_size
+            observed_files = None
+            observed_sha = sha256(path)
+        else:
+            try:
+                observed_files, observed_size, observed_sha = tree_identity(path)
+            except QueueError as exc:
+                return f"pinned {pin['role']} tree invalid: {exc}"
+            if observed_files != pin["files"]:
+                return (
+                    f"pinned {pin['role']} file-count drift: "
+                    f"{observed_files} != {pin['files']}: {path}"
+                )
         if observed_size != pin["bytes"]:
             return (
                 f"pinned {pin['role']} size drift: "
                 f"{observed_size} != {pin['bytes']}: {path}"
             )
-        observed_sha = sha256(path)
         if observed_sha != pin["sha256"]:
             return (
                 f"pinned {pin['role']} SHA-256 drift: "
@@ -344,8 +504,48 @@ def gpu_temperature() -> float:
     return max(temperatures)
 
 
+def _existing_ancestor(path: Path) -> Path:
+    current = path
+    while not current.exists() and current != current.parent:
+        current = current.parent
+    if not current.exists():
+        raise QueueError(f"no existing ancestor for capacity check: {path}")
+    return current
+
+
+def capacity_error(
+    root: Path, job: dict[str, Any], *, minimum_free_bytes: int,
+    minimum_free_inodes: int,
+) -> str | None:
+    """Check every distinct filesystem used by this job's mutable paths."""
+    paths = [
+        root, Path(job["cwd"]), Path(job["log"]),
+        Path(job["success"]["path"]),
+        *(Path(value) for value in job.get("mutable_paths", [])),
+    ]
+    if job.get("progress"):
+        paths.append(Path(job["progress"]["path"]))
+    filesystems: dict[int, Path] = {}
+    for path in paths:
+        ancestor = _existing_ancestor(path.expanduser().resolve())
+        filesystems.setdefault(ancestor.stat().st_dev, ancestor)
+    for path in filesystems.values():
+        free = shutil.disk_usage(path).free
+        if free < minimum_free_bytes:
+            return f"disk guard tripped on {path}: {free} < {minimum_free_bytes}"
+        stats = os.statvfs(path)
+        if stats.f_favail < minimum_free_inodes:
+            return (
+                f"inode guard tripped on {path}: "
+                f"{stats.f_favail} < {minimum_free_inodes}")
+    return None
+
+
 def success_error(
     job: dict[str, Any], root: Path, base_env: dict[str, str],
+    *, minimum_free_bytes: int, minimum_free_inodes: int,
+    maximum_temperature: float,
+    poll_seconds: float,
 ) -> str | None:
     success = job["success"]
     path = _absolute(success["path"], f"job {job['id']} success path", root)
@@ -359,22 +559,54 @@ def success_error(
     validator = success.get("validator")
     if validator:
         timeout = float(success["validator_timeout_seconds"])
-        try:
-            result = subprocess.run(
-                validator,
+        started = time.monotonic()
+        hot_polls = 0
+        with tempfile.TemporaryFile(mode="w+t", encoding="utf-8") as output:
+            try:
+                process = subprocess.Popen(
+                render_args(validator),
                 cwd=_absolute(job["cwd"], f"job {job['id']} cwd", root),
-                env={**base_env, **job.get("env", {})},
-                stdout=subprocess.PIPE,
+                env={**base_env, **render_env(job.get("env", {}))},
+                stdout=output,
                 stderr=subprocess.STDOUT,
                 text=True,
-                check=False,
-                timeout=timeout,
-            )
-        except subprocess.TimeoutExpired:
-            return f"validator timed out after {timeout:g}s"
-        if result.returncode != 0:
-            output = result.stdout.strip()[-2000:]
-            return f"validator exited {result.returncode}: {output}"
+                start_new_session=True,
+                )
+            except OSError as exc:
+                return f"validator launch failed: {exc}"
+            while process.poll() is None:
+                elapsed = time.monotonic() - started
+                if elapsed > timeout:
+                    _terminate_group(process)
+                    return f"validator timed out after {timeout:g}s"
+                try:
+                    capacity = capacity_error(
+                        root, job, minimum_free_bytes=minimum_free_bytes,
+                        minimum_free_inodes=minimum_free_inodes,
+                    )
+                    if capacity is not None:
+                        _terminate_group(process)
+                        return f"validator {capacity}"
+                    observed_temperature = gpu_temperature()
+                    hot_polls = (
+                        hot_polls + 1
+                        if observed_temperature > maximum_temperature else 0
+                    )
+                    if hot_polls >= 3:
+                        _terminate_group(process)
+                        return (
+                            "validator thermal guard tripped: "
+                            f"{observed_temperature:.0f}C > "
+                            f"{maximum_temperature}C for {hot_polls} polls")
+                except (OSError, QueueError, ValueError) as exc:
+                    _terminate_group(process)
+                    return f"validator monitor failed closed: {exc}"
+                time.sleep(min(poll_seconds, max(timeout - elapsed, 0.001)))
+            exit_code = process.wait()
+            output.seek(0)
+            rendered_output = output.read().strip()[-2000:]
+        if exit_code != 0:
+            return f"validator exited {exit_code}: {rendered_output}"
         if expected is not None:
             observed_after = sha256(path)
             if observed_after != expected:
@@ -431,6 +663,7 @@ def monitor_process(
     root: Path,
     job: dict[str, Any],
     minimum_free_bytes: int,
+    minimum_free_inodes: int,
     poll_seconds: float,
     maximum_temperature: float | None,
 ) -> str | None:
@@ -441,12 +674,12 @@ def monitor_process(
     hot_polls = 0
     while process.poll() is None:
         try:
-            free = shutil.disk_usage(root).free
-            if free < minimum_free_bytes:
-                reason = (
-                    f"disk guard tripped during {job['id']}: "
-                    f"{free} < {minimum_free_bytes}"
-                )
+            capacity = capacity_error(
+                root, job, minimum_free_bytes=minimum_free_bytes,
+                minimum_free_inodes=minimum_free_inodes,
+            )
+            if capacity is not None:
+                reason = f"{capacity} during {job['id']}"
                 _terminate_group(process)
                 return reason
             elapsed = time.monotonic() - started_monotonic
@@ -586,8 +819,32 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                     f"job {job['id']} was interrupted and is not resume-safe",
                 )
 
-            artifact_error = success_error(job, root, plan["base_env"])
+            artifact_error = success_error(
+                job, root, plan["base_env"],
+                minimum_free_bytes=int(plan["min_free_bytes"]),
+                minimum_free_inodes=int(plan["min_free_inodes"]),
+                maximum_temperature=float(plan["max_gpu_temperature_c"]),
+                poll_seconds=poll_seconds,
+            )
+            if prior == "complete" and artifact_error is not None:
+                return halt(
+                    state_path, state,
+                    f"completed job {job['id']} evidence drifted: "
+                    f"{artifact_error}",
+                )
             if artifact_error is None:
+                artifact_path = _absolute(
+                    job["success"]["path"],
+                    f"job {job['id']} success path", root,
+                )
+                artifact_sha = sha256(artifact_path)
+                recorded_sha = job_state.get("success_sha256")
+                if recorded_sha is not None and recorded_sha != artifact_sha:
+                    return halt(
+                        state_path, state,
+                        f"job {job['id']} success artifact drifted: "
+                        f"{artifact_sha} != {recorded_sha}",
+                    )
                 if sha256(plan_path) != plan_sha:
                     return halt(
                         state_path, state,
@@ -599,6 +856,7 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                 job_state.update({
                     "state": "complete",
                     "recovered_from_artifact": True,
+                    "success_sha256": artifact_sha,
                     "completed_utc": job_state.get("completed_utc", utc_now()),
                 })
                 publish(
@@ -607,18 +865,22 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                 )
                 continue
 
-            free = shutil.disk_usage(root).free
             minimum = int(plan["min_free_bytes"])
-            if free < minimum:
+            minimum_inodes = int(plan["min_free_inodes"])
+            capacity = capacity_error(
+                root, job, minimum_free_bytes=minimum,
+                minimum_free_inodes=minimum_inodes,
+            )
+            if capacity is not None:
                 return halt(
                     state_path, state,
-                    f"disk preflight failed before {job['id']}: {free} < {minimum}",
+                    f"capacity preflight failed before {job['id']}: {capacity}",
                 )
 
             log_path = _absolute(job["log"], f"job {job['id']} log", root)
             log_path.parent.mkdir(parents=True, exist_ok=True)
             cwd = _absolute(job["cwd"], f"job {job['id']} cwd", root)
-            env = {**plan["base_env"], **job.get("env", {})}
+            env = {**plan["base_env"], **render_env(job.get("env", {}))}
             with log_path.open("a", encoding="utf-8") as log:
                 log.write(
                     f"\nQUEUE JOB START {utc_now()} id={job['id']} "
@@ -648,7 +910,7 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                     signal.signal(signum, interrupt_handler)
                 try:
                     process = subprocess.Popen(
-                        job["command"], cwd=cwd, env=env,
+                        render_args(job["command"]), cwd=cwd, env=env,
                         stdout=log, stderr=subprocess.STDOUT,
                         start_new_session=True,
                     )
@@ -667,6 +929,7 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                         root=root,
                         job=job,
                         minimum_free_bytes=minimum,
+                        minimum_free_inodes=minimum_inodes,
                         poll_seconds=poll_seconds,
                         maximum_temperature=(
                             float(maximum_temperature)
@@ -684,6 +947,8 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
                         f"queue interrupted during {job['id']}: {exc}",
                     )
                 finally:
+                    if process is not None and process.poll() is None:
+                        _terminate_group(process)
                     for signum, handler in previous_handlers.items():
                         signal.signal(signum, handler)
 
@@ -706,7 +971,13 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
             if pin_error is not None:
                 job_state["state"] = "failed"
                 return halt(state_path, state, pin_error)
-            artifact_error = success_error(job, root, plan["base_env"])
+            artifact_error = success_error(
+                job, root, plan["base_env"],
+                minimum_free_bytes=minimum,
+                minimum_free_inodes=minimum_inodes,
+                maximum_temperature=float(maximum_temperature),
+                poll_seconds=poll_seconds,
+            )
             if artifact_error is not None:
                 job_state["state"] = "failed"
                 return halt(
@@ -723,7 +994,14 @@ def run_queue(plan_path: str | Path, state_path: str | Path) -> int:
             if pin_error is not None:
                 job_state["state"] = "failed"
                 return halt(state_path, state, pin_error)
-            job_state.update({"state": "complete", "completed_utc": utc_now()})
+            artifact_path = _absolute(
+                job["success"]["path"],
+                f"job {job['id']} success path", root,
+            )
+            job_state.update({
+                "state": "complete", "completed_utc": utc_now(),
+                "success_sha256": sha256(artifact_path),
+            })
             publish(
                 state_path, state,
                 message=f"job {job['id']} completed and validated",

--- a/tools/experiment_queue.py
+++ b/tools/experiment_queue.py
@@ -651,6 +651,10 @@ def success_error(
                     signal.signal(signum, handler)
             exit_code = process.wait()
             output_size = os.fstat(output.fileno()).st_size
+            if output_size > MAX_VALIDATOR_OUTPUT_BYTES:
+                return (
+                    "validator output limit exceeded: "
+                    f"{output_size} > {MAX_VALIDATOR_OUTPUT_BYTES}")
             output.seek(max(0, output_size - 2000))
             rendered_output = output.read(2000).decode(
                 "utf-8", errors="replace").strip()

--- a/tools/run_reward_candidate_transfer.py
+++ b/tools/run_reward_candidate_transfer.py
@@ -207,6 +207,20 @@ def implementation_identity(root: Path) -> dict[str, str]:
     }
 
 
+def orchestration_identity(root: Path) -> dict[str, str]:
+    paths = (
+        root / "tools/run_reward_candidate_transfer.py",
+        root / "tools/analyze_reward_candidate_transfer.py",
+        root / "tools/game_stats.py",
+        root / "tools/contact_bot_stats.py",
+        root / "training/convert_checkpoint.py",
+        root / "vendor/PufferLib/pufferlib/torch_pufferl.py",
+        root / "vendor/PufferLib/pufferlib/models.py",
+        root / "vendor/PufferLib/pufferlib/selfplay.py",
+    )
+    return {str(path.resolve()): sha256(path) for path in paths}
+
+
 def freeze_manifest(
     path: Path, root: Path, screen_dir: Path, expected_screen_sha: str,
     checkpoints: dict[str, dict[str, Any]], arms: tuple[str, ...],
@@ -235,6 +249,7 @@ def freeze_manifest(
             "min_eval_games": 1_000,
         },
         "implementation": implementation_identity(root),
+        "orchestration_files": orchestration_identity(root),
         "conversion": {
             "converter_sha256": sha256(root / "training/convert_checkpoint.py"),
             "config_sha256": sha256(root / "puffer/config/bloodbowl.ini"),

--- a/tools/run_reward_candidate_transfer.py
+++ b/tools/run_reward_candidate_transfer.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Run a restart-validating scripted transfer matrix for a reward screen.
+
+The completed possession/gain screen supplies four arms and two seeds. This
+runner converts each accepted native checkpoint to Torch, freezes every input
+and conversion hash, then evaluates every arm against both scripted opponent
+styles in both team orientations. Existing artifacts are reused only after full
+validation; partial or drifted artifacts fail closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import analyze_reward_candidate_transfer as candidate_transfer
+import analyze_reward_screen
+
+
+ARMS = ("both", "possession_only", "gain_only", "neither")
+SEEDS = (42, 43)
+BOT_TYPES = (0, 1)
+BOT_TEAMS = (0, 1)
+EXPECTED_NATIVE_BYTES = 16_066_560
+
+
+class RunnerError(ValueError):
+    pass
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunnerError(f"invalid {label}: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RunnerError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def run_checked(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command, text=True, stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, check=False, **kwargs,
+    )
+    if result.returncode != 0:
+        raise RunnerError(
+            f"command exited {result.returncode}: {command!r}\n"
+            f"{result.stdout[-4000:]}")
+    return result
+
+
+def screen_checkpoints(screen_dir: Path, expected_sha: str) -> dict[str, dict[str, Any]]:
+    report = analyze_reward_screen.analyze_screen(
+        screen_dir, analyze_reward_screen.DEFAULT_METRICS,
+        expected_screen_sha=expected_sha,
+    )
+    if not report["screen"]["completion"].get("present"):
+        raise RunnerError("source screen has no verified completion proof")
+    if report["screen"]["profile"] != "possession-gain":
+        raise RunnerError("candidate transfer requires a possession-gain screen")
+    prefix = report["screen"]["prefix"]
+    checkpoints: dict[str, dict[str, Any]] = {arm: {} for arm in ARMS}
+    for arm in ARMS:
+        for seed in SEEDS:
+            result_path = screen_dir / f"{prefix}-{arm}-s{seed}.result.json"
+            result = load_object(result_path, f"screen result {arm}/seed {seed}")
+            native = Path(str(result.get("checkpoint", ""))).expanduser().resolve()
+            if not native.is_file():
+                raise RunnerError(f"missing native checkpoint: {native}")
+            if native.stat().st_size != EXPECTED_NATIVE_BYTES:
+                raise RunnerError(f"wrong native checkpoint size: {native}")
+            observed = sha256(native)
+            if observed != result.get("checkpoint_sha256"):
+                raise RunnerError(
+                    f"native checkpoint hash drift for {arm}/seed {seed}")
+            checkpoints[arm][str(seed)] = {
+                "screen_result": str(result_path),
+                "screen_result_sha256": sha256(result_path),
+                "native": str(native),
+                "native_bytes": native.stat().st_size,
+                "native_sha256": observed,
+            }
+    return checkpoints
+
+
+def convert_checkpoints(
+    root: Path, out_dir: Path, checkpoints: dict[str, dict[str, Any]],
+) -> None:
+    python = root / "vendor/PufferLib/.venv/bin/python"
+    converter = root / "training/convert_checkpoint.py"
+    config = root / "puffer/config/bloodbowl.ini"
+    for arm in ARMS:
+        for seed in SEEDS:
+            record = checkpoints[arm][str(seed)]
+            output = out_dir / "converted" / f"{arm}-s{seed}-torch.bin"
+            output.parent.mkdir(parents=True, exist_ok=True)
+            metadata = output.with_suffix(output.suffix + ".json")
+            if output.exists() or metadata.exists():
+                if not output.is_file() or not metadata.is_file():
+                    raise RunnerError(f"partial conversion artifact: {output}")
+                saved = load_object(metadata, "conversion metadata")
+                expected = {
+                    "schema_version": 1,
+                    "source": record["native"],
+                    "source_sha256": record["native_sha256"],
+                    "converter_sha256": sha256(converter),
+                    "config_sha256": sha256(config),
+                    "obs_size": 2782,
+                    "output": str(output),
+                    "output_sha256": sha256(output),
+                }
+                if any(saved.get(key) != value for key, value in expected.items()):
+                    raise RunnerError(f"conversion metadata drift: {metadata}")
+            else:
+                temporary = output.with_suffix(output.suffix + f".tmp.{os.getpid()}")
+                result = run_checked([
+                    str(python), str(converter), "--to-torch", record["native"],
+                    "--config", str(config), "--obs-size", "2782",
+                    "-o", str(temporary),
+                ], cwd=root)
+                if not temporary.is_file() or temporary.stat().st_size < 1_000_000:
+                    raise RunnerError(f"converter produced invalid output: {temporary}")
+                os.replace(temporary, output)
+                atomic_json(metadata, {
+                    "schema_version": 1,
+                    "source": record["native"],
+                    "source_sha256": record["native_sha256"],
+                    "converter": str(converter),
+                    "converter_sha256": sha256(converter),
+                    "config": str(config),
+                    "config_sha256": sha256(config),
+                    "obs_size": 2782,
+                    "output": str(output),
+                    "output_bytes": output.stat().st_size,
+                    "output_sha256": sha256(output),
+                    "converter_stdout": result.stdout.strip(),
+                    "created_utc": utc_now(),
+                })
+            record.update({
+                "torch": str(output),
+                "torch_bytes": output.stat().st_size,
+                "torch_sha256": sha256(output),
+                "conversion_metadata": str(metadata),
+                "conversion_metadata_sha256": sha256(metadata),
+            })
+
+
+def implementation_identity(root: Path) -> dict[str, str]:
+    python = root / "vendor/PufferLib/.venv/bin/python"
+    module_result = run_checked([
+        str(python), "-c", "from pufferlib import _C; print(_C.__file__)",
+    ], cwd=root / "vendor/PufferLib")
+    module = Path(module_result.stdout.strip()).resolve()
+    if not module.is_file():
+        raise RunnerError(f"imported module is missing: {module}")
+    return {
+        "config_sha256": sha256(root / "puffer/config/bloodbowl.ini"),
+        "compiled_module_sha256": sha256(module),
+        "pufferl_sha256": sha256(root / "vendor/PufferLib/pufferlib/pufferl.py"),
+        "launcher_sha256": sha256(root / "tools/eval_vs_contact_bot.sh"),
+    }
+
+
+def freeze_manifest(
+    path: Path, root: Path, screen_dir: Path, expected_screen_sha: str,
+    checkpoints: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    core = {
+        "schema_version": 1,
+        "matrix_id": path.parent.name,
+        "source_screen": str(screen_dir),
+        "source_screen_sha256": expected_screen_sha,
+        "reference_arm": "both",
+        "candidate_arms": ["possession_only", "gain_only", "neither"],
+        # Remove both terms first; among one-term recipes prefer the settled-state
+        # possession annuity over the outcome-priced gain event (D147/D178).
+        "preference_order": ["neither", "possession_only", "gain_only"],
+        "seeds": list(SEEDS),
+        "bot_types": list(BOT_TYPES),
+        "bot_teams": list(BOT_TEAMS),
+        "settings": {
+            "requested_train_steps": 131_072,
+            "eval_episodes": 1_000,
+            "min_eval_games": 1_000,
+        },
+        "implementation": implementation_identity(root),
+        "conversion": {
+            "converter_sha256": sha256(root / "training/convert_checkpoint.py"),
+            "config_sha256": sha256(root / "puffer/config/bloodbowl.ini"),
+            "obs_size": 2782,
+            "bias_contract": "native-to-torch zero-fills biases",
+        },
+        "checkpoints": checkpoints,
+        "gates": {
+            "mean_score_delta_min": -0.02,
+            "cell_score_delta_min": -0.05,
+            "max_champion_td_relative_drop": 0.20,
+            "max_bot_td_relative_rise": 0.20,
+        },
+    }
+    if path.exists():
+        recorded = load_object(path, "transfer manifest")
+        observed_core = {key: recorded.get(key) for key in core}
+        if observed_core != core:
+            raise RunnerError("existing transfer manifest differs from recomputed plan")
+        return recorded
+    payload = {**core, "created_utc": utc_now()}
+    atomic_json(path, payload)
+    return payload
+
+
+def write_status(path: Path, state: str, completed: int, message: str) -> None:
+    atomic_json(path, {
+        "schema_version": 1, "state": state, "completed_cells": completed,
+        "total_cells": len(ARMS) * len(SEEDS) * len(BOT_TYPES) * len(BOT_TEAMS),
+        "message": message, "updated_utc": utc_now(), "pid": os.getpid(),
+    })
+
+
+def completed_from_status(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    try:
+        value = load_object(path, "transfer status").get("completed_cells", 0)
+        return value if isinstance(value, int) and not isinstance(value, bool) else 0
+    except (OSError, RunnerError):
+        return 0
+
+
+def run_matrix(root: Path, out_dir: Path, plan: dict[str, Any]) -> None:
+    launcher = root / "tools/eval_vs_contact_bot.sh"
+    status_path = out_dir / "TRANSFER_STATUS.json"
+    completed = 0
+    write_status(status_path, "running", completed, "validating transfer cells")
+    for arm in ARMS:
+        for seed in SEEDS:
+            checkpoint = Path(plan["checkpoints"][arm][str(seed)]["torch"])
+            for bot_type in BOT_TYPES:
+                for bot_team in BOT_TEAMS:
+                    log = out_dir / f"{arm}-s{seed}-b{bot_type}-t{bot_team}.log"
+                    if log.exists():
+                        candidate_transfer._validate_cell(
+                            log, {**plan, "_arms": list(ARMS)},
+                            arm, seed, bot_type, bot_team,
+                        )
+                    else:
+                        write_status(
+                            status_path, "running", completed,
+                            f"running {arm}/seed {seed}/bot {bot_type}/team {bot_team}",
+                        )
+                        env = {
+                            **os.environ,
+                            "SEED": str(seed),
+                            "BOT_TYPE": str(bot_type),
+                            "BOT_TEAM": str(bot_team),
+                            "EVAL_EPISODES": "1000",
+                            "MIN_EVAL_GAMES": "1000",
+                        }
+                        result = subprocess.run(
+                            ["bash", str(launcher), str(checkpoint), "131072", str(log)],
+                            cwd=root, env=env, check=False,
+                        )
+                        if result.returncode != 0:
+                            raise RunnerError(
+                                f"transfer cell exited {result.returncode}: {log}")
+                        candidate_transfer._validate_cell(
+                            log, {**plan, "_arms": list(ARMS)},
+                            arm, seed, bot_type, bot_team,
+                        )
+                    completed += 1
+                    write_status(status_path, "running", completed, "cell validated")
+
+
+def complete_transfer(out_dir: Path) -> None:
+    analysis_path = out_dir / "ANALYSIS.json"
+    report = candidate_transfer.analyze(out_dir)
+    atomic_json(analysis_path, report)
+    complete_path = out_dir / "TRANSFER_COMPLETE.json"
+    core = {
+        "schema_version": 1,
+        "transfer_manifest_sha256": sha256(out_dir / "TRANSFER_MANIFEST.json"),
+        "analysis_sha256": sha256(analysis_path),
+        "recommended_confirmation_arm": report["recommendation"]["arm"],
+        "cells": [
+            {"log": row["log"], "sha256": row["log_sha256"]}
+            for row in report["runs"]
+        ],
+    }
+    if complete_path.exists():
+        recorded = load_object(complete_path, "transfer completion")
+        if {key: recorded.get(key) for key in core} != core:
+            raise RunnerError("existing transfer completion is stale")
+    else:
+        atomic_json(complete_path, {**core, "completed_utc": utc_now()})
+    write_status(
+        out_dir / "TRANSFER_STATUS.json", "complete", len(report["runs"]),
+        f"matrix complete; confirmation candidate={report['recommendation']['arm']}",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--screen-dir", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--expected-screen-sha", required=True)
+    parser.add_argument("--plan-only", action="store_true")
+    args = parser.parse_args(argv)
+    root = Path(__file__).resolve().parents[1]
+    screen_dir = args.screen_dir.expanduser().resolve()
+    out_dir = args.out_dir.expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = out_dir / ".transfer.lock"
+    try:
+        with lock_path.open("a+") as lock:
+            try:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                raise RunnerError("another transfer runner holds the lock") from exc
+            checkpoints = screen_checkpoints(
+                screen_dir, args.expected_screen_sha.lower())
+            # Share the exact one-GPU lock used by reward training. Requiring a
+            # completed source screen above prevents stealing the lock during a
+            # brief inter-arm gap.
+            gpu_lock_path = Path("/tmp/bloodbowl-rl-reward-ablation.lock")
+            with gpu_lock_path.open("a+") as gpu_lock:
+                try:
+                    fcntl.flock(gpu_lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError as exc:
+                    raise RunnerError(
+                        "training/evaluation GPU lock is already held") from exc
+                convert_checkpoints(root, out_dir, checkpoints)
+                plan = freeze_manifest(
+                    out_dir / "TRANSFER_MANIFEST.json", root, screen_dir,
+                    args.expected_screen_sha.lower(), checkpoints,
+                )
+                if args.plan_only:
+                    print(
+                        "TRANSFER PLAN VERIFIED: "
+                        f"{out_dir / 'TRANSFER_MANIFEST.json'}")
+                    return 0
+                run_matrix(root, out_dir, plan)
+                complete_transfer(out_dir)
+                print(f"TRANSFER COMPLETE: {out_dir}")
+                return 0
+    except (OSError, RunnerError, ValueError,
+            analyze_reward_screen.AnalysisError,
+            candidate_transfer.TransferError) as exc:
+        status_path = out_dir / "TRANSFER_STATUS.json"
+        write_status(
+            status_path,
+            "failed",
+            completed_from_status(status_path),
+            str(exc),
+        )
+        print(f"candidate-transfer runner failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_reward_candidate_transfer.py
+++ b/tools/run_reward_candidate_transfer.py
@@ -211,6 +211,9 @@ def orchestration_identity(root: Path) -> dict[str, str]:
     paths = (
         root / "tools/run_reward_candidate_transfer.py",
         root / "tools/analyze_reward_candidate_transfer.py",
+        root / "tools/analyze_reward_screen.py",
+        root / "tools/install_puffer_env.sh",
+        root / "tools/cpu_cap.sh",
         root / "tools/game_stats.py",
         root / "tools/contact_bot_stats.py",
         root / "training/convert_checkpoint.py",

--- a/tools/run_reward_candidate_transfer.py
+++ b/tools/run_reward_candidate_transfer.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Run a restart-validating scripted transfer matrix for a reward screen.
 
-The completed possession/gain screen supplies four arms and two seeds. This
-runner converts each accepted native checkpoint to Torch, freezes every input
-and conversion hash, then evaluates every arm against both scripted opponent
-styles in both team orientations. Existing artifacts are reused only after full
-validation; partial or drifted artifacts fail closed.
+A completed possession/gain screen supplies four arms and two seeds; a paired
+confirmation supplies R0 and one candidate. This runner converts each accepted
+native checkpoint to Torch, freezes every input and conversion hash, then
+evaluates every arm against both scripted opponent styles in both team
+orientations. Existing artifacts are reused only after full validation; partial
+or drifted artifacts fail closed.
 """
 
 from __future__ import annotations
@@ -25,7 +26,7 @@ import analyze_reward_candidate_transfer as candidate_transfer
 import analyze_reward_screen
 
 
-ARMS = ("both", "possession_only", "gain_only", "neither")
+FULL_ARMS = ("both", "possession_only", "gain_only", "neither")
 SEEDS = (42, 43)
 BOT_TYPES = (0, 1)
 BOT_TEAMS = (0, 1)
@@ -80,18 +81,31 @@ def run_checked(command: list[str], **kwargs: Any) -> subprocess.CompletedProces
     return result
 
 
-def screen_checkpoints(screen_dir: Path, expected_sha: str) -> dict[str, dict[str, Any]]:
+def screen_checkpoints(
+    screen_dir: Path, expected_sha: str,
+) -> tuple[dict[str, dict[str, Any]], tuple[str, ...]]:
     report = analyze_reward_screen.analyze_screen(
         screen_dir, analyze_reward_screen.DEFAULT_METRICS,
         expected_screen_sha=expected_sha,
     )
     if not report["screen"]["completion"].get("present"):
         raise RunnerError("source screen has no verified completion proof")
-    if report["screen"]["profile"] != "possession-gain":
-        raise RunnerError("candidate transfer requires a possession-gain screen")
+    profile = report["screen"]["profile"]
+    if profile == "possession-gain":
+        arms = FULL_ARMS
+    elif profile == "paired-confirmation":
+        candidate = report["screen"].get("candidate_arm")
+        if candidate not in FULL_ARMS[1:]:
+            raise RunnerError("paired source screen has an invalid candidate")
+        arms = ("both", candidate)
+    else:
+        raise RunnerError(
+            "candidate transfer requires a possession-gain or "
+            "paired-confirmation screen"
+        )
     prefix = report["screen"]["prefix"]
-    checkpoints: dict[str, dict[str, Any]] = {arm: {} for arm in ARMS}
-    for arm in ARMS:
+    checkpoints: dict[str, dict[str, Any]] = {arm: {} for arm in arms}
+    for arm in arms:
         for seed in SEEDS:
             result_path = screen_dir / f"{prefix}-{arm}-s{seed}.result.json"
             result = load_object(result_path, f"screen result {arm}/seed {seed}")
@@ -111,16 +125,17 @@ def screen_checkpoints(screen_dir: Path, expected_sha: str) -> dict[str, dict[st
                 "native_bytes": native.stat().st_size,
                 "native_sha256": observed,
             }
-    return checkpoints
+    return checkpoints, arms
 
 
 def convert_checkpoints(
     root: Path, out_dir: Path, checkpoints: dict[str, dict[str, Any]],
+    arms: tuple[str, ...],
 ) -> None:
     python = root / "vendor/PufferLib/.venv/bin/python"
     converter = root / "training/convert_checkpoint.py"
     config = root / "puffer/config/bloodbowl.ini"
-    for arm in ARMS:
+    for arm in arms:
         for seed in SEEDS:
             record = checkpoints[arm][str(seed)]
             output = out_dir / "converted" / f"{arm}-s{seed}-torch.bin"
@@ -194,18 +209,23 @@ def implementation_identity(root: Path) -> dict[str, str]:
 
 def freeze_manifest(
     path: Path, root: Path, screen_dir: Path, expected_screen_sha: str,
-    checkpoints: dict[str, dict[str, Any]],
+    checkpoints: dict[str, dict[str, Any]], arms: tuple[str, ...],
 ) -> dict[str, Any]:
+    candidates = list(arms[1:])
+    preference = [
+        arm for arm in ("neither", "possession_only", "gain_only")
+        if arm in candidates
+    ]
     core = {
         "schema_version": 1,
         "matrix_id": path.parent.name,
         "source_screen": str(screen_dir),
         "source_screen_sha256": expected_screen_sha,
         "reference_arm": "both",
-        "candidate_arms": ["possession_only", "gain_only", "neither"],
+        "candidate_arms": candidates,
         # Remove both terms first; among one-term recipes prefer the settled-state
         # possession annuity over the outcome-priced gain event (D147/D178).
-        "preference_order": ["neither", "possession_only", "gain_only"],
+        "preference_order": preference,
         "seeds": list(SEEDS),
         "bot_types": list(BOT_TYPES),
         "bot_teams": list(BOT_TEAMS),
@@ -240,10 +260,12 @@ def freeze_manifest(
     return payload
 
 
-def write_status(path: Path, state: str, completed: int, message: str) -> None:
+def write_status(
+    path: Path, state: str, completed: int, total: int, message: str,
+) -> None:
     atomic_json(path, {
         "schema_version": 1, "state": state, "completed_cells": completed,
-        "total_cells": len(ARMS) * len(SEEDS) * len(BOT_TYPES) * len(BOT_TEAMS),
+        "total_cells": total,
         "message": message, "updated_utc": utc_now(), "pid": os.getpid(),
     })
 
@@ -262,8 +284,12 @@ def run_matrix(root: Path, out_dir: Path, plan: dict[str, Any]) -> None:
     launcher = root / "tools/eval_vs_contact_bot.sh"
     status_path = out_dir / "TRANSFER_STATUS.json"
     completed = 0
-    write_status(status_path, "running", completed, "validating transfer cells")
-    for arm in ARMS:
+    arms = (plan["reference_arm"], *plan["candidate_arms"])
+    total = len(arms) * len(SEEDS) * len(BOT_TYPES) * len(BOT_TEAMS)
+    write_status(
+        status_path, "running", completed, total, "validating transfer cells"
+    )
+    for arm in arms:
         for seed in SEEDS:
             checkpoint = Path(plan["checkpoints"][arm][str(seed)]["torch"])
             for bot_type in BOT_TYPES:
@@ -271,12 +297,12 @@ def run_matrix(root: Path, out_dir: Path, plan: dict[str, Any]) -> None:
                     log = out_dir / f"{arm}-s{seed}-b{bot_type}-t{bot_team}.log"
                     if log.exists():
                         candidate_transfer._validate_cell(
-                            log, {**plan, "_arms": list(ARMS)},
+                            log, {**plan, "_arms": list(arms)},
                             arm, seed, bot_type, bot_team,
                         )
                     else:
                         write_status(
-                            status_path, "running", completed,
+                            status_path, "running", completed, total,
                             f"running {arm}/seed {seed}/bot {bot_type}/team {bot_team}",
                         )
                         env = {
@@ -295,11 +321,13 @@ def run_matrix(root: Path, out_dir: Path, plan: dict[str, Any]) -> None:
                             raise RunnerError(
                                 f"transfer cell exited {result.returncode}: {log}")
                         candidate_transfer._validate_cell(
-                            log, {**plan, "_arms": list(ARMS)},
+                            log, {**plan, "_arms": list(arms)},
                             arm, seed, bot_type, bot_team,
                         )
                     completed += 1
-                    write_status(status_path, "running", completed, "cell validated")
+                    write_status(
+                        status_path, "running", completed, total, "cell validated"
+                    )
 
 
 def complete_transfer(out_dir: Path) -> None:
@@ -325,6 +353,7 @@ def complete_transfer(out_dir: Path) -> None:
         atomic_json(complete_path, {**core, "completed_utc": utc_now()})
     write_status(
         out_dir / "TRANSFER_STATUS.json", "complete", len(report["runs"]),
+        len(report["runs"]),
         f"matrix complete; confirmation candidate={report['recommendation']['arm']}",
     )
 
@@ -339,6 +368,7 @@ def main(argv: list[str] | None = None) -> int:
     root = Path(__file__).resolve().parents[1]
     screen_dir = args.screen_dir.expanduser().resolve()
     out_dir = args.out_dir.expanduser().resolve()
+    arms = FULL_ARMS
     out_dir.mkdir(parents=True, exist_ok=True)
     lock_path = out_dir / ".transfer.lock"
     try:
@@ -347,7 +377,7 @@ def main(argv: list[str] | None = None) -> int:
                 fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
             except BlockingIOError as exc:
                 raise RunnerError("another transfer runner holds the lock") from exc
-            checkpoints = screen_checkpoints(
+            checkpoints, arms = screen_checkpoints(
                 screen_dir, args.expected_screen_sha.lower())
             # Share the exact one-GPU lock used by reward training. Requiring a
             # completed source screen above prevents stealing the lock during a
@@ -359,10 +389,10 @@ def main(argv: list[str] | None = None) -> int:
                 except BlockingIOError as exc:
                     raise RunnerError(
                         "training/evaluation GPU lock is already held") from exc
-                convert_checkpoints(root, out_dir, checkpoints)
+                convert_checkpoints(root, out_dir, checkpoints, arms)
                 plan = freeze_manifest(
                     out_dir / "TRANSFER_MANIFEST.json", root, screen_dir,
-                    args.expected_screen_sha.lower(), checkpoints,
+                    args.expected_screen_sha.lower(), checkpoints, arms,
                 )
                 if args.plan_only:
                     print(
@@ -381,6 +411,7 @@ def main(argv: list[str] | None = None) -> int:
             status_path,
             "failed",
             completed_from_status(status_path),
+            len(arms) * len(SEEDS) * len(BOT_TYPES) * len(BOT_TEAMS),
             str(exc),
         )
         print(f"candidate-transfer runner failed: {exc}", file=sys.stderr)

--- a/tools/run_reward_screen.sh
+++ b/tools/run_reward_screen.sh
@@ -8,6 +8,10 @@
 #   WARM=/abs/warm.bin POOL=/abs/pool STEPS=500000000 \
 #     SCREEN_PROFILE=possession-gain PREFIX=possession-gain-v2 \
 #     bash tools/run_reward_screen.sh
+# Example (longer two-arm confirmation after transfer selects a candidate):
+#   WARM=/abs/warm.bin POOL=/abs/pool STEPS=1000000000 \
+#     SCREEN_PROFILE=paired-confirmation CANDIDATE_ARM=gain_only \
+#     PREFIX=gain-confirm-v1 bash tools/run_reward_screen.sh
 set -euo pipefail
 
 if [ $# -ne 0 ]; then
@@ -20,7 +24,8 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 : "${WARM:?WARM is required}"
 : "${POOL:?POOL is required}"
 : "${STEPS:?STEPS is required (explicit experiment budget)}"
-: "${SCREEN_PROFILE:?SCREEN_PROFILE is required (distance-possession or possession-gain)}"
+: "${SCREEN_PROFILE:?SCREEN_PROFILE is required (distance-possession, possession-gain, or paired-confirmation)}"
+CANDIDATE_ARM="${CANDIDATE_ARM:-}"
 PREFIX="${PREFIX:-reward-screen-v1}"
 OUT_DIR="${OUT_DIR:-$ROOT/runs/reward-screens/$PREFIX}"
 POLL_SECONDS="${POLL_SECONDS:-30}"
@@ -67,8 +72,18 @@ case "$PLAN_ONLY" in
   *) echo "PLAN_ONLY must be 0 or 1" >&2; exit 1 ;;
 esac
 case "$SCREEN_PROFILE" in
-  distance-possession|possession-gain) ;;
-  *) echo "SCREEN_PROFILE must be distance-possession or possession-gain" >&2
+  distance-possession|possession-gain)
+    [ -z "$CANDIDATE_ARM" ] || {
+      echo "CANDIDATE_ARM is only valid with paired-confirmation" >&2; exit 1; }
+    ;;
+  paired-confirmation)
+    case "$CANDIDATE_ARM" in
+      possession_only|gain_only|neither) ;;
+      *) echo "paired-confirmation requires CANDIDATE_ARM=possession_only, gain_only, or neither" >&2
+         exit 1 ;;
+    esac
+    ;;
+  *) echo "SCREEN_PROFILE must be distance-possession, possession-gain, or paired-confirmation" >&2
      exit 1 ;;
 esac
 
@@ -97,13 +112,22 @@ PYBIN="$ROOT/vendor/PufferLib/.venv/bin/python"
 [ -x "$PYBIN" ] || { echo "vendored Python missing: $PYBIN" >&2; exit 1; }
 bash "$ROOT/tools/install_puffer_env.sh" --check "$ROOT/vendor/PufferLib"
 
-if [ "$SCREEN_PROFILE" = "distance-possession" ]; then
-  arms=(r0 r3 r1 r2 r2 r1 r3 r0)
-else
-  arms=(both neither possession_only gain_only \
-        gain_only possession_only neither both)
-fi
-seeds=(42 42 42 42 43 43 43 43)
+case "$SCREEN_PROFILE" in
+  distance-possession)
+    arms=(r0 r3 r1 r2 r2 r1 r3 r0)
+    seeds=(42 42 42 42 43 43 43 43)
+    ;;
+  possession-gain)
+    arms=(both neither possession_only gain_only \
+          gain_only possession_only neither both)
+    seeds=(42 42 42 42 43 43 43 43)
+    ;;
+  paired-confirmation)
+    arms=(both "$CANDIDATE_ARM" "$CANDIDATE_ARM" both)
+    seeds=(42 42 43 43)
+    ;;
+esac
+TOTAL_ARMS=${#arms[@]}
 SCREEN_MANIFEST="$OUT_DIR/SCREEN_MANIFEST.json"
 SCREEN_STATUS="$OUT_DIR/SCREEN_STATUS.json"
 SCREEN_COMPLETE="$OUT_DIR/SCREEN_COMPLETE.json"
@@ -130,7 +154,7 @@ freeze_screen_manifest() {
     "$MINIBATCH_SIZE" "$CHECKPOINT_STEPS" "$REPLAY_RATIO" \
     "$CLIP_COEF" "$VF_COEF" "$VF_CLIP_COEF" "$MAX_GRAD_NORM" \
     "$EXPECTED_POOL_HASH" "$MIN_TRAIN_GAMES" "$MIN_EVAL_GAMES" \
-    "$SCREEN_PROFILE" <<'PY'
+    "$SCREEN_PROFILE" "$CANDIDATE_ARM" <<'PY'
 import datetime, hashlib, json, pathlib, subprocess, sys, sysconfig
 
 (
@@ -139,7 +163,7 @@ import datetime, hashlib, json, pathlib, subprocess, sys, sysconfig
     learning_rate, ent_coef, gamma, gae_lambda, horizon, minibatch_size,
     checkpoint_steps, replay_ratio, clip_coef, vf_coef, vf_clip_coef,
     max_grad_norm, expected_pool_hash, min_train_games, min_eval_games,
-    screen_profile,
+    screen_profile, candidate_arm,
 ) = sys.argv[1:]
 root = pathlib.Path(root_path).resolve()
 vendor = root / "vendor" / "PufferLib"
@@ -231,7 +255,7 @@ if screen_profile == "distance-possession":
         "r3": root / "puffer/config/rewards/r3_minimal_block.json",
     }
     arm_order = ("r0", "r3", "r1", "r2", "r2", "r1", "r3", "r0")
-else:
+elif screen_profile == "possession-gain":
     reward_files = {
         "both": root / "puffer/config/rewards/r0_full.json",
         "possession_only": root / "puffer/config/rewards/p1_possession_only.json",
@@ -242,6 +266,26 @@ else:
         "both", "neither", "possession_only", "gain_only",
         "gain_only", "possession_only", "neither", "both",
     )
+    schedule_seeds = (42, 42, 42, 42, 43, 43, 43, 43)
+elif screen_profile == "paired-confirmation":
+    allowed = {"possession_only", "gain_only", "neither"}
+    if candidate_arm not in allowed:
+        raise SystemExit("invalid paired-confirmation candidate")
+    all_reward_files = {
+        "both": root / "puffer/config/rewards/r0_full.json",
+        "possession_only": root / "puffer/config/rewards/p1_possession_only.json",
+        "gain_only": root / "puffer/config/rewards/p2_gain_only.json",
+        "neither": root / "puffer/config/rewards/r2_no_possession.json",
+    }
+    reward_files = {
+        arm: all_reward_files[arm] for arm in ("both", candidate_arm)
+    }
+    arm_order = ("both", candidate_arm, candidate_arm, "both")
+    schedule_seeds = (42, 42, 43, 43)
+else:
+    raise SystemExit(f"unsupported screen profile: {screen_profile}")
+if screen_profile == "distance-possession":
+    schedule_seeds = (42, 42, 42, 42, 43, 43, 43, 43)
 rewards = {}
 for arm, path in reward_files.items():
     reward, digest = load_manifest(path)
@@ -299,7 +343,7 @@ historical_share = 4 * per_bank / ((total // buffers) / 2.0)
 schedule = [
     {"index": index + 1, "arm": arm, "seed": seed}
     for index, (arm, seed) in enumerate(zip(
-        arm_order, (42, 42, 42, 42, 43, 43, 43, 43)))
+        arm_order, schedule_seeds))
 ]
 launcher = root / "tools/run_reward_ablation.sh"
 screen_script = root / "tools/run_reward_screen.sh"
@@ -346,6 +390,8 @@ contract = {
         "historical_game_share": str(historical_share),
     },
 }
+if screen_profile == "paired-confirmation":
+    contract["candidate_arm"] = candidate_arm
 
 if destination.exists():
     recorded = json.loads(destination.read_text(encoding="utf-8"))
@@ -755,7 +801,7 @@ PY
     }
     echo "RECOVER completed detached arm=$arm seed=$seed"
   else
-    echo "START index=$CURRENT_INDEX/8 arm=$arm seed=$seed steps=$STEPS tag=$tag"
+    echo "START index=$CURRENT_INDEX/$TOTAL_ARMS arm=$arm seed=$seed steps=$STEPS tag=$tag"
     write_screen_status running 0 "launching arm"
     env TAG="$tag" REWARD_MANIFEST="$manifest" WARM="$WARM" POOL="$POOL" \
         STEPS="$STEPS" SEED="$seed" LOG="$log" RIG_ALLOW_FLOAT=1 \
@@ -792,7 +838,7 @@ PY
   materialize_result write "$arm" "$seed" "$tag" "$manifest" \
     "$log" "$result"
   COMPLETED_ARMS=$((COMPLETED_ARMS + 1))
-  echo "DONE index=$CURRENT_INDEX/8 arm=$arm seed=$seed result=$result"
+  echo "DONE index=$CURRENT_INDEX/$TOTAL_ARMS arm=$arm seed=$seed result=$result"
   write_screen_status running 0 "arm accepted"
 
   # Status is written immediately before wrapper exit. Require the inherited
@@ -813,7 +859,7 @@ done
 
 CURRENT_ARM=""
 CURRENT_SEED=""
-CURRENT_INDEX=8
+CURRENT_INDEX=$TOTAL_ARMS
 current_screen_sha="$(freeze_screen_manifest)"
 [ "$current_screen_sha" = "$SCREEN_MANIFEST_SHA" ] || {
   echo "screen manifest hash changed before completion" >&2; exit 1; }
@@ -867,7 +913,7 @@ else:
 print(f"SCREEN COMPLETE: {destination}")
 PY
 
-COMPLETED_ARMS=8
-write_screen_status complete 0 "all eight arms accepted and completion summary verified"
+COMPLETED_ARMS=$TOTAL_ARMS
+write_screen_status complete 0 "all $TOTAL_ARMS arms accepted and completion summary verified"
 trap - EXIT INT TERM
 echo "SCREEN COMPLETE: $OUT_DIR"

--- a/tools/run_reward_screen.sh
+++ b/tools/run_reward_screen.sh
@@ -265,6 +265,9 @@ if pool_identity != expected_pool_hash:
 
 sys.path.insert(0, str(root / "tools"))
 from reward_manifest import load_manifest
+from analyze_reward_candidate_transfer import (
+    TransferError, validate_completion_evidence,
+)
 if screen_profile == "distance-possession":
     reward_files = {
         "r0": root / "puffer/config/rewards/r0_full.json",
@@ -389,6 +392,8 @@ contract = {
     "implementation": {
         "screen_script_sha256": sha(screen_script),
         "launcher_sha256": sha(launcher),
+        "candidate_transfer_analyzer_sha256": sha(
+            root / "tools/analyze_reward_candidate_transfer.py"),
         "source_sha256": source_hash_path.read_text().strip(),
         "config_sha256": sha(config),
         "compiled_module": str(module.resolve()),
@@ -411,27 +416,17 @@ contract = {
 if screen_profile == "paired-confirmation":
     contract["candidate_arm"] = candidate_arm
     transfer_complete = pathlib.Path(transfer_complete_path).resolve()
-    if sha(transfer_complete) != expected_transfer_sha:
-        raise SystemExit("transfer completion SHA-256 does not match expectation")
-    transfer = json.loads(transfer_complete.read_text(encoding="utf-8"))
-    if transfer.get("schema_version") != 1:
-        raise SystemExit("unsupported transfer completion schema")
-    if transfer.get("recommended_confirmation_arm") != candidate_arm:
-        raise SystemExit("CANDIDATE_ARM differs from transfer recommendation")
-    analysis_path = transfer_complete.parent / "ANALYSIS.json"
-    transfer_manifest_path = transfer_complete.parent / "TRANSFER_MANIFEST.json"
-    if sha(analysis_path) != transfer.get("analysis_sha256"):
-        raise SystemExit("transfer analysis hash chain is invalid")
-    if sha(transfer_manifest_path) != transfer.get("transfer_manifest_sha256"):
-        raise SystemExit("transfer manifest hash chain is invalid")
-    contract["candidate_evidence"] = {
-        "transfer_complete": str(transfer_complete),
-        "transfer_complete_sha256": expected_transfer_sha,
-        "analysis": str(analysis_path.resolve()),
-        "analysis_sha256": transfer["analysis_sha256"],
-        "transfer_manifest": str(transfer_manifest_path.resolve()),
-        "transfer_manifest_sha256": transfer["transfer_manifest_sha256"],
-    }
+    # The shared validator binds recommended_confirmation_arm, analysis
+    # recommendation, transfer_manifest_sha256, analysis_sha256, and the exact
+    # evaluated cell hashes.
+    try:
+        contract["candidate_evidence"] = validate_completion_evidence(
+            transfer_complete,
+            expected_complete_sha=expected_transfer_sha,
+            expected_candidate=candidate_arm,
+        )
+    except (OSError, TransferError, ValueError) as exc:
+        raise SystemExit(f"invalid candidate transfer evidence: {exc}") from exc
 
 if destination.exists():
     recorded = json.loads(destination.read_text(encoding="utf-8"))

--- a/tools/run_reward_screen.sh
+++ b/tools/run_reward_screen.sh
@@ -11,6 +11,8 @@
 # Example (longer two-arm confirmation after transfer selects a candidate):
 #   WARM=/abs/warm.bin POOL=/abs/pool STEPS=1000000000 \
 #     SCREEN_PROFILE=paired-confirmation CANDIDATE_ARM=gain_only \
+#     TRANSFER_COMPLETE=/abs/TRANSFER_COMPLETE.json \
+#     EXPECTED_TRANSFER_SHA256=<sha256> \
 #     PREFIX=gain-confirm-v1 bash tools/run_reward_screen.sh
 set -euo pipefail
 
@@ -26,6 +28,8 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 : "${STEPS:?STEPS is required (explicit experiment budget)}"
 : "${SCREEN_PROFILE:?SCREEN_PROFILE is required (distance-possession, possession-gain, or paired-confirmation)}"
 CANDIDATE_ARM="${CANDIDATE_ARM:-}"
+TRANSFER_COMPLETE="${TRANSFER_COMPLETE:-}"
+EXPECTED_TRANSFER_SHA256="${EXPECTED_TRANSFER_SHA256:-}"
 PREFIX="${PREFIX:-reward-screen-v1}"
 OUT_DIR="${OUT_DIR:-$ROOT/runs/reward-screens/$PREFIX}"
 POLL_SECONDS="${POLL_SECONDS:-30}"
@@ -73,8 +77,9 @@ case "$PLAN_ONLY" in
 esac
 case "$SCREEN_PROFILE" in
   distance-possession|possession-gain)
-    [ -z "$CANDIDATE_ARM" ] || {
-      echo "CANDIDATE_ARM is only valid with paired-confirmation" >&2; exit 1; }
+    [ -z "$CANDIDATE_ARM$TRANSFER_COMPLETE$EXPECTED_TRANSFER_SHA256" ] || {
+      echo "candidate transfer inputs are only valid with paired-confirmation" >&2
+      exit 1; }
     ;;
   paired-confirmation)
     case "$CANDIDATE_ARM" in
@@ -82,6 +87,12 @@ case "$SCREEN_PROFILE" in
       *) echo "paired-confirmation requires CANDIDATE_ARM=possession_only, gain_only, or neither" >&2
          exit 1 ;;
     esac
+    [ -n "$TRANSFER_COMPLETE" ] || {
+      echo "paired-confirmation requires TRANSFER_COMPLETE" >&2; exit 1; }
+    if ! [[ "$EXPECTED_TRANSFER_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+      echo "paired-confirmation requires a lowercase 64-character EXPECTED_TRANSFER_SHA256" >&2
+      exit 1
+    fi
     ;;
   *) echo "SCREEN_PROFILE must be distance-possession, possession-gain, or paired-confirmation" >&2
      exit 1 ;;
@@ -96,6 +107,11 @@ abspath() {
 WARM="$(abspath "$WARM")"
 POOL="$(abspath "$POOL")"
 OUT_DIR="$(abspath "$OUT_DIR")"
+if [ -n "$TRANSFER_COMPLETE" ]; then
+  TRANSFER_COMPLETE="$(abspath "$TRANSFER_COMPLETE")"
+  [ -f "$TRANSFER_COMPLETE" ] || {
+    echo "missing transfer completion: $TRANSFER_COMPLETE" >&2; exit 1; }
+fi
 [ -f "$WARM" ] || { echo "missing warm checkpoint: $WARM" >&2; exit 1; }
 [ -d "$POOL" ] || { echo "missing static pool: $POOL" >&2; exit 1; }
 mkdir -p "$OUT_DIR"
@@ -154,7 +170,8 @@ freeze_screen_manifest() {
     "$MINIBATCH_SIZE" "$CHECKPOINT_STEPS" "$REPLAY_RATIO" \
     "$CLIP_COEF" "$VF_COEF" "$VF_CLIP_COEF" "$MAX_GRAD_NORM" \
     "$EXPECTED_POOL_HASH" "$MIN_TRAIN_GAMES" "$MIN_EVAL_GAMES" \
-    "$SCREEN_PROFILE" "$CANDIDATE_ARM" <<'PY'
+    "$SCREEN_PROFILE" "$CANDIDATE_ARM" "$TRANSFER_COMPLETE" \
+    "$EXPECTED_TRANSFER_SHA256" <<'PY'
 import datetime, hashlib, json, pathlib, subprocess, sys, sysconfig
 
 (
@@ -163,7 +180,8 @@ import datetime, hashlib, json, pathlib, subprocess, sys, sysconfig
     learning_rate, ent_coef, gamma, gae_lambda, horizon, minibatch_size,
     checkpoint_steps, replay_ratio, clip_coef, vf_coef, vf_clip_coef,
     max_grad_norm, expected_pool_hash, min_train_games, min_eval_games,
-    screen_profile, candidate_arm,
+    screen_profile, candidate_arm, transfer_complete_path,
+    expected_transfer_sha,
 ) = sys.argv[1:]
 root = pathlib.Path(root_path).resolve()
 vendor = root / "vendor" / "PufferLib"
@@ -392,6 +410,28 @@ contract = {
 }
 if screen_profile == "paired-confirmation":
     contract["candidate_arm"] = candidate_arm
+    transfer_complete = pathlib.Path(transfer_complete_path).resolve()
+    if sha(transfer_complete) != expected_transfer_sha:
+        raise SystemExit("transfer completion SHA-256 does not match expectation")
+    transfer = json.loads(transfer_complete.read_text(encoding="utf-8"))
+    if transfer.get("schema_version") != 1:
+        raise SystemExit("unsupported transfer completion schema")
+    if transfer.get("recommended_confirmation_arm") != candidate_arm:
+        raise SystemExit("CANDIDATE_ARM differs from transfer recommendation")
+    analysis_path = transfer_complete.parent / "ANALYSIS.json"
+    transfer_manifest_path = transfer_complete.parent / "TRANSFER_MANIFEST.json"
+    if sha(analysis_path) != transfer.get("analysis_sha256"):
+        raise SystemExit("transfer analysis hash chain is invalid")
+    if sha(transfer_manifest_path) != transfer.get("transfer_manifest_sha256"):
+        raise SystemExit("transfer manifest hash chain is invalid")
+    contract["candidate_evidence"] = {
+        "transfer_complete": str(transfer_complete),
+        "transfer_complete_sha256": expected_transfer_sha,
+        "analysis": str(analysis_path.resolve()),
+        "analysis_sha256": transfer["analysis_sha256"],
+        "transfer_manifest": str(transfer_manifest_path.resolve()),
+        "transfer_manifest_sha256": transfer["transfer_manifest_sha256"],
+    }
 
 if destination.exists():
     recorded = json.loads(destination.read_text(encoding="utf-8"))

--- a/tools/test_analyze_reward_candidate_transfer.py
+++ b/tools/test_analyze_reward_candidate_transfer.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import analyze_reward_candidate_transfer as transfer
+
+
+def digest(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+class RewardCandidateTransferTests(unittest.TestCase):
+    def write_manifest(self, root: Path) -> dict:
+        arms = ("both", "possession_only", "gain_only", "neither")
+        manifest = {
+            "schema_version": 1,
+            "matrix_id": "candidate-transfer-test",
+            "reference_arm": "both",
+            "candidate_arms": list(arms[1:]),
+            "preference_order": ["neither", "possession_only", "gain_only"],
+            "seeds": [42, 43],
+            "bot_types": [0, 1],
+            "bot_teams": [0, 1],
+            "settings": {
+                "requested_train_steps": 131072,
+                "eval_episodes": 1000,
+                "min_eval_games": 1000,
+            },
+            "implementation": {
+                "config_sha256": digest("config"),
+                "compiled_module_sha256": digest("module"),
+                "pufferl_sha256": digest("pufferl"),
+                "launcher_sha256": digest("launcher"),
+            },
+            "checkpoints": {
+                arm: {
+                    str(seed): {"torch_sha256": digest(f"{arm}-{seed}")}
+                    for seed in (42, 43)
+                }
+                for arm in arms
+            },
+            "gates": {
+                "mean_score_delta_min": -0.02,
+                "cell_score_delta_min": -0.05,
+                "max_champion_td_relative_drop": 0.20,
+                "max_bot_td_relative_rise": 0.20,
+            },
+        }
+        (root / "TRANSFER_MANIFEST.json").write_text(
+            json.dumps(manifest), encoding="utf-8")
+        return manifest
+
+    def write_cell(
+        self, root: Path, manifest: dict, arm: str, seed: int,
+        bot_type: int, bot_team: int,
+    ) -> None:
+        scores = {
+            "both": 0.50,
+            "possession_only": 0.49,
+            "gain_only": 0.52,
+            "neither": 0.44,
+        }
+        champion_tds = {
+            "both": 1.0, "possession_only": 0.95,
+            "gain_only": 1.05, "neither": 0.70,
+        }
+        bot_tds = {
+            "both": 0.8, "possession_only": 0.82,
+            "gain_only": 0.75, "neither": 1.1,
+        }
+        champion_team = 1 - bot_team
+        score = scores[arm]
+        settings = manifest["settings"]
+        implementation = manifest["implementation"]
+        eval_manifest = {
+            "schema_version": 1,
+            "mode": "scripted_bot_frozen",
+            "checkpoint_sha256": manifest["checkpoints"][arm][str(seed)][
+                "torch_sha256"],
+            "requested_train_steps": settings["requested_train_steps"],
+            "seed": seed,
+            **implementation,
+            "bot_type": bot_type,
+            "bot_team": bot_team,
+            "eval_episodes": settings["eval_episodes"],
+            "min_eval_games": settings["min_eval_games"],
+            "command": [
+                "puffer", "train", "bloodbowl",
+                "--train.total-timesteps",
+                str(settings["requested_train_steps"]),
+                "--eval-episodes", str(settings["eval_episodes"]),
+                "--seed", str(seed), "--train.seed", str(seed),
+                "--env.seed", str(seed),
+                "--env.scripted-opponent-type", str(bot_type),
+                "--env.scripted-opponent-team", str(bot_team),
+            ],
+        }
+        panel = {
+            "_puffer_schema": 2,
+            "_puffer_phase_eval": 1,
+            "_puffer_env_cumulative": 0,
+            "_puffer_final_reprint": 0,
+            "_puffer_eval_episodes_completed": settings["eval_episodes"],
+            "n": settings["eval_episodes"],
+            "slot_0_score": score if champion_team == 0 else 1 - score,
+            "slot_1_score": score if champion_team == 1 else 1 - score,
+            "draw_rate": 0.4,
+            "tds_t0": (champion_tds[arm] if champion_team == 0
+                       else bot_tds[arm]),
+            "tds_t1": (champion_tds[arm] if champion_team == 1
+                       else bot_tds[arm]),
+            "blocks_thrown_t0": 8.0 if champion_team == 0 else 10.0,
+            "blocks_thrown_t1": 8.0 if champion_team == 1 else 10.0,
+            "reward_clip_episodes": 0,
+            "reward_nonfinite_episodes": 0,
+            "error_episodes": 0,
+            "demo_episodes": 0,
+            "demo_fallbacks": 0,
+        }
+        final = dict(panel, _puffer_final_reprint=1)
+        path = root / f"{arm}-s{seed}-b{bot_type}-t{bot_team}.log"
+        path.write_text(
+            transfer.MANIFEST_PREFIX + json.dumps(eval_manifest) + "\n"
+            "PufferLib 4.0\nPUFFER_ENV_JSON " + json.dumps(panel) + "\n"
+            "PufferLib 4.0\nPUFFER_ENV_JSON " + json.dumps(final) + "\n",
+            encoding="utf-8",
+        )
+
+    def build_matrix(self, root: Path) -> dict:
+        manifest = self.write_manifest(root)
+        arms = [manifest["reference_arm"], *manifest["candidate_arms"]]
+        for arm in arms:
+            for seed in manifest["seeds"]:
+                for bot_type in manifest["bot_types"]:
+                    for bot_team in manifest["bot_teams"]:
+                        self.write_cell(
+                            root, manifest, arm, seed, bot_type, bot_team)
+        return manifest
+
+    def test_dynamic_matrix_and_fail_closed_recommendation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.build_matrix(root)
+            report = transfer.analyze(root)
+
+        self.assertEqual(report["cell_count"], 32)
+        self.assertEqual(report["total_games"], 32_000)
+        self.assertEqual(report["recommendation"]["arm"], "possession_only")
+        self.assertEqual(
+            report["candidate_contrasts"]["gain_only"]["eligible"], True)
+        self.assertEqual(
+            report["candidate_contrasts"]["possession_only"]["eligible"], True)
+        self.assertEqual(
+            report["candidate_contrasts"]["neither"]["eligible"], False)
+
+    def test_manifest_or_cell_drift_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            manifest = self.build_matrix(root)
+            path = root / "gain_only-s42-b0-t0.log"
+            text = path.read_text().replace(
+                manifest["implementation"]["config_sha256"], digest("drift"), 1)
+            path.write_text(text)
+            with self.assertRaisesRegex(transfer.TransferError, "config_sha256"):
+                transfer.analyze(root)
+
+    def test_missing_cell_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.build_matrix(root)
+            (root / "neither-s43-b1-t1.log").unlink()
+            with self.assertRaisesRegex(transfer.TransferError, "missing transfer"):
+                transfer.analyze(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_analyze_reward_candidate_transfer.py
+++ b/tools/test_analyze_reward_candidate_transfer.py
@@ -16,6 +16,8 @@ def digest(label: str) -> str:
 class RewardCandidateTransferTests(unittest.TestCase):
     def write_manifest(self, root: Path) -> dict:
         arms = ("both", "possession_only", "gain_only", "neither")
+        orchestration = root / "orchestration.py"
+        orchestration.write_text("# frozen\n")
         manifest = {
             "schema_version": 1,
             "matrix_id": "candidate-transfer-test",
@@ -35,6 +37,9 @@ class RewardCandidateTransferTests(unittest.TestCase):
                 "compiled_module_sha256": digest("module"),
                 "pufferl_sha256": digest("pufferl"),
                 "launcher_sha256": digest("launcher"),
+            },
+            "orchestration_files": {
+                str(orchestration): digest("# frozen\n"),
             },
             "checkpoints": {
                 arm: {
@@ -116,7 +121,11 @@ class RewardCandidateTransferTests(unittest.TestCase):
             "blocks_thrown_t0": 8.0 if champion_team == 0 else 10.0,
             "blocks_thrown_t1": 8.0 if champion_team == 1 else 10.0,
             "reward_clip_episodes": 0,
+            "reward_clip_frac": 0,
+            "reward_clip_frac_nonzero": 0,
+            "reward_clip_excess": 0,
             "reward_nonfinite_episodes": 0,
+            "reward_nonfinite_frac": 0,
             "error_episodes": 0,
             "demo_episodes": 0,
             "demo_fallbacks": 0,
@@ -174,6 +183,20 @@ class RewardCandidateTransferTests(unittest.TestCase):
             self.build_matrix(root)
             (root / "neither-s43-b1-t1.log").unlink()
             with self.assertRaisesRegex(transfer.TransferError, "missing transfer"):
+                transfer.analyze(root)
+
+    def test_missing_integrity_counter_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.build_matrix(root)
+            path = root / "both-s42-b0-t0.log"
+            text = path.read_text().replace(
+                '"reward_clip_excess": 0, ', "", 2
+            )
+            path.write_text(text)
+            with self.assertRaisesRegex(
+                transfer.TransferError, "missing integrity counters"
+            ):
                 transfer.analyze(root)
 
 

--- a/tools/test_analyze_reward_candidate_transfer.py
+++ b/tools/test_analyze_reward_candidate_transfer.py
@@ -14,6 +14,26 @@ def digest(label: str) -> str:
 
 
 class RewardCandidateTransferTests(unittest.TestCase):
+    @staticmethod
+    def write_completion(root: Path, report: dict) -> Path:
+        analysis = root / "ANALYSIS.json"
+        analysis.write_text(
+            json.dumps(report, sort_keys=True, allow_nan=False) + "\n",
+            encoding="utf-8",
+        )
+        complete = root / "TRANSFER_COMPLETE.json"
+        complete.write_text(json.dumps({
+            "schema_version": 1,
+            "recommended_confirmation_arm": report["recommendation"]["arm"],
+            "analysis_sha256": hashlib.sha256(analysis.read_bytes()).hexdigest(),
+            "transfer_manifest_sha256": report["transfer_manifest"]["sha256"],
+            "cells": [
+                {"log": row["log"], "sha256": row["log_sha256"]}
+                for row in report["runs"]
+            ],
+        }, sort_keys=True) + "\n", encoding="utf-8")
+        return complete
+
     def write_manifest(self, root: Path) -> dict:
         arms = ("both", "possession_only", "gain_only", "neither")
         orchestration = root / "orchestration.py"
@@ -165,6 +185,50 @@ class RewardCandidateTransferTests(unittest.TestCase):
             report["candidate_contrasts"]["possession_only"]["eligible"], True)
         self.assertEqual(
             report["candidate_contrasts"]["neither"]["eligible"], False)
+
+    def test_transfer_manifest_identity_is_not_shadowed_by_orchestration(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.build_matrix(root)
+            report = transfer.analyze(root)
+            manifest = root / "TRANSFER_MANIFEST.json"
+
+            self.assertEqual(
+                report["transfer_manifest"]["path"], str(manifest.resolve()))
+            self.assertEqual(
+                report["transfer_manifest"]["sha256"],
+                hashlib.sha256(manifest.read_bytes()).hexdigest(),
+            )
+
+    def test_completion_evidence_requires_semantic_agreement(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.build_matrix(root)
+            report = transfer.analyze(root)
+            complete = self.write_completion(root, report)
+            expected = hashlib.sha256(complete.read_bytes()).hexdigest()
+            evidence = transfer.validate_completion_evidence(
+                complete, expected_complete_sha=expected,
+                expected_candidate="possession_only",
+            )
+            self.assertEqual(evidence["transfer_complete_sha256"], expected)
+
+            report["recommendation"]["arm"] = "gain_only"
+            analysis = root / "ANALYSIS.json"
+            analysis.write_text(
+                json.dumps(report, sort_keys=True) + "\n", encoding="utf-8")
+            payload = json.loads(complete.read_text())
+            payload["analysis_sha256"] = hashlib.sha256(
+                analysis.read_bytes()).hexdigest()
+            complete.write_text(json.dumps(payload, sort_keys=True) + "\n")
+            expected = hashlib.sha256(complete.read_bytes()).hexdigest()
+            with self.assertRaisesRegex(
+                transfer.TransferError, "analysis recommendation differs"
+            ):
+                transfer.validate_completion_evidence(
+                    complete, expected_complete_sha=expected,
+                    expected_candidate="possession_only",
+                )
 
     def test_manifest_or_cell_drift_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/test_analyze_reward_candidate_transfer.py
+++ b/tools/test_analyze_reward_candidate_transfer.py
@@ -223,7 +223,44 @@ class RewardCandidateTransferTests(unittest.TestCase):
             complete.write_text(json.dumps(payload, sort_keys=True) + "\n")
             expected = hashlib.sha256(complete.read_bytes()).hexdigest()
             with self.assertRaisesRegex(
-                transfer.TransferError, "analysis recommendation differs"
+                transfer.TransferError, "differs from regenerated"
+            ):
+                transfer.validate_completion_evidence(
+                    complete, expected_complete_sha=expected,
+                    expected_candidate="possession_only",
+                )
+
+    def test_self_consistent_forged_analysis_cannot_replace_cell_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.build_matrix(root)
+            report = transfer.analyze(root)
+            report["runs"] = []
+            report["cell_count"] = 0
+            report["total_games"] = 0
+            complete = self.write_completion(root, report)
+            expected = hashlib.sha256(complete.read_bytes()).hexdigest()
+
+            with self.assertRaisesRegex(
+                transfer.TransferError, "differs from regenerated"
+            ):
+                transfer.validate_completion_evidence(
+                    complete, expected_complete_sha=expected,
+                    expected_candidate="possession_only",
+                )
+
+    def test_completion_evidence_rehashes_live_cell_logs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.build_matrix(root)
+            report = transfer.analyze(root)
+            complete = self.write_completion(root, report)
+            expected = hashlib.sha256(complete.read_bytes()).hexdigest()
+            cell = root / report["runs"][0]["log"]
+            cell.write_text(cell.read_text() + "tampered\n")
+
+            with self.assertRaisesRegex(
+                transfer.TransferError, "differs from regenerated"
             ):
                 transfer.validate_completion_evidence(
                     complete, expected_complete_sha=expected,

--- a/tools/test_analyze_reward_screen.py
+++ b/tools/test_analyze_reward_screen.py
@@ -206,6 +206,79 @@ class RewardScreenAnalysisTests(unittest.TestCase):
             "interaction": 3.0,
         })
 
+    def test_paired_confirmation_profile_computes_candidate_contrast(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            prefix = "paired-confirmation-test"
+            candidate = "gain_only"
+            schedule_pairs = (
+                ("both", 42), (candidate, 42),
+                (candidate, 43), ("both", 43),
+            )
+            schedule = [
+                {"index": index, "arm": arm, "seed": seed}
+                for index, (arm, seed) in enumerate(schedule_pairs, 1)
+            ]
+            rewards = {
+                arm: {
+                    "reward_sha256":
+                        analyze_reward_screen.POSSESSION_GAIN_REWARD_SHA256[arm]
+                }
+                for arm in ("both", candidate)
+            }
+            manifest = {
+                "schema_version": 1,
+                "contract": {
+                    "prefix": prefix,
+                    "screen_profile": "paired-confirmation",
+                    "candidate_arm": candidate,
+                    "requested_steps": 1_000_000_000,
+                    "final_steps": 999_948_288,
+                    "schedule": schedule,
+                    "settings": {"expected_checkpoint_bytes": "16"},
+                    "rewards": rewards,
+                },
+            }
+            manifest_path = root / "SCREEN_MANIFEST.json"
+            write_json(manifest_path, manifest)
+            manifest_sha = sha256(manifest_path)
+            values = {
+                ("both", 42): 18.0, (candidate, 42): 17.0,
+                ("both", 43): 20.0, (candidate, 43): 21.0,
+            }
+            for arm, seed in schedule_pairs:
+                write_json(root / f"{prefix}-{arm}-s{seed}.result.json", {
+                    "schema_version": 2,
+                    "trainer_complete": True,
+                    "acceptance_pass": True,
+                    "acceptance_failures": [],
+                    "arm": arm,
+                    "seed": seed,
+                    "tag": f"{prefix}-{arm}-s{seed}",
+                    "screen_manifest_sha256": manifest_sha,
+                    "reward_sha256": rewards[arm]["reward_sha256"],
+                    "checkpoint_bytes": 16,
+                    "checkpoint_sha256": digest(f"checkpoint-{arm}-{seed}"),
+                    "log_sha256": digest(f"log-{arm}-{seed}"),
+                    "status_sha256": digest(f"status-{arm}-{seed}"),
+                    "process_sha256": digest(f"process-{arm}-{seed}"),
+                    "run_manifest_sha256": digest(f"manifest-{arm}-{seed}"),
+                    "eval_metrics": {"n": 10_001, "tds": values[(arm, seed)]},
+                })
+
+            report = analyze_reward_screen.analyze_screen(root, ("tds",))
+
+        self.assertEqual(report["screen"]["profile"], "paired-confirmation")
+        self.assertEqual(report["screen"]["candidate_arm"], candidate)
+        self.assertEqual(report["per_seed"]["42"]["effects"]["tds"], {
+            "candidate_minus_both": -1.0,
+        })
+        self.assertEqual(
+            report["across_seeds"]["effects"]["tds"]
+            ["candidate_minus_both"]["mean"],
+            0.0,
+        )
+
     def test_tampered_result_hash_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:
             self.build_screen(tmp)

--- a/tools/test_experiment_contracts.py
+++ b/tools/test_experiment_contracts.py
@@ -168,6 +168,27 @@ class ExperimentContractTests(unittest.TestCase):
         self.assertTrue(possession.is_file())
         self.assertTrue(gain.is_file())
 
+    def test_paired_confirmation_requires_an_explicit_candidate(self):
+        result = run_script(
+            "tools/run_reward_screen.sh",
+            env={
+                "WARM": "missing.bin",
+                "POOL": "missing-pool",
+                "STEPS": "1000000000",
+                "SCREEN_PROFILE": "paired-confirmation",
+            },
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("CANDIDATE_ARM", result.stderr)
+        self.assertNotIn("missing warm checkpoint", result.stderr)
+
+        source = (ROOT / "tools/run_reward_screen.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("paired-confirmation", source)
+        self.assertIn("TOTAL_ARMS", source)
+        self.assertNotIn("index=$CURRENT_INDEX/8", source)
+
     @unittest.skipUnless(VENDOR_CHECKOUT, "vendored Puffer checkout unavailable")
     def test_puffer_machine_log_uses_explicit_loop_phase_and_fresh_panels(self):
         source = PUFFERL_SOURCE.read_text(encoding="utf-8")

--- a/tools/test_experiment_contracts.py
+++ b/tools/test_experiment_contracts.py
@@ -186,6 +186,48 @@ class ExperimentContractTests(unittest.TestCase):
         self.assertIn("from pufferlib import _C; print(_C.__file__)", source)
         self.assertNotIn("find pufferlib -maxdepth 1 -name '_C*.so'", source)
 
+    def test_candidate_transfer_is_a_frozen_both_sides_matrix(self):
+        runner = (ROOT / "tools/run_reward_candidate_transfer.py").read_text(
+            encoding="utf-8"
+        )
+        analyzer = (
+            ROOT / "tools/analyze_reward_candidate_transfer.py"
+        ).read_text(encoding="utf-8")
+        for contract in (
+            "TRANSFER_MANIFEST.json",
+            "TRANSFER_COMPLETE.json",
+            "EXPECTED_NATIVE_BYTES",
+            "BOT_TYPES = (0, 1)",
+            "BOT_TEAMS = (0, 1)",
+            "expected_screen_sha",
+            "screen_checkpoints",
+            "conversion_metadata_sha256",
+        ):
+            self.assertIn(contract, runner)
+        for gate in (
+            "mean_score_delta_min",
+            "cell_score_delta_min",
+            "max_champion_td_relative_drop",
+            "max_bot_td_relative_rise",
+        ):
+            self.assertIn(gate, runner)
+            self.assertIn(gate, analyzer)
+
+    def test_vacation_queue_is_hash_pinned_and_fail_closed(self):
+        source = (ROOT / "tools/experiment_queue.py").read_text(
+            encoding="utf-8"
+        )
+        for contract in (
+            "plan_sha256",
+            "resume_safe",
+            "max_runtime_seconds",
+            "max_gpu_temperature_c",
+            "min_free_bytes",
+            "success validation failed",
+            "later jobs were not run",
+        ):
+            self.assertIn(contract, source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_experiment_contracts.py
+++ b/tools/test_experiment_contracts.py
@@ -189,6 +189,28 @@ class ExperimentContractTests(unittest.TestCase):
         self.assertIn("TOTAL_ARMS", source)
         self.assertNotIn("index=$CURRENT_INDEX/8", source)
 
+        result = run_script(
+            "tools/run_reward_screen.sh",
+            env={
+                "WARM": "missing.bin",
+                "POOL": "missing-pool",
+                "STEPS": "1000000000",
+                "SCREEN_PROFILE": "paired-confirmation",
+                "CANDIDATE_ARM": "gain_only",
+            },
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("TRANSFER_COMPLETE", result.stderr)
+        self.assertNotIn("missing warm checkpoint", result.stderr)
+        for contract in (
+            "EXPECTED_TRANSFER_SHA256",
+            "recommended_confirmation_arm",
+            "candidate_evidence",
+            "transfer_manifest_sha256",
+            "analysis_sha256",
+        ):
+            self.assertIn(contract, source)
+
     @unittest.skipUnless(VENDOR_CHECKOUT, "vendored Puffer checkout unavailable")
     def test_puffer_machine_log_uses_explicit_loop_phase_and_fresh_panels(self):
         source = PUFFERL_SOURCE.read_text(encoding="utf-8")

--- a/tools/test_experiment_queue.py
+++ b/tools/test_experiment_queue.py
@@ -21,27 +21,24 @@ class ExperimentQueueTests(unittest.TestCase):
     def tearDown(self):
         self.gpu_patch.stop()
 
-    @staticmethod
-    def typed(arguments: list[str], mutable: set[str]) -> list[dict[str, str]]:
-        executable = str(Path(sys.executable).resolve())
-        rendered = []
-        for value in arguments:
-            if str(Path(value).resolve()) == executable:
-                rendered.append({"kind": "pinned", "path": executable})
-            elif value in mutable:
-                rendered.append({"kind": "mutable", "path": value})
-            else:
-                rendered.append({"kind": "literal", "value": value})
-        return rendered
-
     def make_plan(self, root: Path, jobs: list[dict], **overrides) -> Path:
-        validator_body = (
-            "import pathlib,sys; "
-            "raise SystemExit(0 if pathlib.Path(sys.argv[1]).is_file() else 1)"
+        executable = Path(sys.executable).resolve()
+        validator_script = root / "validate_success.py"
+        validator_script.write_text(
+            "import pathlib,sys\n"
+            "raise SystemExit(0 if pathlib.Path(sys.argv[1]).is_file() else 1)\n"
         )
+        pinned_paths = {str(executable), str(validator_script.resolve())}
+        producer_by_path: dict[str, str] = {}
         for job in jobs:
+            command = job["command"]
+            if command[:2] == [sys.executable, "-c"]:
+                script = root / f"{job['id']}_command.py"
+                script.write_text(command[2] + "\n")
+                job["command"] = [sys.executable, str(script), *command[3:]]
+                pinned_paths.add(str(script.resolve()))
             job.setdefault("resume_safe", False)
-            job.setdefault("pinned_inputs", [str(Path(sys.executable).resolve())])
+            job.setdefault("pinned_inputs", [])
             job.setdefault("max_runtime_seconds", 5)
             if "progress" not in job:
                 job.setdefault(
@@ -51,8 +48,7 @@ class ExperimentQueueTests(unittest.TestCase):
                 "validator",
                 [
                     sys.executable,
-                    "-c",
-                    validator_body,
+                    str(validator_script),
                     job["success"]["path"],
                 ],
             )
@@ -63,16 +59,37 @@ class ExperimentQueueTests(unittest.TestCase):
             }
             if "progress" in job:
                 mutable.add(job["progress"]["path"])
-            job["command"] = self.typed(job["command"], mutable)
-            job["success"]["validator"] = self.typed(
-                job["success"]["validator"], mutable)
+
+            def typed(arguments: list[str]) -> list[dict[str, str]]:
+                rendered = []
+                for value in arguments:
+                    resolved = str(Path(value).resolve())
+                    if resolved in pinned_paths:
+                        rendered.append({"kind": "pinned", "path": resolved})
+                        if resolved not in job["pinned_inputs"]:
+                            job["pinned_inputs"].append(resolved)
+                    elif value in mutable:
+                        rendered.append({"kind": "mutable", "path": value})
+                    elif resolved in producer_by_path:
+                        rendered.append({
+                            "kind": "artifact",
+                            "job": producer_by_path[resolved],
+                            "path": resolved,
+                        })
+                    else:
+                        rendered.append({"kind": "literal", "value": value})
+                return rendered
+
+            job["command"] = typed(job["command"])
+            job["success"]["validator"] = typed(
+                job["success"]["validator"])
             job["env"] = {
-                key: ({"kind": "mutable", "path": value}
-                      if value in mutable
-                      else {"kind": "literal", "value": value})
+                key: typed([value])[0]
                 for key, value in job.get("env", {}).items()
             }
-        executable = Path(sys.executable).resolve()
+            producer_by_path[
+                str(Path(job["success"]["path"]).resolve())
+            ] = job["id"]
         payload = {
             "schema_version": 1,
             "queue_id": "test-queue",
@@ -86,13 +103,16 @@ class ExperimentQueueTests(unittest.TestCase):
                 for key in ("HOME", "PATH")
                 if key in os.environ
             },
-            "pinned_files": [{
-                "kind": "file",
-                "path": str(executable),
-                "bytes": executable.stat().st_size,
-                "sha256": hashlib.sha256(executable.read_bytes()).hexdigest(),
-                "role": "test Python executable",
-            }],
+            "pinned_files": [
+                {
+                    "kind": "file", "path": value,
+                    "bytes": Path(value).stat().st_size,
+                    "sha256": hashlib.sha256(Path(value).read_bytes()).hexdigest(),
+                    "role": "test Python executable" if Path(value) == executable
+                    else "pinned test runner",
+                }
+                for value in sorted(pinned_paths)
+            ],
             "jobs": jobs,
             **overrides,
         }
@@ -122,9 +142,10 @@ class ExperimentQueueTests(unittest.TestCase):
             second = self.write_job(
                 root, "second",
                 "import pathlib,sys; "
-                "assert pathlib.Path('first.done').read_text() == 'one'; "
+                "assert pathlib.Path(sys.argv[2]).read_text() == 'one'; "
                 "pathlib.Path(sys.argv[1]).write_text('two')",
             )
+            second["command"].append(first["success"]["path"])
             plan = self.make_plan(root, [first, second])
             state = root / "state.json"
 
@@ -313,6 +334,46 @@ class ExperimentQueueTests(unittest.TestCase):
             self.assertIn("evidence drifted", observed["message"])
             self.assertFalse(marker.exists())
 
+    def test_completed_queue_revalidates_artifacts_on_restart(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root, "complete-restart",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).write_text('ok')",
+            )
+            plan = self.make_plan(root, [job])
+            state = root / "state.json"
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            self.assertEqual(json.loads(state.read_text())["state"], "complete")
+            Path(job["success"]["path"]).unlink()
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            observed = json.loads(state.read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("evidence drifted", observed["message"])
+
+    def test_consumer_cannot_mutate_a_predecessor_artifact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            producer = self.write_job(
+                root, "producer",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).write_text('A')",
+            )
+            consumer = self.write_job(
+                root, "consumer",
+                "import pathlib,sys; source=pathlib.Path(sys.argv[2]); "
+                "value=source.read_text(); source.write_text('B'); "
+                "pathlib.Path(sys.argv[1]).write_text('used-'+value)",
+            )
+            consumer["command"].append(producer["success"]["path"])
+            plan = self.make_plan(root, [producer, consumer])
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            observed = json.loads(state.read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("producer success artifact drifted", observed["message"])
+
     def test_hanging_validator_is_bounded(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -323,10 +384,18 @@ class ExperimentQueueTests(unittest.TestCase):
             )
             plan = self.make_plan(root, [job])
             payload = json.loads(plan.read_text())
+            hanging = root / "hanging_validator.py"
+            hanging.write_text("import time\ntime.sleep(60)\n")
+            payload["pinned_files"].append({
+                "kind": "file", "path": str(hanging),
+                "bytes": hanging.stat().st_size,
+                "sha256": hashlib.sha256(hanging.read_bytes()).hexdigest(),
+                "role": "hanging test validator",
+            })
+            payload["jobs"][0]["pinned_inputs"].append(str(hanging))
             payload["jobs"][0]["success"]["validator"] = [
                 {"kind": "pinned", "path": str(Path(sys.executable).resolve())},
-                {"kind": "literal", "value": "-c"},
-                {"kind": "literal", "value": "import time; time.sleep(60)"},
+                {"kind": "pinned", "path": str(hanging)},
             ]
             payload["jobs"][0]["success"]["validator_timeout_seconds"] = 0.02
             plan.write_text(json.dumps(payload))
@@ -429,6 +498,27 @@ class ExperimentQueueTests(unittest.TestCase):
             }
             plan.write_text(json.dumps(payload))
             with self.assertRaisesRegex(queue.QueueError, "path-bearing"):
+                queue.validate_plan(plan)
+
+            for value in ("pool", "input.ini", ".", "..", "-c", "-m"):
+                (root / "pool").mkdir(exist_ok=True)
+                (root / "input.ini").touch(exist_ok=True)
+                payload["jobs"][0]["env"] = {
+                    "POOL": {"kind": "literal", "value": value}
+                }
+                plan.write_text(json.dumps(payload))
+                with self.subTest(value=value):
+                    with self.assertRaisesRegex(queue.QueueError, "path-bearing"):
+                        queue.validate_plan(plan)
+
+            payload["jobs"][0]["env"] = {}
+            payload["jobs"][0]["command"][1] = {
+                "kind": "literal", "value": "future_runner.py",
+            }
+            plan.write_text(json.dumps(payload))
+            with self.assertRaisesRegex(
+                queue.QueueError, "interpreter requires a pinned runner"
+            ):
                 queue.validate_plan(plan)
 
     def test_long_job_cannot_claim_progress_exemption(self):

--- a/tools/test_experiment_queue.py
+++ b/tools/test_experiment_queue.py
@@ -406,6 +406,38 @@ class ExperimentQueueTests(unittest.TestCase):
             self.assertEqual(observed["state"], "halted")
             self.assertIn("validator timed out", observed["message"])
 
+    def test_fast_validator_output_is_bounded_after_exit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root, "validator-output",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()",
+            )
+            plan = self.make_plan(root, [job])
+            payload = json.loads(plan.read_text())
+            noisy = root / "noisy_validator.py"
+            noisy.write_text(
+                "import os\n"
+                f"os.write(1, b'x' * ({queue.MAX_VALIDATOR_OUTPUT_BYTES} + 1))\n"
+            )
+            payload["pinned_files"].append({
+                "kind": "file", "path": str(noisy),
+                "bytes": noisy.stat().st_size,
+                "sha256": hashlib.sha256(noisy.read_bytes()).hexdigest(),
+                "role": "noisy test validator",
+            })
+            payload["jobs"][0]["pinned_inputs"].append(str(noisy))
+            payload["jobs"][0]["success"]["validator"] = [
+                {"kind": "pinned", "path": str(Path(sys.executable).resolve())},
+                {"kind": "pinned", "path": str(noisy)},
+            ]
+            plan.write_text(json.dumps(payload))
+
+            self.assertEqual(queue.run_queue(plan, root / "state.json"), 0)
+            observed = json.loads((root / "state.json").read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("validator output limit exceeded", observed["message"])
+
     def test_unknown_guard_field_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tools/test_experiment_queue.py
+++ b/tools/test_experiment_queue.py
@@ -497,10 +497,13 @@ class ExperimentQueueTests(unittest.TestCase):
                 "POOL": {"kind": "literal", "value": str(root / "pool")}
             }
             plan.write_text(json.dumps(payload))
-            with self.assertRaisesRegex(queue.QueueError, "path-bearing"):
+            with self.assertRaisesRegex(queue.QueueError, "literal must be"):
                 queue.validate_plan(plan)
 
-            for value in ("pool", "input.ini", ".", "..", "-c", "-m"):
+            for value in (
+                "pool", "future_pool", "input.ini", ".", "..", "-c", "-m",
+                "-e",
+            ):
                 (root / "pool").mkdir(exist_ok=True)
                 (root / "input.ini").touch(exist_ok=True)
                 payload["jobs"][0]["env"] = {
@@ -508,7 +511,7 @@ class ExperimentQueueTests(unittest.TestCase):
                 }
                 plan.write_text(json.dumps(payload))
                 with self.subTest(value=value):
-                    with self.assertRaisesRegex(queue.QueueError, "path-bearing"):
+                    with self.assertRaisesRegex(queue.QueueError, "literal must be"):
                         queue.validate_plan(plan)
 
             payload["jobs"][0]["env"] = {}
@@ -517,7 +520,16 @@ class ExperimentQueueTests(unittest.TestCase):
             }
             plan.write_text(json.dumps(payload))
             with self.assertRaisesRegex(
-                queue.QueueError, "interpreter requires a pinned runner"
+                queue.QueueError, "literal must be"
+            ):
+                queue.validate_plan(plan)
+
+            payload["jobs"][0]["command"][1] = {
+                "kind": "literal", "value": "--eval",
+            }
+            plan.write_text(json.dumps(payload))
+            with self.assertRaisesRegex(
+                queue.QueueError, "requires a pinned runner"
             ):
                 queue.validate_plan(plan)
 

--- a/tools/test_experiment_queue.py
+++ b/tools/test_experiment_queue.py
@@ -14,12 +14,46 @@ import experiment_queue as queue
 
 class ExperimentQueueTests(unittest.TestCase):
     def make_plan(self, root: Path, jobs: list[dict], **overrides) -> Path:
+        validator_body = (
+            "import pathlib,sys; "
+            "raise SystemExit(0 if pathlib.Path(sys.argv[1]).is_file() else 1)"
+        )
+        for job in jobs:
+            job.setdefault("resume_safe", False)
+            job.setdefault("pinned_inputs", [str(Path(sys.executable).resolve())])
+            job.setdefault("max_runtime_seconds", 5)
+            if "progress" not in job:
+                job.setdefault(
+                    "progress_not_required_reason", "bounded unit-test command"
+                )
+            job["success"].setdefault(
+                "validator",
+                [
+                    sys.executable,
+                    "-c",
+                    validator_body,
+                    job["success"]["path"],
+                ],
+            )
+            job["success"].setdefault("validator_timeout_seconds", 2)
+        executable = Path(sys.executable).resolve()
         payload = {
             "schema_version": 1,
             "queue_id": "test-queue",
             "root": str(root),
             "min_free_bytes": 1,
             "poll_seconds": 0.01,
+            "base_env": {
+                key: os.environ[key]
+                for key in ("HOME", "PATH")
+                if key in os.environ
+            },
+            "pinned_files": [{
+                "path": str(executable),
+                "bytes": executable.stat().st_size,
+                "sha256": hashlib.sha256(executable.read_bytes()).hexdigest(),
+                "role": "test Python executable",
+            }],
             "jobs": jobs,
             **overrides,
         }
@@ -191,6 +225,93 @@ class ExperimentQueueTests(unittest.TestCase):
             observed = json.loads(state.read_text())
             self.assertEqual(observed["state"], "halted")
             self.assertIn("not resume-safe", observed["message"])
+
+            # A persisted safety halt is terminal across service restarts.
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            observed_again = json.loads(state.read_text())
+            self.assertEqual(observed_again["state"], "halted")
+
+    def test_interrupted_unsafe_job_cannot_recover_from_artifact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root, "unsafe-artifact", "raise SystemExit('must not run')"
+            )
+            plan = self.make_plan(root, [job])
+            Path(job["success"]["path"]).touch()
+            plan_sha = hashlib.sha256(plan.read_bytes()).hexdigest()
+            state = root / "state.json"
+            recorded = queue.new_state(json.loads(plan.read_text()), plan_sha)
+            recorded["jobs"][0]["state"] = "running"
+            queue.atomic_json(state, recorded)
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            observed = json.loads(state.read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("not resume-safe", observed["message"])
+
+    def test_hanging_validator_is_bounded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root,
+                "validator-timeout",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()",
+            )
+            plan = self.make_plan(root, [job])
+            payload = json.loads(plan.read_text())
+            payload["jobs"][0]["success"]["validator"] = [
+                sys.executable, "-c", "import time; time.sleep(60)"
+            ]
+            payload["jobs"][0]["success"]["validator_timeout_seconds"] = 0.02
+            plan.write_text(json.dumps(payload))
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            observed = json.loads(state.read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("validator timed out", observed["message"])
+
+    def test_unknown_guard_field_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root,
+                "typo",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()",
+                max_runtime_second=5,
+            )
+            plan = self.make_plan(root, [job])
+            with self.assertRaisesRegex(queue.QueueError, "unknown job 1 fields"):
+                queue.run_queue(plan, root / "state.json")
+
+    def test_pinned_input_drift_halts_before_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root,
+                "pin-drift",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()",
+            )
+            pinned = root / "reward.json"
+            pinned.write_text("frozen")
+            plan = self.make_plan(root, [job])
+            payload = json.loads(plan.read_text())
+            payload["pinned_files"].append({
+                "path": str(pinned),
+                "bytes": pinned.stat().st_size,
+                "sha256": hashlib.sha256(pinned.read_bytes()).hexdigest(),
+                "role": "reward manifest",
+            })
+            plan.write_text(json.dumps(payload))
+            pinned.write_text("drifted")
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            observed = json.loads(state.read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("pinned reward manifest", observed["message"])
+            self.assertFalse(Path(job["success"]["path"]).exists())
 
     def test_temperature_query_failure_terminates_job_and_halts(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/test_experiment_queue.py
+++ b/tools/test_experiment_queue.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+
+import json
+import hashlib
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import experiment_queue as queue
+
+
+class ExperimentQueueTests(unittest.TestCase):
+    def make_plan(self, root: Path, jobs: list[dict], **overrides) -> Path:
+        payload = {
+            "schema_version": 1,
+            "queue_id": "test-queue",
+            "root": str(root),
+            "min_free_bytes": 1,
+            "poll_seconds": 0.01,
+            "jobs": jobs,
+            **overrides,
+        }
+        path = root / "plan.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    @staticmethod
+    def write_job(root: Path, job_id: str, body: str, **overrides) -> dict:
+        success = root / f"{job_id}.done"
+        return {
+            "id": job_id,
+            "command": [sys.executable, "-c", body, str(success)],
+            "cwd": str(root),
+            "log": str(root / f"{job_id}.log"),
+            "success": {"path": str(success)},
+            **overrides,
+        }
+
+    def test_runs_jobs_in_order_and_publishes_complete_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = self.write_job(
+                root, "first",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).write_text('one')",
+            )
+            second = self.write_job(
+                root, "second",
+                "import pathlib,sys; "
+                "assert pathlib.Path('first.done').read_text() == 'one'; "
+                "pathlib.Path(sys.argv[1]).write_text('two')",
+            )
+            plan = self.make_plan(root, [first, second])
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["state"], "complete")
+            self.assertEqual([j["state"] for j in recorded["jobs"]],
+                             ["complete", "complete"])
+            self.assertEqual((root / "second.done").read_text(), "two")
+
+    def test_existing_success_artifact_is_validated_and_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            success = root / "done"
+            success.write_text("kept")
+            job = {
+                "id": "skip",
+                "command": [sys.executable, "-c", "raise SystemExit(9)"],
+                "cwd": str(root),
+                "log": str(root / "skip.log"),
+                "success": {"path": str(success)},
+            }
+            plan = self.make_plan(root, [job])
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["jobs"][0]["state"], "complete")
+            self.assertTrue(recorded["jobs"][0]["recovered_from_artifact"])
+
+    def test_failure_halts_without_running_later_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            failed = self.write_job(root, "failed", "raise SystemExit(7)")
+            later = self.write_job(
+                root, "later",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()",
+            )
+            plan = self.make_plan(root, [failed, later])
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["state"], "halted")
+            self.assertEqual(recorded["jobs"][0]["exit_code"], 7)
+            self.assertEqual(recorded["jobs"][1]["state"], "pending")
+            self.assertFalse((root / "later.done").exists())
+
+    def test_plan_drift_halts_a_preexisting_queue(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root, "once",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()",
+            )
+            plan = self.make_plan(root, [job])
+            state = root / "state.json"
+            self.assertEqual(queue.run_queue(plan, state), 0)
+
+            payload = json.loads(plan.read_text())
+            payload["min_free_bytes"] = 2
+            plan.write_text(json.dumps(payload), encoding="utf-8")
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["state"], "halted")
+            self.assertIn("plan SHA-256 changed", recorded["message"])
+
+    def test_success_digest_is_enforced(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root, "digest",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).write_text('wrong')",
+            )
+            job["success"]["sha256"] = "0" * 64
+            plan = self.make_plan(root, [job])
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["state"], "halted")
+            self.assertIn("success validation failed", recorded["message"])
+
+    def test_absent_progress_file_halts_a_hung_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root,
+                "hung",
+                "import time; time.sleep(60)",
+                progress={
+                    "path": str(root / "never-created.progress"),
+                    "max_stale_seconds": 0.02,
+                },
+            )
+            plan = self.make_plan(root, [job])
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["state"], "halted")
+            self.assertIn("absent", recorded["message"])
+
+    def test_max_runtime_halts_a_hung_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root,
+                "bounded",
+                "import time; time.sleep(60)",
+                max_runtime_seconds=0.02,
+            )
+            plan = self.make_plan(root, [job])
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["state"], "halted")
+            self.assertIn("runtime guard", recorded["message"])
+
+    def test_interrupted_non_resume_safe_job_halts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root,
+                "unsafe",
+                "raise SystemExit('must not run')",
+            )
+            plan = self.make_plan(root, [job])
+            plan_sha = hashlib.sha256(plan.read_bytes()).hexdigest()
+            state = root / "state.json"
+            recorded = queue.new_state(json.loads(plan.read_text()), plan_sha)
+            recorded["jobs"][0]["state"] = "running"
+            queue.atomic_json(state, recorded)
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            observed = json.loads(state.read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("not resume-safe", observed["message"])
+
+    def test_temperature_query_failure_terminates_job_and_halts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root,
+                "thermal-query",
+                "import time; time.sleep(60)",
+            )
+            plan = self.make_plan(root, [job], max_gpu_temperature_c=88)
+            state = root / "state.json"
+
+            with mock.patch.object(
+                queue,
+                "gpu_temperature",
+                side_effect=[70.0, queue.QueueError("query unavailable")],
+            ):
+                self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["state"], "halted")
+            self.assertIn("monitor failed closed", recorded["message"])
+
+    def test_preexisting_stale_progress_gets_a_startup_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            progress = root / "progress.json"
+            progress.write_text("old")
+            os.utime(progress, (1, 1))
+            job = self.write_job(
+                root,
+                "recovery",
+                "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()",
+                progress={
+                    "path": str(progress),
+                    "max_stale_seconds": 1,
+                },
+            )
+            plan = self.make_plan(root, [job])
+            state = root / "state.json"
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            recorded = json.loads(state.read_text())
+            self.assertEqual(recorded["state"], "complete")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_experiment_queue.py
+++ b/tools/test_experiment_queue.py
@@ -13,6 +13,27 @@ import experiment_queue as queue
 
 
 class ExperimentQueueTests(unittest.TestCase):
+    def setUp(self):
+        self.gpu_patch = mock.patch.object(
+            queue, "gpu_temperature", return_value=50.0)
+        self.gpu_patch.start()
+
+    def tearDown(self):
+        self.gpu_patch.stop()
+
+    @staticmethod
+    def typed(arguments: list[str], mutable: set[str]) -> list[dict[str, str]]:
+        executable = str(Path(sys.executable).resolve())
+        rendered = []
+        for value in arguments:
+            if str(Path(value).resolve()) == executable:
+                rendered.append({"kind": "pinned", "path": executable})
+            elif value in mutable:
+                rendered.append({"kind": "mutable", "path": value})
+            else:
+                rendered.append({"kind": "literal", "value": value})
+        return rendered
+
     def make_plan(self, root: Path, jobs: list[dict], **overrides) -> Path:
         validator_body = (
             "import pathlib,sys; "
@@ -36,19 +57,37 @@ class ExperimentQueueTests(unittest.TestCase):
                 ],
             )
             job["success"].setdefault("validator_timeout_seconds", 2)
+            mutable = {
+                job["log"], job["success"]["path"],
+                *(job.get("mutable_paths", [])),
+            }
+            if "progress" in job:
+                mutable.add(job["progress"]["path"])
+            job["command"] = self.typed(job["command"], mutable)
+            job["success"]["validator"] = self.typed(
+                job["success"]["validator"], mutable)
+            job["env"] = {
+                key: ({"kind": "mutable", "path": value}
+                      if value in mutable
+                      else {"kind": "literal", "value": value})
+                for key, value in job.get("env", {}).items()
+            }
         executable = Path(sys.executable).resolve()
         payload = {
             "schema_version": 1,
             "queue_id": "test-queue",
             "root": str(root),
             "min_free_bytes": 1,
+            "min_free_inodes": 1,
             "poll_seconds": 0.01,
+            "max_gpu_temperature_c": 88,
             "base_env": {
                 key: os.environ[key]
                 for key in ("HOME", "PATH")
                 if key in os.environ
             },
             "pinned_files": [{
+                "kind": "file",
                 "path": str(executable),
                 "bytes": executable.stat().st_size,
                 "sha256": hashlib.sha256(executable.read_bytes()).hexdigest(),
@@ -250,6 +289,30 @@ class ExperimentQueueTests(unittest.TestCase):
             self.assertEqual(observed["state"], "halted")
             self.assertIn("not resume-safe", observed["message"])
 
+    def test_completed_job_with_missing_artifact_halts_without_rerun(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            marker = root / "reran"
+            job = self.write_job(
+                root, "completed",
+                "import pathlib,sys; pathlib.Path('reran').touch(); "
+                "pathlib.Path(sys.argv[1]).touch()",
+            )
+            plan = self.make_plan(root, [job])
+            plan_sha = hashlib.sha256(plan.read_bytes()).hexdigest()
+            state = root / "state.json"
+            recorded = queue.new_state(json.loads(plan.read_text()), plan_sha)
+            recorded["state"] = "running"
+            recorded["jobs"][0]["state"] = "complete"
+            recorded["jobs"][0]["success_sha256"] = "0" * 64
+            queue.atomic_json(state, recorded)
+
+            self.assertEqual(queue.run_queue(plan, state), 0)
+            observed = json.loads(state.read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("evidence drifted", observed["message"])
+            self.assertFalse(marker.exists())
+
     def test_hanging_validator_is_bounded(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -261,7 +324,9 @@ class ExperimentQueueTests(unittest.TestCase):
             plan = self.make_plan(root, [job])
             payload = json.loads(plan.read_text())
             payload["jobs"][0]["success"]["validator"] = [
-                sys.executable, "-c", "import time; time.sleep(60)"
+                {"kind": "pinned", "path": str(Path(sys.executable).resolve())},
+                {"kind": "literal", "value": "-c"},
+                {"kind": "literal", "value": "import time; time.sleep(60)"},
             ]
             payload["jobs"][0]["success"]["validator_timeout_seconds"] = 0.02
             plan.write_text(json.dumps(payload))
@@ -298,6 +363,7 @@ class ExperimentQueueTests(unittest.TestCase):
             plan = self.make_plan(root, [job])
             payload = json.loads(plan.read_text())
             payload["pinned_files"].append({
+                "kind": "file",
                 "path": str(pinned),
                 "bytes": pinned.stat().st_size,
                 "sha256": hashlib.sha256(pinned.read_bytes()).hexdigest(),
@@ -312,6 +378,82 @@ class ExperimentQueueTests(unittest.TestCase):
             self.assertEqual(observed["state"], "halted")
             self.assertIn("pinned reward manifest", observed["message"])
             self.assertFalse(Path(job["success"]["path"]).exists())
+
+    def test_directory_input_requires_and_rechecks_a_tree_pin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pool = root / "pool"
+            pool.mkdir()
+            (pool / "input.txt").write_text("frozen")
+            job = self.write_job(
+                root, "tree-pin",
+                "import os,pathlib,sys; pathlib.Path(sys.argv[1]).write_text("
+                "pathlib.Path(os.environ['POOL']).joinpath('input.txt').read_text())",
+                env={"POOL": str(pool)},
+            )
+            plan = self.make_plan(root, [job])
+            payload = json.loads(plan.read_text())
+            files, size, identity = queue.tree_identity(pool)
+            payload["pinned_files"].append({
+                "kind": "tree", "path": str(pool), "files": files,
+                "bytes": size, "sha256": identity, "role": "replay pool",
+            })
+            payload["jobs"][0]["pinned_inputs"].append(str(pool))
+            payload["jobs"][0]["env"]["POOL"] = {
+                "kind": "pinned", "path": str(pool),
+            }
+            plan.write_text(json.dumps(payload))
+            (pool / "input.txt").write_text("mutated-unpinned")
+
+            self.assertEqual(queue.run_queue(plan, root / "state.json"), 0)
+            observed = json.loads((root / "state.json").read_text())
+            self.assertEqual(observed["state"], "halted")
+            self.assertIn("pinned replay pool", observed["message"])
+            self.assertFalse(Path(job["success"]["path"]).exists())
+
+    def test_path_bearing_literal_and_untyped_env_are_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root, "typed", "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()"
+            )
+            plan = self.make_plan(root, [job])
+            payload = json.loads(plan.read_text())
+            payload["jobs"][0]["env"] = {"POOL": str(root / "pool")}
+            plan.write_text(json.dumps(payload))
+            with self.assertRaisesRegex(queue.QueueError, "typed argument"):
+                queue.validate_plan(plan)
+
+            payload["jobs"][0]["env"] = {
+                "POOL": {"kind": "literal", "value": str(root / "pool")}
+            }
+            plan.write_text(json.dumps(payload))
+            with self.assertRaisesRegex(queue.QueueError, "path-bearing"):
+                queue.validate_plan(plan)
+
+    def test_long_job_cannot_claim_progress_exemption(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root, "long", "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()",
+                max_runtime_seconds=queue.MAX_PROGRESS_EXEMPT_SECONDS + 1,
+            )
+            plan = self.make_plan(root, [job])
+            with self.assertRaisesRegex(queue.QueueError, "progress-exemption"):
+                queue.validate_plan(plan)
+
+    def test_thermal_limit_is_mandatory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = self.write_job(
+                root, "thermal", "import pathlib,sys; pathlib.Path(sys.argv[1]).touch()"
+            )
+            plan = self.make_plan(root, [job])
+            payload = json.loads(plan.read_text())
+            del payload["max_gpu_temperature_c"]
+            plan.write_text(json.dumps(payload))
+            with self.assertRaisesRegex(queue.QueueError, "must be in 1..120"):
+                queue.validate_plan(plan)
 
     def test_temperature_query_failure_terminates_job_and_halts(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/test_run_reward_candidate_transfer.py
+++ b/tools/test_run_reward_candidate_transfer.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import run_reward_candidate_transfer as runner
+
+
+class RewardCandidateTransferRunnerTests(unittest.TestCase):
+    def test_paired_screen_discovers_only_reference_and_candidate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            prefix = "paired"
+            for arm in ("both", "gain_only"):
+                for seed in (42, 43):
+                    checkpoint = root / f"{arm}-{seed}.bin"
+                    checkpoint.write_bytes(b"test")
+                    result = {
+                        "checkpoint": str(checkpoint),
+                        "checkpoint_sha256": hashlib.sha256(
+                            checkpoint.read_bytes()
+                        ).hexdigest(),
+                    }
+                    (root / f"{prefix}-{arm}-s{seed}.result.json").write_text(
+                        json.dumps(result), encoding="utf-8"
+                    )
+            report = {
+                "screen": {
+                    "completion": {"present": True},
+                    "profile": "paired-confirmation",
+                    "prefix": prefix,
+                    "candidate_arm": "gain_only",
+                }
+            }
+            with (
+                mock.patch.object(
+                    runner.analyze_reward_screen,
+                    "analyze_screen",
+                    return_value=report,
+                ),
+                mock.patch.object(runner, "EXPECTED_NATIVE_BYTES", 4),
+            ):
+                checkpoints, arms = runner.screen_checkpoints(
+                    root, "0" * 64
+                )
+
+        self.assertEqual(arms, ("both", "gain_only"))
+        self.assertEqual(set(checkpoints), set(arms))
+        self.assertEqual(set(checkpoints["both"]), {"42", "43"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_run_reward_candidate_transfer.py
+++ b/tools/test_run_reward_candidate_transfer.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import tempfile
+import subprocess
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -51,6 +52,77 @@ class RewardCandidateTransferRunnerTests(unittest.TestCase):
         self.assertEqual(arms, ("both", "gain_only"))
         self.assertEqual(set(checkpoints), set(arms))
         self.assertEqual(set(checkpoints["both"]), {"42", "43"})
+
+    def test_conversion_reuse_rejects_converter_drift(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "training").mkdir()
+            (root / "puffer/config").mkdir(parents=True)
+            converter = root / "training/convert_checkpoint.py"
+            converter.write_text("converter-v1")
+            (root / "puffer/config/bloodbowl.ini").write_text("config-v1")
+            checkpoints = {"both": {}}
+            for seed in runner.SEEDS:
+                source = root / f"source-{seed}.bin"
+                source.write_bytes(b"native")
+                checkpoints["both"][str(seed)] = {
+                    "native": str(source),
+                    "native_sha256": runner.sha256(source),
+                }
+
+            def fake_run(command, **_kwargs):
+                output = Path(command[command.index("-o") + 1])
+                output.write_bytes(b"x" * 1_000_001)
+                return subprocess.CompletedProcess(command, 0, "converted")
+
+            with mock.patch.object(runner, "run_checked", side_effect=fake_run):
+                runner.convert_checkpoints(
+                    root, root / "out", checkpoints, ("both",)
+                )
+                runner.convert_checkpoints(
+                    root, root / "out", checkpoints, ("both",)
+                )
+                converter.write_text("converter-v2")
+                with self.assertRaisesRegex(runner.RunnerError, "metadata drift"):
+                    runner.convert_checkpoints(
+                        root, root / "out", checkpoints, ("both",)
+                    )
+
+    def test_frozen_manifest_rejects_recomputed_plan_drift(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "training").mkdir()
+            (root / "puffer/config").mkdir(parents=True)
+            (root / "training/convert_checkpoint.py").write_text("converter")
+            (root / "puffer/config/bloodbowl.ini").write_text("config")
+            manifest = root / "TRANSFER_MANIFEST.json"
+            checkpoints = {
+                arm: {str(seed): {"torch_sha256": "0" * 64}
+                      for seed in runner.SEEDS}
+                for arm in ("both", "gain_only")
+            }
+            with (
+                mock.patch.object(
+                    runner, "implementation_identity", return_value={"x": "1"}
+                ),
+                mock.patch.object(
+                    runner, "orchestration_identity", return_value={"y": "2"}
+                ),
+            ):
+                runner.freeze_manifest(
+                    manifest, root, root / "screen", "a" * 64,
+                    checkpoints, ("both", "gain_only"),
+                )
+                saved = json.loads(manifest.read_text())
+                saved["gates"]["mean_score_delta_min"] = -0.5
+                manifest.write_text(json.dumps(saved))
+                with self.assertRaisesRegex(
+                    runner.RunnerError, "differs from recomputed plan"
+                ):
+                    runner.freeze_manifest(
+                        manifest, root, root / "screen", "a" * 64,
+                        checkpoints, ("both", "gain_only"),
+                    )
 
 
 if __name__ == "__main__":

--- a/training/systemd/experiment-queue@.service
+++ b/training/systemd/experiment-queue@.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Blood Bowl immutable experiment queue (%i)
+After=network-online.target
+StartLimitIntervalSec=3600
+StartLimitBurst=10
+
+[Service]
+Type=simple
+WorkingDirectory=%h/bloodbowl-rl-audit
+Environment=PYTHONUNBUFFERED=1
+ExecStart=%h/bloodbowl-rl-audit/vendor/PufferLib/.venv/bin/python %h/bloodbowl-rl-audit/tools/experiment_queue.py --plan %h/bloodbowl-rl-audit/runs/%i/QUEUE_PLAN.json --state %h/bloodbowl-rl-audit/runs/%i/QUEUE_STATE.json
+Restart=on-failure
+RestartSec=30
+KillMode=control-group
+TimeoutStopSec=45
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- add an immutable, fail-closed experiment queue and systemd user-service template for six-day RTX 2070 runs
- add a manifested four-arm scripted transfer gate and dynamic paired R0-versus-candidate confirmation profile
- add runtime/disk/progress/thermal/artifact guards, focused tests, CI coverage, and operational guidance

## Safety boundary
This executes only a reviewed literal queue in the isolated audit checkout. It cannot invent experiments or promote a production reward; any drift or failed validator halts all later jobs.

## Verification
- 42 focused reward/queue/transfer/contract tests
- full reward/replay/analyzer suite passed before paired-profile commit
- 10 BC streaming tests passed in project venv
- 392 engine, 25 reward, and 2 scripted-bot tests passed
- ruff, shell syntax, and diff checks passed

Independent reviews are in progress.