### PR TITLE
Fix BBTV external stream default

### DIFF
--- a/docs/stream-protocol.md
+++ b/docs/stream-protocol.md
@@ -23,8 +23,9 @@ all viewers see the same match.
 
 ## Connection
 
-- Endpoint (production): `wss://bbstream.seconds0.com/ws` *(placeholder —
-  final host TBD when the backend deploys; treat as a config value)*.
+- Endpoint (production): `wss://bbtv.seconds0.com/ws`. The bundled web client
+  uses the current page host by default and still accepts a `?ws=...` override
+  for development or alternate deployments.
 - On connect the server sends `hello`, then a full `snapshot`, then `delta`
   messages as the game progresses.
 - Heartbeat: server sends `{"t":"ping","seq":N}` every 15s; reply

--- a/docs/vacation-progress.md
+++ b/docs/vacation-progress.md
@@ -57,3 +57,59 @@ Next steps:
    confirmation gates.
 5. Deploy the exact merged source artifact-preservingly, freeze the final queue,
    smoke it on the 2070, start it, and verify BBTV before departure.
+
+## 2026-07-14 00:34 PDT
+
+Status:
+
+- The corrected possession/gain screen remains healthy on arm 2/8
+  (`neither`, seed 42). The latest durable training readout is 408,682,496 of
+  500,000,000 requested steps, still in training, with zero reward clipping,
+  non-finite rewards, error episodes, demonstrations, or demonstration
+  fallbacks. GPU snapshot: 83 C, 80% utilization, 5,737 MiB used; disk is 6%
+  full and inode use is 1%.
+- Arm 1/8 (`both`, seed 42) completed and passed its acceptance contract at
+  499,908,608 exact learner steps and 10,026 evaluation games.
+- BBTV's follower, tunnel, and public WebSocket are healthy. Its manifested
+  selection is arm 2 at step 299,761,664 versus the frozen turnover3 warm;
+  the follower will select a newer complete checkpoint after the current
+  two-game presentation cycle finishes.
+
+Completed since the previous handoff:
+
+- PR #8 passed hosted CI and three independent reviews, then merged to `main`
+  as `4ec580d3c57148716965c4890aac51f0f6d5a7b0`.
+- Deployed that exact tracked tree to `/home/rache/bloodbowl-rl` without
+  deleting remote-only artifacts or rebuilding/restarting live services.
+  A checksum-and-mode dry run is clean across all 4,148 archive entries;
+  overwritten content is preserved at
+  `/home/rache/deployments/pr8-backup-before-4ec580d`, and production records
+  the deployment in `.deployed-source.json`.
+- Rechecked user-service liveness, Tailscale, linger, capacity, thermal state,
+  the public HTTP page, and an external secure WebSocket handshake. All are
+  healthy.
+
+Current blockers / review work:
+
+- The public page's deployed JavaScript still defaults external viewers to
+  `ws://localhost:8787/ws`, even though the tunnel correctly exposes
+  `wss://bbtv.seconds0.com/ws`. A scoped same-host WebSocket default fix is in
+  progress. The in-app browser is unavailable in this session, so visual
+  canvas inspection remains an explicit pending verification; transport can
+  still be verified externally.
+- The audit snapshot must remain untouched until all eight screen arms finish.
+  The vacation queue cannot be frozen until the main-lineage confirmation,
+  scripted transfer, and learned transfer produce accepted literal evidence.
+
+Next steps:
+
+1. Test, review, merge, and deploy the BBTV default-WebSocket fix, then verify
+   public JavaScript plus the external `hello`/`match_start`/`snapshot` flow.
+2. Continue monitoring all integrity, capacity, thermal, and BBTV indicators
+   while the corrected screen runs.
+3. After the eight-arm screen finishes, atomically analyze it, run the
+   predeclared transfer and paired-confirmation gates, and select at most one
+   simplification candidate.
+4. Deploy the exact merged queue source to the now-idle audit snapshot, freeze
+   every input, execute the interruption/failure/resume smokes, start the user
+   service, and complete the departure gate.

--- a/stream/web/app.js
+++ b/stream/web/app.js
@@ -7,7 +7,9 @@
 
 // ---------------------------------------------------------------- config
 const PARAMS = new URLSearchParams(location.search);
-const LOCAL_HOSTS = new Set(['', 'localhost', '127.0.0.1', '::1']);
+const LOCAL_HOSTS = new Set([
+  '', 'localhost', '127.0.0.1', '0.0.0.0', '::1', '[::1]',
+]);
 const DEFAULT_WS_URL = LOCAL_HOSTS.has(location.hostname)
   ? 'ws://localhost:8787/ws'
   : `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws`;

--- a/stream/web/app.js
+++ b/stream/web/app.js
@@ -7,7 +7,11 @@
 
 // ---------------------------------------------------------------- config
 const PARAMS = new URLSearchParams(location.search);
-const WS_URL = PARAMS.get('ws') || 'ws://localhost:8787/ws';
+const LOCAL_HOSTS = new Set(['', 'localhost', '127.0.0.1', '::1']);
+const DEFAULT_WS_URL = LOCAL_HOSTS.has(location.hostname)
+  ? 'ws://localhost:8787/ws'
+  : `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws`;
+const WS_URL = PARAMS.get('ws') || DEFAULT_WS_URL;
 const COLS = 26, ROWS = 15, CELL = 36;
 const TWEEN_MS = 250;        // move animation
 const PROBS_MS = 700;        // "AI mind" card lifetime


### PR DESCRIPTION
## Summary

- default external BBTV viewers to the same-host secure WebSocket (`wss://bbtv.seconds0.com/ws`)
- preserve localhost development and the explicit `?ws=` override
- document the deployed production endpoint
- append the 00:34 PDT vacation progress handoff

## Verification

- `node --check stream/web/app.js`
- 4 focused URL-resolution cases (HTTPS, HTTP+port, localhost, override)
- `(cd stream_backend && ../vendor/PufferLib/.venv/bin/python -m unittest test_follow_latest.py)` (12 passed)
- external `wss://bbtv.seconds0.com/ws` probe received `hello`, `match_start`, and `snapshot`

## Deployment

After merge, deploy only `stream/web/app.js` artifact-preservingly. `bbweb.service` serves it directly; no training or BBTV service restart is required.