### PR TITLE
Preserve full checkpoint steps in BBTV labels

### DIFF
--- a/stream_backend/follow_latest.py
+++ b/stream_backend/follow_latest.py
@@ -164,8 +164,9 @@ def stable_native(path: Path, expected_bytes: int, seconds: float) -> os.stat_re
 
 
 def _conversion_label(candidate: Candidate, digest: str) -> str:
-    return _hashed_torch_label(
-        f"{candidate.tag}-step{candidate.step:012d}", digest
+    return _bounded_torch_label(
+        candidate.tag,
+        f"-step{candidate.step:012d}-{digest[:10]}_torch.bin",
     )
 
 
@@ -175,6 +176,10 @@ def _baseline_label(candidate: Candidate, digest: str) -> str:
 
 def _hashed_torch_label(prefix: str, digest: str) -> str:
     suffix = f"-{digest[:10]}_torch.bin"
+    return _bounded_torch_label(prefix, suffix)
+
+
+def _bounded_torch_label(prefix: str, suffix: str) -> str:
     prefix_budget = 96 - len(suffix)
     bounded_prefix = safe_label(prefix)[:prefix_budget].rstrip("-._")
     return f"{bounded_prefix or 'checkpoint'}{suffix}"

--- a/stream_backend/test_follow_latest.py
+++ b/stream_backend/test_follow_latest.py
@@ -240,7 +240,7 @@ class FollowLatestTests(unittest.TestCase):
             "arm-seed-42-_torch.bin",
         )
 
-    def test_conversion_label_preserves_digest_and_prunable_suffix(self):
+    def test_conversion_label_preserves_step_digest_and_prunable_suffix(self):
         candidate = SimpleNamespace(
             tag="vacation-" + "very-long-arm-name-" * 8,
             step=1_598_160_896,
@@ -249,7 +249,11 @@ class FollowLatestTests(unittest.TestCase):
         label = follow_latest._conversion_label(candidate, "a" * 64)
 
         self.assertLessEqual(len(label), 96)
-        self.assertTrue(label.endswith("-aaaaaaaaaa_torch.bin"))
+        self.assertTrue(
+            label.endswith(
+                "-step001598160896-aaaaaaaaaa_torch.bin"
+            )
+        )
         self.assertTrue(Path(label).match("*_torch.bin"))
 
     def test_server_command_forwards_sample_mode(self):


### PR DESCRIPTION
## Summary
- reserve the full 12-digit native checkpoint step before truncating long BBTV tags
- continue preserving the source digest and `_torch.bin` cache-pruning suffix
- pin the long-tag behavior with a regression test

## Verification
- `PYTHONPATH=stream_backend python3 -m unittest stream_backend.test_follow_latest` (14 tests)
- `python3 -m compileall -q stream_backend/follow_latest.py stream_backend/test_follow_latest.py`
- `git diff --check`

Viewer-only change; it does not touch the trainer, reward configuration, frozen queue, or checkpoint selection metadata.