### PR TITLE
feat: stream sampled policies on BBTV

### DIFF
--- a/docs/bbtv-latest-checkpoint.md
+++ b/docs/bbtv-latest-checkpoint.md
@@ -44,6 +44,14 @@ The follower rechecks after every two streamed games. Home and away are swapped
 between those games by the existing match runner. A just-finished checkpoint can
 therefore take up to one two-game cycle to appear.
 
+The checked-in launcher samples legal actions from each policy by default
+(`BBTV_SAMPLE=1`). This matches the action-selection mode used by training and
+evaluation more closely than greedy argmax and makes the public stream a more
+representative qualitative view of learned behavior. BBTV games remain
+observational: their small, unpaired sample must not be used for reward tuning,
+promotion, or regression gates. The exact child command, including `--sample`,
+is recorded in `server_status.json`.
+
 ## RTX 2070 service
 
 The repository launcher is `stream_backend/run_follow_latest.sh`. Production is
@@ -60,7 +68,12 @@ systemctl --user daemon-reload
 systemctl --user restart bbstream.service
 systemctl --user status bbstream.service
 cat /home/rache/bloodbowl-rl-audit/runs/bbtv-follow/selection.json
+cat /home/rache/bloodbowl-rl-audit/runs/bbtv-follow/server_status.json
 ```
+
+To compare with or immediately roll back to deterministic greedy viewing, set
+`BBTV_SAMPLE=0` in the service environment and restart only
+`bbstream.service`. Removing that override restores sampled viewing.
 
 Rollback preserves the original static launcher:
 

--- a/stream_backend/follow_latest.py
+++ b/stream_backend/follow_latest.py
@@ -342,7 +342,7 @@ def prune_cache(cache_dir: Path, selected: set[Path], keep: int) -> None:
 def server_command(
     args: argparse.Namespace, checkpoint_a: Path, checkpoint_b: Path
 ) -> list[str]:
-    return [
+    command = [
         str(args.server_python),
         str(args.server_script),
         "--ckpt-a",
@@ -356,6 +356,9 @@ def server_command(
         "--max-games",
         str(args.games_per_cycle),
     ]
+    if args.sample:
+        command.append("--sample")
+    return command
 
 
 def choose_stream_pair(
@@ -475,6 +478,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--port", type=int, default=8787)
     parser.add_argument("--pace", type=float, default=0.6)
     parser.add_argument("--games-per-cycle", type=int, default=2)
+    parser.add_argument(
+        "--sample",
+        action="store_true",
+        help="sample policy actions instead of using greedy argmax",
+    )
     parser.add_argument("--stability-seconds", type=float, default=1.0)
     parser.add_argument("--retry-seconds", type=float, default=5.0)
     parser.add_argument("--conversion-timeout-seconds", type=float, default=300.0)

--- a/stream_backend/follow_latest.py
+++ b/stream_backend/follow_latest.py
@@ -164,15 +164,20 @@ def stable_native(path: Path, expected_bytes: int, seconds: float) -> os.stat_re
 
 
 def _conversion_label(candidate: Candidate, digest: str) -> str:
-    return safe_label(
-        f"{candidate.tag}-step{candidate.step:012d}-{digest[:10]}_torch.bin"
+    return _hashed_torch_label(
+        f"{candidate.tag}-step{candidate.step:012d}", digest
     )
 
 
 def _baseline_label(candidate: Candidate, digest: str) -> str:
-    return safe_label(
-        f"baseline-{candidate.warm_path.stem}-{digest[:10]}_torch.bin"
-    )
+    return _hashed_torch_label(f"baseline-{candidate.warm_path.stem}", digest)
+
+
+def _hashed_torch_label(prefix: str, digest: str) -> str:
+    suffix = f"-{digest[:10]}_torch.bin"
+    prefix_budget = 96 - len(suffix)
+    bounded_prefix = safe_label(prefix)[:prefix_budget].rstrip("-._")
+    return f"{bounded_prefix or 'checkpoint'}{suffix}"
 
 
 def convert_native(

--- a/stream_backend/run_follow_latest.sh
+++ b/stream_backend/run_follow_latest.sh
@@ -15,6 +15,15 @@ export OMP_NUM_THREADS=${OMP_NUM_THREADS:-4}
 source "$ROOT/rig-env.sh"
 export PYTHONPATH="$VIEWER_ROOT${PYTHONPATH:+:$PYTHONPATH}"
 
+case "${BBTV_SAMPLE:-1}" in
+  1) SAMPLE_ARGS=(--sample) ;;
+  0) SAMPLE_ARGS=() ;;
+  *)
+    echo "BBTV_SAMPLE must be 0 (greedy) or 1 (sampled)" >&2
+    exit 2
+    ;;
+esac
+
 exec nice -n 19 ionice -c 3 \
   "$ROOT/vendor/PufferLib/.venv/bin/python" \
   "$ROOT/stream_backend/follow_latest.py" \
@@ -31,4 +40,5 @@ exec nice -n 19 ionice -c 3 \
   --pace "${BBTV_PACE:-0.6}" \
   --games-per-cycle "${BBTV_GAMES_PER_CYCLE:-2}" \
   --stability-seconds "${BBTV_STABILITY_SECONDS:-1}" \
-  --keep-converted "${BBTV_KEEP_CONVERTED:-24}"
+  --keep-converted "${BBTV_KEEP_CONVERTED:-24}" \
+  "${SAMPLE_ARGS[@]}"

--- a/stream_backend/test_follow_latest.py
+++ b/stream_backend/test_follow_latest.py
@@ -240,6 +240,27 @@ class FollowLatestTests(unittest.TestCase):
             "arm-seed-42-_torch.bin",
         )
 
+    def test_server_command_forwards_sample_mode(self):
+        args = SimpleNamespace(
+            server_python=Path("viewer-python"),
+            server_script=Path("server.py"),
+            port=8787,
+            pace=0.6,
+            games_per_cycle=2,
+            sample=True,
+        )
+
+        sampled = follow_latest.server_command(
+            args, Path("learner.bin"), Path("baseline.bin")
+        )
+        args.sample = False
+        greedy = follow_latest.server_command(
+            args, Path("learner.bin"), Path("baseline.bin")
+        )
+
+        self.assertEqual(sampled[-1], "--sample")
+        self.assertNotIn("--sample", greedy)
+
     def test_parser_preserves_virtualenv_python_symlink(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -262,9 +283,11 @@ class FollowLatestTests(unittest.TestCase):
                     "--config", str(script),
                     "--server-python", str(venv_python),
                     "--server-script", str(script),
+                    "--sample",
                 ])
         self.assertEqual(args.converter_python, venv_python.absolute())
         self.assertNotEqual(args.converter_python, real_python.resolve())
+        self.assertTrue(args.sample)
 
 
 if __name__ == "__main__":

--- a/stream_backend/test_follow_latest.py
+++ b/stream_backend/test_follow_latest.py
@@ -240,6 +240,18 @@ class FollowLatestTests(unittest.TestCase):
             "arm-seed-42-_torch.bin",
         )
 
+    def test_conversion_label_preserves_digest_and_prunable_suffix(self):
+        candidate = SimpleNamespace(
+            tag="vacation-" + "very-long-arm-name-" * 8,
+            step=1_598_160_896,
+        )
+
+        label = follow_latest._conversion_label(candidate, "a" * 64)
+
+        self.assertLessEqual(len(label), 96)
+        self.assertTrue(label.endswith("-aaaaaaaaaa_torch.bin"))
+        self.assertTrue(Path(label).match("*_torch.bin"))
+
     def test_server_command_forwards_sample_mode(self):
         args = SimpleNamespace(
             server_python=Path("viewer-python"),


### PR DESCRIPTION
## Summary

- add an explicit sampled-policy mode to the latest-checkpoint follower
- make the production BBTV launcher use sampled actions by default with a one-variable greedy rollback
- preserve digest-bearing `*_torch.bin` cache names for long experiment tags so bounded pruning actually works
- document viewer provenance and the qualitative-only evidence boundary

## Safety

- viewer-only; no trainer, reward, queue, checkpoint, or promotion changes
- exact child command remains recorded in `server_status.json`
- set `BBTV_SAMPLE=0` and restart only `bbstream.service` for immediate greedy rollback
- the cache-name correction causes at most one reconversion per selected pair, then restores the existing 24-file bound

## Verification

- `python3 -m unittest discover -s stream_backend -p "test_*.py"` (14 tests)
- `bash -n stream_backend/run_follow_latest.sh`
- `shellcheck -x stream_backend/run_follow_latest.sh`
- `git diff --check`

## Review coverage

- inline correctness/security/operational review completed
- external Codex CLI unavailable due a broken local binary installation
- Gemini CLI required interactive authentication and could not run headlessly
- full repository CI is required before merge