### PR TITLE
feat: freeze long-horizon milestone evaluation

### DIFF
--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -564,6 +564,20 @@ runtime/progress/capacity/thermal guards cannot strand GPU work. Do not add an
 inner `setsid`, `nohup`, daemonizer, or process supervisor to a queue-owned
 training path.
 
+Post-run long-horizon characterization uses
+`tools/run_checkpoint_milestone_eval.py` under the fixed protocol in
+`docs/plans/r0-milestone-evaluation.md`. Accept only a completed and revalidated
+`control-final` screen. Resolve the predeclared 0/1/2/4/6/8/10/12B points by
+embedded native step (never mtime), freeze every hash before matching, use
+common seeds and both native backend roles, and require an exclusive idle GPU.
+Do not stop a training or BBTV process to make the evaluator run; remain
+pending. Label the vacation static banks as in-pool, historical exact anchors
+as lineage-connected transfer rather than independent holdout, scripted bots
+as functional probes, and forced rosters as stratification because procgen
+trained on every roster ID. The fixed plateau rule only compresses a later
+evaluation. It cannot select/promote a reward, mutate a queue, or change a
+production default.
+
 ---
 
 ## 12. Session checklist

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -569,9 +569,9 @@ Post-run long-horizon characterization uses
 `docs/plans/r0-milestone-evaluation.md`. Accept only a completed and revalidated
 `control-final` screen. Resolve the predeclared 0/1/2/4/6/8/10/12B points by
 embedded native step (never mtime), freeze every hash before matching, use
-common seeds and both native backend roles, and require an exclusive idle GPU.
-Do not stop a training or BBTV process to make the evaluator run; remain
-pending. Label the vacation static banks as in-pool, historical exact anchors
+common seeds and both native backend roles, and require an exclusive idle GPU
+with the BBTV follower explicitly quiesced. Do not stop a training or BBTV
+process to make the evaluator run; remain pending. Label the vacation static banks as in-pool, historical exact anchors
 as lineage-connected transfer rather than independent holdout, scripted bots
 as functional probes, and forced rosters as stratification because procgen
 trained on every roster ID. The fixed plateau rule only compresses a later

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             tools.test_freeze_vacation_queue \
             tools.test_freeze_vacation_overflow \
             tools.test_run_frozen_reward_screen \
+            tools.test_run_checkpoint_milestone_eval \
             tools.test_run_reward_learned_transfer \
             tools.test_start_vacation_overflow \
             tools.test_validate_primary_queue_completion \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,18 @@ primary plan, both original validators, primary-service inactivity, unchanged
 pins, and an idle GPU. Never append the active plan, deploy over one of its
 pinned files, start the overflow early, or timer-relaunch existing state.
 
+After an accepted R0 `control-final` screen, use
+`tools/run_checkpoint_milestone_eval.py` and
+`docs/plans/r0-milestone-evaluation.md` for the predeclared 0/1/2/4/6/8/10/12B
+trajectory. Resolve checkpoints by embedded step, hash every selected native
+file, and require an exclusive idle GPU; the evaluator must remain pending
+rather than stopping a training or BBTV process. Keep static-pool dashboard
+scores labeled in-pool, historical anchors labeled unseen exact checkpoints
+but lineage-connected, scripted bots separate, and the forced roster grid
+labeled stratification rather than unseen-roster transfer. The fixed plateau
+rule only nominates terminal/plateau policies for more evaluation. It never
+changes a reward, active queue, production default, or promotion verdict.
+
 ## Replay and BC contract
 
 - Filter by the embedded replay `rulesVersion`; filenames, directory names, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,8 +156,9 @@ After an accepted R0 `control-final` screen, use
 `tools/run_checkpoint_milestone_eval.py` and
 `docs/plans/r0-milestone-evaluation.md` for the predeclared 0/1/2/4/6/8/10/12B
 trajectory. Resolve checkpoints by embedded step, hash every selected native
-file, and require an exclusive idle GPU; the evaluator must remain pending
-rather than stopping a training or BBTV process. Keep static-pool dashboard
+file, and require an exclusive idle GPU with the BBTV follower explicitly
+quiesced; the evaluator must remain pending rather than stopping a training or
+BBTV process. Keep static-pool dashboard
 scores labeled in-pool, historical anchors labeled unseen exact checkpoints
 but lineage-connected, scripted bots separate, and the forced roster grid
 labeled stratification rather than unseen-roster transfer. The fixed plateau

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,19 @@ newer evidence wins.
   inactive primary service, unchanged pins, no prior overflow state, and no GPU
   compute PID. The overflow is third-ancestry characterization, never a reward
   rescue, candidate switch, promotion, or permission to edit the active plan.
+- Post-run R0 trajectory evaluation is frozen in
+  `docs/plans/r0-milestone-evaluation.md` and implemented by
+  `tools/run_checkpoint_milestone_eval.py`. It accepts only a completed,
+  revalidated `control-final` screen; resolves 0/1/2/4/6/8/10/12B native
+  checkpoints by embedded step; hashes spec, implementation, results,
+  checkpoints, anchors, cells, analysis, and completion; uses common match
+  seeds and both backend roles; and fails closed unless the GPU is exclusive.
+  Static-pool metrics are in-sample, exact historical anchors are
+  lineage-connected rather than independently held out, and a forced roster
+  grid is stratification because training sampled every roster. Plateau
+  nomination is for Stage-B compression only, never automatic selection or
+  promotion. Do not deploy this tool over the pinned live audit snapshot or
+  start it while primary/overflow/BBTV owns the GPU.
 
 ### Engine / rules / oracles (stable since v1)
 - PufferLib 4.0 (`vendor/PufferLib`, branch 4.0) uses `src/vecenv.h` macros — the online `env_binding.h` ABI is dead 3.0. `ocean/chess/` is the template; `ocean/convert/` is stale.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,13 +200,14 @@ newer evidence wins.
   revalidated `control-final` screen; resolves 0/1/2/4/6/8/10/12B native
   checkpoints by embedded step; hashes spec, implementation, results,
   checkpoints, anchors, cells, analysis, and completion; uses common match
-  seeds and both backend roles; and fails closed unless the GPU is exclusive.
+  seeds and both backend roles; and fails closed unless the GPU is exclusive
+  and the BBTV follower was explicitly quiesced.
   Static-pool metrics are in-sample, exact historical anchors are
   lineage-connected rather than independently held out, and a forced roster
   grid is stratification because training sampled every roster. Plateau
   nomination is for Stage-B compression only, never automatic selection or
   promotion. Do not deploy this tool over the pinned live audit snapshot or
-  start it while primary/overflow/BBTV owns the GPU.
+  start it while primary/overflow is live or BBTV remains active.
 
 ### Engine / rules / oracles (stable since v1)
 - PufferLib 4.0 (`vendor/PufferLib`, branch 4.0) uses `src/vecenv.h` macros — the online `env_binding.h` ABI is dead 3.0. `ocean/chess/` is the template; `ocean/convert/` is stale.

--- a/docs/plans/r0-milestone-evaluation.md
+++ b/docs/plans/r0-milestone-evaluation.md
@@ -189,9 +189,10 @@ The runner must:
    cell whose identity, implementation, checkpoint, game count, or integrity
    fields differ;
 6. hold the shared reward/evaluation GPU lock, bound each cell runtime, publish
-   atomic progress, and require an exclusive evaluation GPU gate. If a training
-   queue or BBTV match process still owns the GPU, remain pending and do not
-   stop it implicitly;
+   atomic progress, and require an exclusive evaluation GPU gate. The BBTV
+   follower must be explicitly quiesced first so it cannot start a new match
+   after an idle-PID check. If a training queue, other compute process, or BBTV
+   follower remains active, stay pending and do not stop it implicitly;
 7. write an analysis plus completion proof chaining the manifest and every
    cell SHA-256;
 8. make no automatic reward, checkpoint, production, or queue change.

--- a/docs/plans/r0-milestone-evaluation.md
+++ b/docs/plans/r0-milestone-evaluation.md
@@ -118,15 +118,17 @@ do not use a naive per-game binomial interval as the only uncertainty estimate.
 Stage A may nominate exactly two policies per seed/ancestry for Stage B:
 
 1. the exact 12B terminal checkpoint; and
-2. the earliest milestone whose equal-anchor macro score is within 0.01 of the
-   maximum Stage-A milestone and for which neither of the next two milestones
-   is more than 0.02 better.
+2. the earliest nonterminal milestone whose equal-anchor macro score is within
+   0.01 of the maximum Stage-A milestone and for which two later milestones
+   exist and neither is more than 0.02 better.
 
-If no milestone satisfies the second rule, use the highest-scoring milestone
-and label the choice exploratory. If the nominated point differs across seeds,
-preserve each seed's own nomination; never swap seed identities or choose one
-seed's visually best checkpoint for all seeds. This rule is a compression rule
-for additional evaluation, not a production-selection gate.
+If no milestone satisfies the second rule, use the highest-scoring nonterminal
+milestone and label the choice exploratory. This keeps the Stage-B comparator
+distinct from the terminal instead of allowing a vacuous terminal-vs-terminal
+comparison. If the nominated point differs across seeds, preserve each seed's
+own nomination; never swap seed identities or choose one seed's visually best
+checkpoint for all seeds. This rule is a compression rule for additional
+evaluation, not a production-selection gate.
 
 ## Stage B: transfer confirmation
 
@@ -172,6 +174,8 @@ training invalid and does not promote R0.
 
 The milestone evaluator must be a separate post-run tool and artifact tree. It
 must not modify or become an input to the active primary or overflow queues.
+The four learned anchors are ordered exactly as declared in the protocol; that
+order is part of the common-match-seed assignment and may not be permuted.
 
 The runner must:
 

--- a/docs/plans/r0-milestone-evaluation.md
+++ b/docs/plans/r0-milestone-evaluation.md
@@ -1,0 +1,243 @@
+# R0 long-horizon milestone evaluation
+
+Status: predeclared post-run research protocol. This document does not alter
+the active vacation queues, choose a checkpoint from live metrics, or authorize
+a reward/default promotion.
+
+## Question
+
+The vacation queues train unchanged R0 for 12B steps at seeds 42, 43, and 44
+from the turnover3, league9, and (conditionally) netblock ancestries. Their
+purpose is long-horizon seed/ancestry characterization after the `neither`
+simplification failed its frozen confirmation gate. They are not a reward A/B.
+
+The first main-arm trajectory improved against all four static training banks
+through 6B, but touchdowns and ball progress were non-monotonic. The post-run
+question is therefore:
+
+> Does R0's strength against fixed opponents continue improving from 0--12B,
+> plateau, or regress, and is the trajectory consistent across seeds and
+> ancestries?
+
+Training dashboards, BBTV games, human-stat proximity, and a single newest
+checkpoint cannot answer this question.
+
+## Evidence partitions
+
+Keep the following names exact in every artifact and report.
+
+1. **Training-pool evidence.** The learner was trained with the static
+   `league9`, `violence`, `netblock`, and `turnover3` banks. Dashboard
+   `historical_winrate` and any new matches against these four checkpoints are
+   in-pool measurements. They diagnose optimization but are not transfer.
+2. **Unseen-exact-checkpoint transfer.** Historical checkpoints such as
+   `statmatch1`, `league7b`, `exploiter1`, and `gen1` were not exact members of
+   the vacation static pool. They provide a fixed strength/style spread, but
+   the population is lineage-connected: several are ancestors of, or prior
+   opponents used to produce, later policies. Call them unseen exact
+   checkpoints, not independent held-out lineages.
+3. **Scripted transfer.** The contact and cage-advance bots are distinct fixed
+   policies and must be evaluated with both bot sides. Their deterministic
+   weaknesses make them functional probes, not a complete external standard.
+4. **Roster stratification.** Training procgen sampled all BB2025 roster IDs.
+   The forced matchup grid is an equal-weight stratified test of archetype and
+   matchup robustness, not unseen-roster generalization.
+
+In-sample, unseen-checkpoint, scripted, and roster-stratified results must be
+reported separately. No pooled headline may erase these partitions.
+
+## Frozen checkpoints
+
+For every accepted seed run, preserve the exact native checkpoint at or
+immediately before each target:
+
+```text
+0B warm, 1B, 2B, 4B, 6B, 8B, 10B, exact final 12B
+```
+
+For non-final targets, choose the greatest embedded checkpoint step not above
+the target. Require the gap to be no larger than one frozen checkpoint
+interval. The 12B point is the exact final checkpoint named by the accepted
+arm result. Record target step, embedded step, byte size, SHA-256, source run
+manifest, source result, screen completion, lineage, and training seed. Never
+select by modification time.
+
+The warm checkpoint is one shared baseline per ancestry, not three independent
+seed observations. Do not triple-count it in uncertainty estimates.
+
+## Stage A: fixed trajectory matrix
+
+Use the four unseen-exact-checkpoint anchors below after verifying their current
+native files, architecture, provenance, and SHA-256 on the evaluation host:
+
+| Anchor | Current RTX SHA-256 | Role |
+|---|---|---|
+| `statmatch1` | `85315d26a40f26a387ef28742b7f3306583ca73b488aae01e06c72566f5ab435` | historically strongest, distinct reward/style probe |
+| `league7b` | `2bf0815f506ac98e4972744903164673d40bee27b0b0c9197268b4c094fcdec1` | strong hard-pool policy and league-family reference |
+| `exploiter1` | `6373cfa349bab8eee133933d42b353e796d2693e4e85b5a285c999647b11771a` | deliberately non-transitive attack style |
+| `gen1` | `62f6fcbc111e3b319ac0158358f0211e8aaf460c88f49eee86ff4639a148945a` | stable non-degenerate floor |
+
+All four files were 16,066,560 bytes on the RTX host on 2026-07-14. The
+evaluator must re-hash them at freeze and before every cell; this table is
+provenance, not permission to ignore later drift.
+
+For every lineage, seed, and frozen milestone:
+
+- play 2,048 complete kickoff games per anchor and backend role;
+- load the focal checkpoint once as policy A and once as policy B;
+- use identical match seeds for all milestones within a
+  `(seed, anchor, backend role)` stratum;
+- keep `demo_reset_pct=0`, macro moves off, scripted opponent off, and procgen
+  roster settings unchanged;
+- require the native BB2025 GPU-fp32 module, observation size 2782, exact
+  implementation/config hashes, and zero clip, non-finite, error, demo, and
+  fallback counters;
+- store W/D/L-equivalent match score, draw rate, TD for/against, games, all
+  integrity fields, raw environment metrics, and immutable cell hashes.
+
+At eight checkpoints, three seeds, four anchors, two backend roles, and 2,048
+games, Stage A is 393,216 games per ancestry. This is descriptive trajectory
+evidence. One 2,048-game cell is not decision-grade inside a narrow Elo band.
+
+### Fixed summaries
+
+For each milestone report:
+
+- equal-anchor/equal-role macro mean and per-seed values;
+- per-anchor and per-backend-role means;
+- score, TD-for, and TD-against change from the ancestry warm checkpoint;
+- change from the preceding frozen milestone;
+- in-pool dashboard trajectory beside, never merged with, transfer results.
+
+Treat seeds, anchors, roles, and checkpoints as repeated strata rather than
+independent games. Report the raw paired strata and a seed-clustered bootstrap;
+do not use a naive per-game binomial interval as the only uncertainty estimate.
+
+## Fixed plateau rule
+
+Stage A may nominate exactly two policies per seed/ancestry for Stage B:
+
+1. the exact 12B terminal checkpoint; and
+2. the earliest milestone whose equal-anchor macro score is within 0.01 of the
+   maximum Stage-A milestone and for which neither of the next two milestones
+   is more than 0.02 better.
+
+If no milestone satisfies the second rule, use the highest-scoring milestone
+and label the choice exploratory. If the nominated point differs across seeds,
+preserve each seed's own nomination; never swap seed identities or choose one
+seed's visually best checkpoint for all seeds. This rule is a compression rule
+for additional evaluation, not a production-selection gate.
+
+## Stage B: transfer confirmation
+
+Evaluate the terminal and fixed-rule plateau nominees without changing them.
+
+### Scripted bots
+
+For both contact and cage-advance bots and both bot sides, run 4,096 full
+kickoff games per nominated checkpoint. Apply native-to-Torch conversion
+symmetrically where the scripted evaluator requires Torch, record input/output
+hashes, and remember that conversion zero-fills native biases. Use common eval
+seeds for terminal/plateau pairs.
+
+### Forced roster grid
+
+Use the audit's six fixed pairs in both home/away orders:
+
+| Pair | Team IDs |
+|---|---:|
+| Orc / Dwarf | 22 / 7 |
+| Orc / Wood Elf | 22 / 29 |
+| Skaven / Dark Elf | 24 / 6 |
+| Human / Necromantic Horror | 13 / 17 |
+| Goblin / Orc | 10 / 22 |
+| Tomb Kings / Wood Elf | 26 / 29 |
+
+Run each focal checkpoint against at least two fixed unseen-checkpoint anchors,
+in both backend roles, for 512 complete games per ordered matchup. Macro-average
+all ordered roster cells equally; do not allow common or high-throughput
+rosters to dominate. Report every critical cell, especially stunty/strength and
+slow/fast extremes.
+
+### Stage-B interpretation
+
+A terminal checkpoint is a long-horizon keeper only if its paired macro score
+is non-inferior to the plateau nominee, no critical roster cell has a material
+drop, and TD-against does not show a compensating defensive regression. A
+plateau nomination that wins Stage B can support an early-stopping hypothesis
+for a future matched run; it does not retroactively make the completed 12B
+training invalid and does not promote R0.
+
+## Immutable runner contract
+
+The milestone evaluator must be a separate post-run tool and artifact tree. It
+must not modify or become an input to the active primary or overflow queues.
+
+The runner must:
+
+1. require an accepted `control-final` `SCREEN_COMPLETE.json` and re-run the
+   existing analyzer/validator before discovering checkpoint directories;
+2. require a complete, absolute-path spec whose bytes are hashed before any
+   cell starts;
+3. resolve target steps once, hash every selected checkpoint, then freeze a
+   manifest that cannot be overwritten with different inputs;
+4. freeze the imported module, complete config tree, Puffer sources, runner,
+   analyzer, warm/result/run-manifest/screen-completion files, anchors,
+   checkpoint sizes/hashes, seeds, targets, match seeds, roster settings,
+   games, and integrity requirements;
+5. use one restart-validating atomic result per cell and reject an existing
+   cell whose identity, implementation, checkpoint, game count, or integrity
+   fields differ;
+6. hold the shared reward/evaluation GPU lock, bound each cell runtime, publish
+   atomic progress, and require an exclusive evaluation GPU gate. If a training
+   queue or BBTV match process still owns the GPU, remain pending and do not
+   stop it implicitly;
+7. write an analysis plus completion proof chaining the manifest and every
+   cell SHA-256;
+8. make no automatic reward, checkpoint, production, or queue change.
+
+The primary and optional overflow training queues remain the only unattended
+GPU work during the vacation. The evaluator may be merged and tested while
+training runs, but it should not be deployed into the pinned audit snapshot or
+started until the relevant source screen has completed and the GPU is idle.
+
+The per-lineage spec has this exact shape; replace only the output/source paths,
+completion hash, and matrix ID after the accepted screen exists:
+
+```json
+{
+  "schema_version": 1,
+  "matrix_id": "vacation-r0-main-milestones-v1",
+  "root": "/home/rache/bloodbowl-rl-audit",
+  "out_dir": "/home/rache/bloodbowl-rl-audit/runs/vacation-r0-main-milestones-v1",
+  "screen_complete": "/absolute/path/to/SCREEN_COMPLETE.json",
+  "screen_complete_sha256": "<lowercase SHA-256>",
+  "target_steps": [0, 1000000000, 2000000000, 4000000000, 6000000000, 8000000000, 10000000000, 12000000000],
+  "max_target_gap_steps": 50000000,
+  "games_per_cell": 2048,
+  "anchors": [
+    {"name": "statmatch1", "path": "/home/rache/bloodbowl-rl-audit/training/statmatch1_cap.bin", "bytes": 16066560, "sha256": "85315d26a40f26a387ef28742b7f3306583ca73b488aae01e06c72566f5ab435"},
+    {"name": "league7b", "path": "/home/rache/bloodbowl-rl-audit/training/league7b_cap.bin", "bytes": 16066560, "sha256": "2bf0815f506ac98e4972744903164673d40bee27b0b0c9197268b4c094fcdec1"},
+    {"name": "exploiter1", "path": "/home/rache/bloodbowl-rl-audit/training/v4_exploiter1_cap.bin", "bytes": 16066560, "sha256": "6373cfa349bab8eee133933d42b353e796d2693e4e85b5a285c999647b11771a"},
+    {"name": "gen1", "path": "/home/rache/bloodbowl-rl-audit/training/v4_contested_cap.bin", "bytes": 16066560, "sha256": "62f6fcbc111e3b319ac0158358f0211e8aaf460c88f49eee86ff4639a148945a"}
+  ],
+  "orientations": [0, 1]
+}
+```
+
+After review and an exclusive-GPU gate, first freeze without running cells:
+
+```bash
+python tools/run_checkpoint_milestone_eval.py --spec /absolute/spec.json --plan-only
+```
+
+The same command without `--plan-only` runs or restart-validates the matrix.
+Validation later uses `--validate-complete` plus the recorded completion SHA.
+
+## Promotion boundary
+
+This protocol characterizes R0 optimization length and ancestry sensitivity.
+It cannot settle the reward because every vacation arm uses the same reward.
+Any next reward change remains a matched causal experiment and must satisfy the
+July audit's learned-opponent, scripted, roster-grid, seed, ancestry, integrity,
+and production-review gates. BBTV remains qualitative throughout.

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -14,6 +14,7 @@ import argparse
 import datetime as dt
 import fcntl
 import hashlib
+import itertools
 import json
 import math
 import os
@@ -911,6 +912,39 @@ def mean(values: list[float]) -> float:
     return statistics.fmean(values)
 
 
+def percentile(sorted_values: list[float], probability: float) -> float:
+    if not sorted_values:
+        raise MilestoneEvalError("cannot take a percentile of an empty list")
+    if not 0.0 <= probability <= 1.0:
+        raise MilestoneEvalError("percentile probability is outside [0, 1]")
+    position = (len(sorted_values) - 1) * probability
+    lower = int(math.floor(position))
+    upper = int(math.ceil(position))
+    if lower == upper:
+        return sorted_values[lower]
+    fraction = position - lower
+    return sorted_values[lower] * (1.0 - fraction) + sorted_values[upper] * fraction
+
+
+def exact_cluster_bootstrap(values: list[float]) -> dict[str, Any]:
+    """Exact ordinary bootstrap over the three declared seed strata."""
+    if len(values) != len(CONTROL_SEEDS):
+        raise MilestoneEvalError(
+            f"cluster bootstrap requires exactly {len(CONTROL_SEEDS)} seed strata"
+        )
+    resampled = sorted(
+        mean(list(sample)) for sample in itertools.product(values, repeat=len(values))
+    )
+    return {
+        "mean": mean(values),
+        "sample_sd": statistics.stdev(values),
+        "lower_95": percentile(resampled, 0.025),
+        "upper_95": percentile(resampled, 0.975),
+        "clusters": len(values),
+        "exact_resamples": len(resampled),
+    }
+
+
 def nominate(points: list[dict[str, Any]]) -> dict[str, Any]:
     trained = [point for point in points if point["target_steps"] > 0]
     best_score = max(point["macro_score"] for point in trained)
@@ -997,6 +1031,37 @@ def analyze(directory: str | Path) -> dict[str, Any]:
             )
         trajectories[str(seed)] = points
         nominations[str(seed)] = nominate(points)
+    aggregate_trajectory = []
+    for index, target in enumerate(plan["target_steps"]):
+        seed_points = [
+            trajectories[str(seed)][index] for seed in plan["training_seeds"]
+        ]
+        aggregate_trajectory.append(
+            {
+                "target_steps": target,
+                "embedded_steps_by_seed": {
+                    str(seed): trajectories[str(seed)][index]["embedded_steps"]
+                    for seed in plan["training_seeds"]
+                },
+                "score": exact_cluster_bootstrap(
+                    [point["macro_score"] for point in seed_points]
+                ),
+                "score_delta_warm": exact_cluster_bootstrap(
+                    [point["score_delta_warm"] for point in seed_points]
+                ),
+                "tds_for_delta_warm": exact_cluster_bootstrap(
+                    [point["tds_for_delta_warm"] for point in seed_points]
+                ),
+                "tds_against_delta_warm": exact_cluster_bootstrap(
+                    [point["tds_against_delta_warm"] for point in seed_points]
+                ),
+                "cluster_unit": (
+                    "evaluation_seed_batch_for_shared_warm_policy"
+                    if target == 0
+                    else "training_seed"
+                ),
+            }
+        )
     return {
         "schema_version": SCHEMA_VERSION,
         "analysis": "control_final_checkpoint_milestones",
@@ -1007,11 +1072,14 @@ def analyze(directory: str | Path) -> dict[str, Any]:
         "total_games": sum(row["games"] for row in rows),
         "runs": rows,
         "trajectories": trajectories,
+        "aggregate_trajectory": aggregate_trajectory,
         "stage_b_nominations": nominations,
         "warning": (
             "These anchors are unseen exact checkpoints but lineage-connected. "
             "The fixed nomination compresses Stage B evaluation; it is not a "
-            "reward or production promotion gate."
+            "reward or production promotion gate. Exact ordinary bootstrap "
+            "intervals use only three seed strata and must be read with the "
+            "raw paired strata, not as high-powered confidence claims."
         ),
     }
 

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -281,6 +281,10 @@ def validate_spec(path: Path) -> dict[str, Any]:
         raise MilestoneEvalError(
             "anchor names/hashes differ from the predeclared transfer set"
         )
+    if [record["name"] for record in anchors] != list(FIXED_ANCHOR_SHA256):
+        raise MilestoneEvalError(
+            "anchor order differs from the predeclared common-seed strata"
+        )
     return {
         "schema_version": SCHEMA_VERSION,
         "matrix_id": matrix_id,
@@ -613,6 +617,8 @@ def validate_plan_contract(plan: dict[str, Any]) -> None:
     anchors = plan.get("anchors")
     if (
         not isinstance(anchors, list)
+        or [record.get("name") for record in anchors if isinstance(record, dict)]
+        != list(FIXED_ANCHOR_SHA256)
         or {
             record.get("name"): record.get("sha256")
             for record in anchors
@@ -1055,7 +1061,10 @@ def exact_cluster_bootstrap(values: list[float]) -> dict[str, Any]:
 def nominate(points: list[dict[str, Any]]) -> dict[str, Any]:
     trained = [point for point in points if point["target_steps"] > 0]
     best_score = max(point["macro_score"] for point in trained)
-    for index, point in enumerate(trained):
+    # A plateau comparator must be distinct from the terminal and must have two
+    # later observed milestones. Otherwise "neither of the next two" would be
+    # satisfied vacuously and Stage B could degenerate into terminal vs itself.
+    for index, point in enumerate(trained[:-2]):
         if point["macro_score"] < best_score - 0.01:
             continue
         later = trained[index + 1 : index + 3]
@@ -1066,14 +1075,20 @@ def nominate(points: list[dict[str, Any]]) -> dict[str, Any]:
             return {
                 "target_steps": point["target_steps"],
                 "embedded_steps": point["embedded_steps"],
-                "rule": "earliest_within_0.01_of_max_without_next_two_gt_0.02",
+                "rule": (
+                    "earliest_nonterminal_within_0.01_of_max_"
+                    "without_next_two_gt_0.02"
+                ),
                 "exploratory": False,
             }
-    best = max(trained, key=lambda point: point["macro_score"])
+    nonterminal = trained[:-1]
+    if not nonterminal:
+        raise MilestoneEvalError("plateau nomination requires a nonterminal milestone")
+    best = max(nonterminal, key=lambda point: point["macro_score"])
     return {
         "target_steps": best["target_steps"],
         "embedded_steps": best["embedded_steps"],
-        "rule": "highest_scoring_fallback",
+        "rule": "highest_scoring_nonterminal_fallback",
         "exploratory": True,
     }
 

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -1,0 +1,1132 @@
+#!/usr/bin/env python3
+"""Freeze, run, and verify a long-horizon checkpoint milestone matrix.
+
+This is a post-run evaluator for an accepted ``control-final`` reward screen.
+It resolves predeclared target steps to exact native checkpoints, hashes every
+input, and evaluates each seed/milestone against fixed learned anchors in both
+native backend roles.  It never changes a reward, training queue, checkpoint,
+or production default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import math
+import os
+import re
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import analyze_reward_screen
+import run_reward_candidate_transfer
+
+
+SCHEMA_VERSION = 1
+EXPECTED_NATIVE_BYTES = 16_066_560
+CONTROL_SEEDS = (42, 43, 44)
+INTEGRITY_KEYS = (
+    "reward_clip_frac",
+    "reward_clip_frac_nonzero",
+    "reward_clip_excess",
+    "reward_nonfinite_frac",
+    "reward_clip_episodes",
+    "reward_nonfinite_episodes",
+    "error_episodes",
+    "demo_episodes",
+    "demo_fallbacks",
+)
+NAME_PATTERN = re.compile(r"[a-z][a-z0-9_-]{0,63}")
+SHA_PATTERN = re.compile(r"[0-9a-f]{64}")
+SPEC_KEYS = {
+    "schema_version",
+    "matrix_id",
+    "root",
+    "out_dir",
+    "screen_complete",
+    "screen_complete_sha256",
+    "target_steps",
+    "max_target_gap_steps",
+    "games_per_cell",
+    "anchors",
+    "orientations",
+}
+
+
+class MilestoneEvalError(ValueError):
+    pass
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: str | Path, payload: dict[str, Any]) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + f".tmp.{os.getpid()}")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, destination)
+
+
+def load_object(path: str | Path, label: str) -> dict[str, Any]:
+    path = Path(path)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MilestoneEvalError(f"invalid {label}: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise MilestoneEvalError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def need_sha(value: Any, label: str) -> str:
+    if not isinstance(value, str) or SHA_PATTERN.fullmatch(value) is None:
+        raise MilestoneEvalError(f"{label} must be a lowercase SHA-256")
+    return value
+
+
+def finite(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise MilestoneEvalError(f"{label} must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise MilestoneEvalError(f"{label} must be finite")
+    return result
+
+
+def positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise MilestoneEvalError(f"{label} must be a positive integer")
+    return value
+
+
+def absolute_file(value: Any, label: str) -> Path:
+    if not isinstance(value, str) or not Path(value).is_absolute():
+        raise MilestoneEvalError(f"{label} must be an absolute path")
+    path = Path(value).expanduser().resolve()
+    if not path.is_file():
+        raise MilestoneEvalError(f"missing {label}: {path}")
+    return path
+
+
+def under_root(path: Path, root: Path, label: str) -> Path:
+    path = path.expanduser().resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise MilestoneEvalError(f"{label} escapes root {root}: {path}") from exc
+    return path
+
+
+def validate_spec(path: Path) -> dict[str, Any]:
+    raw = load_object(path, "milestone spec")
+    if set(raw) != SPEC_KEYS:
+        raise MilestoneEvalError(
+            "milestone spec fields differ; "
+            f"unknown={sorted(set(raw) - SPEC_KEYS)}, "
+            f"missing={sorted(SPEC_KEYS - set(raw))}"
+        )
+    if raw.get("schema_version") != SCHEMA_VERSION:
+        raise MilestoneEvalError("unsupported milestone spec schema")
+    matrix_id = raw.get("matrix_id")
+    if not isinstance(matrix_id, str) or NAME_PATTERN.fullmatch(matrix_id) is None:
+        raise MilestoneEvalError("matrix_id has unsupported characters")
+    root_value = raw.get("root")
+    if not isinstance(root_value, str) or not Path(root_value).is_absolute():
+        raise MilestoneEvalError("root must be an absolute path")
+    root = Path(root_value).expanduser().resolve()
+    if not root.is_dir():
+        raise MilestoneEvalError(f"root is missing: {root}")
+    if root != Path(__file__).resolve().parents[1]:
+        raise MilestoneEvalError("spec root differs from the runner checkout")
+    out_value = raw.get("out_dir")
+    if not isinstance(out_value, str) or not Path(out_value).is_absolute():
+        raise MilestoneEvalError("out_dir must be an absolute path")
+    out_dir = under_root(Path(out_value), root, "out_dir")
+    screen_complete = under_root(
+        absolute_file(raw.get("screen_complete"), "screen completion"),
+        root,
+        "screen completion",
+    )
+    if screen_complete.name != "SCREEN_COMPLETE.json":
+        raise MilestoneEvalError("screen completion must be SCREEN_COMPLETE.json")
+    expected_screen_sha = need_sha(
+        raw.get("screen_complete_sha256"), "screen completion SHA-256"
+    )
+    if sha256(screen_complete) != expected_screen_sha:
+        raise MilestoneEvalError("screen completion SHA-256 drift")
+    targets = raw.get("target_steps")
+    if (
+        not isinstance(targets, list)
+        or not targets
+        or any(isinstance(v, bool) or not isinstance(v, int) or v < 0 for v in targets)
+        or targets != sorted(set(targets))
+        or targets[0] != 0
+    ):
+        raise MilestoneEvalError(
+            "target_steps must be unique increasing nonnegative integers starting at 0"
+        )
+    max_gap = positive_int(raw.get("max_target_gap_steps"), "max_target_gap_steps")
+    games = positive_int(raw.get("games_per_cell"), "games_per_cell")
+    if games < 1_000:
+        raise MilestoneEvalError("games_per_cell must be at least 1000")
+    orientations = raw.get("orientations")
+    if orientations != [0, 1]:
+        raise MilestoneEvalError("orientations must be exactly [0, 1]")
+    anchors_raw = raw.get("anchors")
+    if not isinstance(anchors_raw, list) or len(anchors_raw) < 2:
+        raise MilestoneEvalError("at least two anchors are required")
+    anchors = []
+    names: set[str] = set()
+    hashes: set[str] = set()
+    for index, record in enumerate(anchors_raw, 1):
+        if not isinstance(record, dict) or set(record) != {
+            "name",
+            "path",
+            "bytes",
+            "sha256",
+        }:
+            raise MilestoneEvalError(
+                f"anchor {index} must contain name/path/bytes/sha256"
+            )
+        name = record.get("name")
+        if not isinstance(name, str) or NAME_PATTERN.fullmatch(name) is None:
+            raise MilestoneEvalError(f"anchor {index} has an invalid name")
+        if name in names:
+            raise MilestoneEvalError(f"duplicate anchor name: {name}")
+        names.add(name)
+        anchor = under_root(
+            absolute_file(record.get("path"), f"anchor {name}"), root, f"anchor {name}"
+        )
+        size = positive_int(record.get("bytes"), f"anchor {name} bytes")
+        if size != EXPECTED_NATIVE_BYTES or anchor.stat().st_size != size:
+            raise MilestoneEvalError(f"anchor {name} architecture/size drift")
+        expected = need_sha(record.get("sha256"), f"anchor {name} SHA-256")
+        if sha256(anchor) != expected:
+            raise MilestoneEvalError(f"anchor {name} SHA-256 drift")
+        if expected in hashes:
+            raise MilestoneEvalError(f"anchor {name} duplicates another checkpoint")
+        hashes.add(expected)
+        anchors.append(
+            {"name": name, "path": str(anchor), "bytes": size, "sha256": expected}
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "matrix_id": matrix_id,
+        "root": str(root),
+        "out_dir": str(out_dir),
+        "screen_complete": str(screen_complete),
+        "screen_complete_sha256": expected_screen_sha,
+        "target_steps": targets,
+        "max_target_gap_steps": max_gap,
+        "games_per_cell": games,
+        "anchors": anchors,
+        "orientations": orientations,
+        "spec_path": str(path.resolve()),
+        "spec_sha256": sha256(path),
+    }
+
+
+def checkpoint_files(run_dir: Path) -> list[tuple[int, Path]]:
+    rows = []
+    for path in run_dir.glob("*.bin"):
+        if path.stem.isdigit():
+            rows.append((int(path.stem), path.resolve()))
+    rows.sort()
+    if not rows:
+        raise MilestoneEvalError(f"run has no native checkpoints: {run_dir}")
+    if len({step for step, _ in rows}) != len(rows):
+        raise MilestoneEvalError(f"run has duplicate embedded steps: {run_dir}")
+    return rows
+
+
+def resolve_target(
+    rows: list[tuple[int, Path]], target: int, max_gap: int
+) -> tuple[int, Path]:
+    eligible = [row for row in rows if row[0] <= target]
+    if not eligible:
+        raise MilestoneEvalError(f"no checkpoint exists at or before {target}")
+    step, path = eligible[-1]
+    if target - step > max_gap:
+        raise MilestoneEvalError(
+            f"checkpoint gap exceeds contract at target {target}: {target - step}"
+        )
+    return step, path
+
+
+def implementation_identity(root: Path) -> dict[str, Any]:
+    python = root / "vendor/PufferLib/.venv/bin/python"
+    probe = subprocess.run(
+        [
+            str(python),
+            "-c",
+            (
+                "from pufferlib import _C; print(_C.__file__); "
+                "print(_C.env_name, int(bool(_C.gpu)), int(_C.precision_bytes))"
+            ),
+        ],
+        cwd=root / "vendor/PufferLib",
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    if probe.returncode != 0:
+        raise MilestoneEvalError(f"native module probe failed: {probe.stdout[-2000:]}")
+    lines = [line.strip() for line in probe.stdout.splitlines() if line.strip()]
+    if len(lines) != 2:
+        raise MilestoneEvalError(f"unexpected native module probe: {probe.stdout!r}")
+    module = Path(lines[0]).resolve()
+    try:
+        env_name, gpu, precision = lines[1].split()
+    except ValueError as exc:
+        raise MilestoneEvalError(f"unexpected native probe fields: {lines[1]}") from exc
+    if (env_name, gpu, precision) != ("bloodbowl", "1", "4"):
+        raise MilestoneEvalError(
+            f"milestone eval requires bloodbowl GPU fp32; got {lines[1]}"
+        )
+    files = {
+        "compiled_module": module,
+        "package_init": root / "vendor/PufferLib/pufferlib/__init__.py",
+        "default_config": root / "vendor/PufferLib/config/default.ini",
+        "env_config": root / "vendor/PufferLib/config/bloodbowl.ini",
+        "pufferl": root / "vendor/PufferLib/pufferlib/pufferl.py",
+        "models": root / "vendor/PufferLib/pufferlib/models.py",
+        "selfplay": root / "vendor/PufferLib/pufferlib/selfplay.py",
+        "runner": Path(__file__).resolve(),
+        "screen_analyzer": root / "tools/analyze_reward_screen.py",
+    }
+    for label, path in files.items():
+        if not path.is_file():
+            raise MilestoneEvalError(f"missing implementation file {label}: {path}")
+    config_tree = root / "vendor/PufferLib/config"
+    return {
+        "env_name": env_name,
+        "gpu": int(gpu),
+        "precision_bytes": int(precision),
+        "config_tree_path": str(config_tree.resolve()),
+        "config_tree_sha256": run_reward_candidate_transfer.tree_sha256(config_tree),
+        **{f"{key}_path": str(path) for key, path in files.items()},
+        **{f"{key}_sha256": sha256(path) for key, path in files.items()},
+    }
+
+
+def source_screen(spec: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    complete = Path(spec["screen_complete"])
+    directory = complete.parent
+    completion = load_object(complete, "screen completion")
+    manifest_sha = need_sha(
+        completion.get("screen_manifest_sha256"),
+        "screen completion manifest SHA-256",
+    )
+    report = analyze_reward_screen.analyze_screen(
+        directory,
+        analyze_reward_screen.DEFAULT_METRICS,
+        expected_screen_sha=manifest_sha,
+    )
+    if report["screen"]["profile"] != "control-final":
+        raise MilestoneEvalError("milestone eval requires a control-final screen")
+    proof = report["screen"]["completion"]
+    if (
+        not proof.get("present")
+        or proof.get("sha256") != spec["screen_complete_sha256"]
+    ):
+        raise MilestoneEvalError("screen completion evidence is not exact")
+    manifest_path = directory / "SCREEN_MANIFEST.json"
+    manifest = load_object(manifest_path, "screen manifest")
+    if sha256(manifest_path) != manifest_sha:
+        raise MilestoneEvalError("screen manifest SHA-256 drift")
+    contract = manifest.get("contract")
+    if not isinstance(contract, dict):
+        raise MilestoneEvalError("screen manifest has no contract")
+    schedule = contract.get("schedule")
+    expected_schedule = [
+        {"index": index + 1, "arm": "both", "seed": seed}
+        for index, seed in enumerate(CONTROL_SEEDS)
+    ]
+    if schedule != expected_schedule:
+        raise MilestoneEvalError("control-final screen schedule is not seeds 42/43/44")
+    if spec["target_steps"][-1] != int(contract.get("requested_steps", -1)):
+        raise MilestoneEvalError("last target must equal screen requested_steps")
+    return report, manifest
+
+
+def resolve_checkpoints(
+    spec: dict[str, Any], report: dict[str, Any], manifest: dict[str, Any]
+) -> dict[str, list[dict[str, Any]]]:
+    root = Path(spec["root"])
+    directory = Path(spec["screen_complete"]).parent
+    prefix = report["screen"]["prefix"]
+    warm_record = manifest["contract"].get("warm")
+    if not isinstance(warm_record, dict):
+        raise MilestoneEvalError("screen manifest has no warm checkpoint identity")
+    warm = under_root(
+        absolute_file(warm_record.get("path"), "warm checkpoint"),
+        root,
+        "warm checkpoint",
+    )
+    if warm.stat().st_size != EXPECTED_NATIVE_BYTES:
+        raise MilestoneEvalError("warm checkpoint architecture/size drift")
+    warm_sha = need_sha(warm_record.get("sha256"), "warm checkpoint SHA-256")
+    if sha256(warm) != warm_sha:
+        raise MilestoneEvalError("warm checkpoint SHA-256 drift")
+    checkpoints: dict[str, list[dict[str, Any]]] = {}
+    for seed in CONTROL_SEEDS:
+        result_path = directory / f"{prefix}-both-s{seed}.result.json"
+        result = load_object(result_path, f"screen result seed {seed}")
+        if result.get("acceptance_pass") is not True or result.get("seed") != seed:
+            raise MilestoneEvalError(f"seed {seed} result is not accepted/exact")
+        final_path = under_root(
+            absolute_file(result.get("checkpoint"), f"seed {seed} final"),
+            root,
+            f"seed {seed} final",
+        )
+        if final_path.stat().st_size != EXPECTED_NATIVE_BYTES:
+            raise MilestoneEvalError(f"seed {seed} final checkpoint size drift")
+        final_sha = need_sha(
+            result.get("checkpoint_sha256"), f"seed {seed} final SHA-256"
+        )
+        if sha256(final_path) != final_sha:
+            raise MilestoneEvalError(f"seed {seed} final checkpoint SHA-256 drift")
+        if not final_path.stem.isdigit():
+            raise MilestoneEvalError(
+                f"seed {seed} final checkpoint has no embedded step"
+            )
+        final_embedded = int(final_path.stem)
+        final_target = spec["target_steps"][-1]
+        if (
+            final_embedded > final_target
+            or final_target - final_embedded > spec["max_target_gap_steps"]
+        ):
+            raise MilestoneEvalError(
+                f"seed {seed} final checkpoint misses the target-step contract"
+            )
+        run_dir = under_root(final_path.parent, root, f"seed {seed} run directory")
+        run_manifest = run_dir / "RUN_MANIFEST.json"
+        if not run_manifest.is_file():
+            raise MilestoneEvalError(f"seed {seed} run manifest is missing")
+        if sha256(run_manifest) != result.get("run_manifest_sha256"):
+            raise MilestoneEvalError(f"seed {seed} run manifest SHA-256 drift")
+        rows = checkpoint_files(run_dir)
+        records = [
+            {
+                "target_steps": 0,
+                "embedded_steps": 0,
+                "native": str(warm),
+                "native_bytes": warm.stat().st_size,
+                "native_sha256": warm_sha,
+                "source": "warm",
+            }
+        ]
+        for target in spec["target_steps"][1:-1]:
+            embedded, checkpoint = resolve_target(
+                rows, target, spec["max_target_gap_steps"]
+            )
+            if checkpoint.stat().st_size != EXPECTED_NATIVE_BYTES:
+                raise MilestoneEvalError(
+                    f"seed {seed} target {target} checkpoint size drift"
+                )
+            records.append(
+                {
+                    "target_steps": target,
+                    "embedded_steps": embedded,
+                    "native": str(checkpoint),
+                    "native_bytes": checkpoint.stat().st_size,
+                    "native_sha256": sha256(checkpoint),
+                    "source": "interval",
+                }
+            )
+        records.append(
+            {
+                "target_steps": spec["target_steps"][-1],
+                "embedded_steps": final_embedded,
+                "native": str(final_path),
+                "native_bytes": final_path.stat().st_size,
+                "native_sha256": final_sha,
+                "source": "accepted_final",
+            }
+        )
+        for record in records:
+            record.update(
+                {
+                    "training_seed": seed,
+                    "screen_result": str(result_path.resolve()),
+                    "screen_result_sha256": sha256(result_path),
+                    "run_manifest": str(run_manifest.resolve()),
+                    "run_manifest_sha256": sha256(run_manifest),
+                }
+            )
+        checkpoints[str(seed)] = records
+    return checkpoints
+
+
+def freeze_manifest(spec: dict[str, Any]) -> dict[str, Any]:
+    report, screen_manifest = source_screen(spec)
+    root = Path(spec["root"])
+    checkpoints = resolve_checkpoints(spec, report, screen_manifest)
+    core = {
+        "schema_version": SCHEMA_VERSION,
+        "matrix_id": spec["matrix_id"],
+        "spec": spec["spec_path"],
+        "spec_sha256": spec["spec_sha256"],
+        "screen_complete": spec["screen_complete"],
+        "screen_complete_sha256": spec["screen_complete_sha256"],
+        "screen_manifest_sha256": report["screen"]["manifest_sha256"],
+        "profile": "control-final",
+        "training_seeds": list(CONTROL_SEEDS),
+        "target_steps": spec["target_steps"],
+        "max_target_gap_steps": spec["max_target_gap_steps"],
+        "games_per_cell": spec["games_per_cell"],
+        "orientations": spec["orientations"],
+        "anchors": spec["anchors"],
+        "checkpoints": checkpoints,
+        "implementation": implementation_identity(root),
+    }
+    out_dir = Path(spec["out_dir"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "MILESTONE_EVAL_MANIFEST.json"
+    if path.exists():
+        recorded = load_object(path, "milestone manifest")
+        if {key: recorded.get(key) for key in core} != core:
+            raise MilestoneEvalError(
+                "existing milestone manifest differs from recomputed plan"
+            )
+        return recorded
+    payload = {**core, "created_utc": utc_now()}
+    atomic_json(path, payload)
+    return payload
+
+
+def checkpoint_record(plan: dict[str, Any], seed: int, target: int) -> dict[str, Any]:
+    matches = [
+        row for row in plan["checkpoints"][str(seed)] if row["target_steps"] == target
+    ]
+    if len(matches) != 1:
+        raise MilestoneEvalError(f"missing/duplicate seed {seed} target {target}")
+    return matches[0]
+
+
+def cell_filename(seed: int, target: int, anchor: str, orientation: int) -> str:
+    return f"s{seed}-t{target:012d}-{anchor}-o{orientation}.json"
+
+
+def expected_cells(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for seed_index, seed in enumerate(plan["training_seeds"]):
+        for target in plan["target_steps"]:
+            for anchor_index, anchor in enumerate(plan["anchors"]):
+                for orientation in plan["orientations"]:
+                    rows.append(
+                        {
+                            "training_seed": seed,
+                            "target_steps": target,
+                            "anchor": anchor["name"],
+                            "orientation": orientation,
+                            # Common across milestones in the same stratum.
+                            "match_seed": (
+                                30_000
+                                + seed_index * 1_000
+                                + anchor_index * 10
+                                + orientation
+                            ),
+                            "path": cell_filename(
+                                seed, target, anchor["name"], orientation
+                            ),
+                        }
+                    )
+    return rows
+
+
+def validate_cell(
+    path: Path, plan: dict[str, Any], expected: dict[str, Any]
+) -> dict[str, Any]:
+    cell = load_object(path, "milestone cell")
+    if cell.get("schema_version") != SCHEMA_VERSION:
+        raise MilestoneEvalError(f"unsupported cell schema: {path.name}")
+    identity = {
+        "training_seed": expected["training_seed"],
+        "target_steps": expected["target_steps"],
+        "anchor": expected["anchor"],
+        "orientation": expected["orientation"],
+        "match_seed": expected["match_seed"],
+        "games_requested": plan["games_per_cell"],
+        "milestone_eval_manifest_sha256": sha256(
+            path.parent / "MILESTONE_EVAL_MANIFEST.json"
+        ),
+    }
+    for key, value in identity.items():
+        if cell.get(key) != value:
+            raise MilestoneEvalError(
+                f"{path.name} {key}={cell.get(key)!r}, expected {value!r}"
+            )
+    if cell.get("implementation") != plan.get("implementation"):
+        raise MilestoneEvalError(f"{path.name} implementation identity drift")
+    checkpoint = checkpoint_record(
+        plan, expected["training_seed"], expected["target_steps"]
+    )
+    anchor = next(x for x in plan["anchors"] if x["name"] == expected["anchor"])
+    if cell.get("focal_checkpoint_sha256") != checkpoint["native_sha256"]:
+        raise MilestoneEvalError(f"{path.name} focal checkpoint drift")
+    if cell.get("anchor_checkpoint_sha256") != anchor["sha256"]:
+        raise MilestoneEvalError(f"{path.name} anchor checkpoint drift")
+    games = finite(cell.get("games"), f"{path.name} games")
+    if games < plan["games_per_cell"]:
+        raise MilestoneEvalError(f"{path.name} completed too few games")
+    focal = finite(cell.get("focal_score"), f"{path.name} focal score")
+    opponent = finite(cell.get("opponent_score"), f"{path.name} opponent score")
+    draw = finite(cell.get("draw_rate"), f"{path.name} draw rate")
+    focal_win = finite(cell.get("focal_win_rate"), f"{path.name} focal win rate")
+    focal_loss = finite(cell.get("focal_loss_rate"), f"{path.name} focal loss rate")
+    focal_tds = finite(cell.get("focal_tds"), f"{path.name} focal TDs")
+    opponent_tds = finite(cell.get("opponent_tds"), f"{path.name} opponent TDs")
+    if min(focal, opponent, draw) < -1e-6 or max(focal, opponent, draw) > 1 + 1e-6:
+        raise MilestoneEvalError(f"{path.name} contains impossible rates")
+    if abs(focal + opponent - 1.0) > 2e-4:
+        raise MilestoneEvalError(f"{path.name} slot scores do not sum to one")
+    if (
+        abs(focal_win - (focal - 0.5 * draw)) > 2e-4
+        or abs(focal_loss - (opponent - 0.5 * draw)) > 2e-4
+        or min(focal_win, focal_loss) < -1e-6
+    ):
+        raise MilestoneEvalError(f"{path.name} contains inconsistent W/D/L rates")
+    if focal_tds < 0 or opponent_tds < 0:
+        raise MilestoneEvalError(f"{path.name} contains impossible TD rates")
+    integrity = cell.get("integrity")
+    if not isinstance(integrity, dict) or set(integrity) != set(INTEGRITY_KEYS):
+        raise MilestoneEvalError(f"{path.name} integrity fields are incomplete")
+    parsed_integrity = {
+        key: finite(value, f"{path.name} integrity.{key}")
+        for key, value in integrity.items()
+    }
+    bad = {key: value for key, value in parsed_integrity.items() if value != 0.0}
+    if bad:
+        raise MilestoneEvalError(f"{path.name} integrity counters nonzero: {bad}")
+    return {
+        **identity,
+        "embedded_steps": checkpoint["embedded_steps"],
+        "games": games,
+        "focal_score": focal,
+        "opponent_score": opponent,
+        "draw_rate": draw,
+        "focal_win_rate": focal_win,
+        "focal_loss_rate": focal_loss,
+        "focal_tds": focal_tds,
+        "opponent_tds": opponent_tds,
+        "focal_checkpoint_sha256": checkpoint["native_sha256"],
+        "anchor_checkpoint_sha256": anchor["sha256"],
+        "file": path.name,
+        "file_sha256": sha256(path),
+    }
+
+
+def verify_implementation(plan: dict[str, Any]) -> None:
+    implementation = plan["implementation"]
+    for key in (
+        "compiled_module",
+        "package_init",
+        "default_config",
+        "env_config",
+        "pufferl",
+        "models",
+        "selfplay",
+        "runner",
+        "screen_analyzer",
+    ):
+        path = Path(implementation[f"{key}_path"])
+        if not path.is_file() or sha256(path) != implementation[f"{key}_sha256"]:
+            raise MilestoneEvalError(f"implementation drift before cell: {key}")
+    config_tree = Path(implementation["config_tree_path"])
+    if (
+        not config_tree.is_dir()
+        or run_reward_candidate_transfer.tree_sha256(config_tree)
+        != implementation["config_tree_sha256"]
+    ):
+        raise MilestoneEvalError("implementation drift before cell: config_tree")
+
+
+def require_idle_gpu() -> None:
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-compute-apps=pid,process_name",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        raise MilestoneEvalError(
+            f"cannot prove an idle evaluation GPU: {result.stdout[-1000:]}"
+        )
+    owners = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if owners:
+        raise MilestoneEvalError(
+            "evaluation GPU is not exclusive; existing compute owners: "
+            + "; ".join(owners)
+        )
+
+
+def run_cell(root: Path, plan_path: Path, cell_path: Path) -> int:
+    plan = load_object(plan_path, "milestone manifest")
+    expected = next(
+        (row for row in expected_cells(plan) if row["path"] == cell_path.name), None
+    )
+    if expected is None:
+        raise MilestoneEvalError(f"unplanned milestone cell: {cell_path}")
+    require_idle_gpu()
+    verify_implementation(plan)
+    checkpoint = checkpoint_record(
+        plan, expected["training_seed"], expected["target_steps"]
+    )
+    anchor = next(x for x in plan["anchors"] if x["name"] == expected["anchor"])
+    for record, path_key, hash_key, label in (
+        (checkpoint, "native", "native_sha256", "focal"),
+        (anchor, "path", "sha256", "anchor"),
+    ):
+        path = Path(record[path_key])
+        if not path.is_file() or sha256(path) != record[hash_key]:
+            raise MilestoneEvalError(f"{label} checkpoint drift before cell")
+    sys.path.insert(0, str(root / "vendor/PufferLib"))
+    from pufferlib import _C  # type: ignore
+    from pufferlib import pufferl  # type: ignore
+
+    implementation = plan["implementation"]
+    imported = Path(_C.__file__).resolve()
+    if (
+        getattr(_C, "env_name", None) != "bloodbowl"
+        or not bool(getattr(_C, "gpu", False))
+        or int(_C.precision_bytes) != 4
+        or imported != Path(implementation["compiled_module_path"]).resolve()
+        or sha256(imported) != implementation["compiled_module_sha256"]
+    ):
+        raise MilestoneEvalError("cell imported the wrong native module")
+    args = pufferl.load_config("bloodbowl")
+    args["train"]["gpus"] = 1
+    args["train"]["seed"] = expected["match_seed"]
+    args["env"]["seed"] = expected["match_seed"]
+    args["env"]["macro_moves"] = 0
+    args["env"]["demo_reset_pct"] = 0.0
+    args["env"]["scripted_opponent"] = 0
+    args["env"]["exclude_team"] = -1
+    args["env"]["force_home_team"] = -1
+    args["env"]["force_away_team"] = -1
+    args["vec"]["num_threads"] = 16
+    focal_path = checkpoint["native"]
+    anchor_path = anchor["path"]
+    if expected["orientation"] == 0:
+        policy_a, policy_b = focal_path, anchor_path
+        focal_key, opponent_key = "env/slot_0_score", "env/slot_1_score"
+        focal_tds_key, opponent_tds_key = "env/tds_t0", "env/tds_t1"
+    else:
+        policy_a, policy_b = anchor_path, focal_path
+        focal_key, opponent_key = "env/slot_1_score", "env/slot_0_score"
+        focal_tds_key, opponent_tds_key = "env/tds_t1", "env/tds_t0"
+    logs = pufferl.match(
+        env_name="bloodbowl",
+        policy_a_path=policy_a,
+        policy_b_path=policy_b,
+        num_games=plan["games_per_cell"],
+        args=args,
+        verbose=False,
+    )
+    numeric = {
+        key: finite(value, f"match log {key}")
+        for key, value in logs.items()
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    }
+    required = [
+        "env/n",
+        focal_key,
+        opponent_key,
+        "env/draw_rate",
+        focal_tds_key,
+        opponent_tds_key,
+        *(f"env/{key}" for key in INTEGRITY_KEYS),
+    ]
+    missing = [key for key in required if key not in numeric]
+    if missing:
+        raise MilestoneEvalError(f"match omitted required keys: {missing}")
+    if numeric["env/n"] < plan["games_per_cell"]:
+        raise MilestoneEvalError("match returned too few completed games")
+    integrity = {key: numeric[f"env/{key}"] for key in INTEGRITY_KEYS}
+    bad = {key: value for key, value in integrity.items() if value != 0.0}
+    if bad:
+        raise MilestoneEvalError(f"match integrity counters nonzero: {bad}")
+    atomic_json(
+        cell_path,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "created_utc": utc_now(),
+            "milestone_eval_manifest_sha256": sha256(plan_path),
+            **{
+                key: expected[key]
+                for key in (
+                    "training_seed",
+                    "target_steps",
+                    "anchor",
+                    "orientation",
+                    "match_seed",
+                )
+            },
+            "embedded_steps": checkpoint["embedded_steps"],
+            "games_requested": plan["games_per_cell"],
+            "games": numeric["env/n"],
+            "focal_score": numeric[focal_key],
+            "opponent_score": numeric[opponent_key],
+            "draw_rate": numeric["env/draw_rate"],
+            "focal_win_rate": (numeric[focal_key] - 0.5 * numeric["env/draw_rate"]),
+            "focal_loss_rate": (numeric[opponent_key] - 0.5 * numeric["env/draw_rate"]),
+            "focal_tds": numeric[focal_tds_key],
+            "opponent_tds": numeric[opponent_tds_key],
+            "focal_checkpoint": focal_path,
+            "focal_checkpoint_sha256": checkpoint["native_sha256"],
+            "anchor_checkpoint": anchor_path,
+            "anchor_checkpoint_sha256": anchor["sha256"],
+            "policy_a": policy_a,
+            "policy_b": policy_b,
+            "implementation": implementation,
+            "integrity": integrity,
+            "raw_env_metrics": {
+                key.removeprefix("env/"): value
+                for key, value in numeric.items()
+                if key.startswith("env/")
+            },
+        },
+    )
+    validate_cell(cell_path, plan, expected)
+    return 0
+
+
+def mean(values: list[float]) -> float:
+    if not values:
+        raise MilestoneEvalError("cannot summarize an empty list")
+    return statistics.fmean(values)
+
+
+def nominate(points: list[dict[str, Any]]) -> dict[str, Any]:
+    trained = [point for point in points if point["target_steps"] > 0]
+    best_score = max(point["macro_score"] for point in trained)
+    for index, point in enumerate(trained):
+        if point["macro_score"] < best_score - 0.01:
+            continue
+        later = trained[index + 1 : index + 3]
+        if all(
+            next_point["macro_score"] <= point["macro_score"] + 0.02
+            for next_point in later
+        ):
+            return {
+                "target_steps": point["target_steps"],
+                "embedded_steps": point["embedded_steps"],
+                "rule": "earliest_within_0.01_of_max_without_next_two_gt_0.02",
+                "exploratory": False,
+            }
+    best = max(trained, key=lambda point: point["macro_score"])
+    return {
+        "target_steps": best["target_steps"],
+        "embedded_steps": best["embedded_steps"],
+        "rule": "highest_scoring_fallback",
+        "exploratory": True,
+    }
+
+
+def analyze(directory: str | Path) -> dict[str, Any]:
+    directory = Path(directory).expanduser().resolve()
+    plan_path = directory / "MILESTONE_EVAL_MANIFEST.json"
+    plan = load_object(plan_path, "milestone manifest")
+    rows = [
+        validate_cell(directory / expected["path"], plan, expected)
+        for expected in expected_cells(plan)
+    ]
+    trajectories: dict[str, list[dict[str, Any]]] = {}
+    nominations = {}
+    for seed in plan["training_seeds"]:
+        points = []
+        for target in plan["target_steps"]:
+            cells = [
+                row
+                for row in rows
+                if row["training_seed"] == seed and row["target_steps"] == target
+            ]
+            checkpoint = checkpoint_record(plan, seed, target)
+            point = {
+                "target_steps": target,
+                "embedded_steps": checkpoint["embedded_steps"],
+                "macro_score": mean([row["focal_score"] for row in cells]),
+                "macro_tds_for": mean([row["focal_tds"] for row in cells]),
+                "macro_tds_against": mean([row["opponent_tds"] for row in cells]),
+                "by_anchor": {
+                    anchor["name"]: mean(
+                        [
+                            row["focal_score"]
+                            for row in cells
+                            if row["anchor"] == anchor["name"]
+                        ]
+                    )
+                    for anchor in plan["anchors"]
+                },
+                "by_orientation": {
+                    str(orientation): mean(
+                        [
+                            row["focal_score"]
+                            for row in cells
+                            if row["orientation"] == orientation
+                        ]
+                    )
+                    for orientation in plan["orientations"]
+                },
+            }
+            if points:
+                point["score_delta_previous"] = (
+                    point["macro_score"] - points[-1]["macro_score"]
+                )
+            points.append(point)
+        warm = points[0]
+        for point in points:
+            point["score_delta_warm"] = point["macro_score"] - warm["macro_score"]
+            point["tds_for_delta_warm"] = point["macro_tds_for"] - warm["macro_tds_for"]
+            point["tds_against_delta_warm"] = (
+                point["macro_tds_against"] - warm["macro_tds_against"]
+            )
+        trajectories[str(seed)] = points
+        nominations[str(seed)] = nominate(points)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "analysis": "control_final_checkpoint_milestones",
+        "directory": str(directory),
+        "manifest": {"path": str(plan_path), "sha256": sha256(plan_path)},
+        "screen_complete_sha256": plan["screen_complete_sha256"],
+        "cell_count": len(rows),
+        "total_games": sum(row["games"] for row in rows),
+        "runs": rows,
+        "trajectories": trajectories,
+        "stage_b_nominations": nominations,
+        "warning": (
+            "These anchors are unseen exact checkpoints but lineage-connected. "
+            "The fixed nomination compresses Stage B evaluation; it is not a "
+            "reward or production promotion gate."
+        ),
+    }
+
+
+def complete(directory: Path) -> None:
+    report = analyze(directory)
+    analysis_path = directory / "ANALYSIS.json"
+    atomic_json(analysis_path, report)
+    core = {
+        "schema_version": SCHEMA_VERSION,
+        "milestone_eval_manifest_sha256": sha256(
+            directory / "MILESTONE_EVAL_MANIFEST.json"
+        ),
+        "analysis_sha256": sha256(analysis_path),
+        "screen_complete_sha256": report["screen_complete_sha256"],
+        "cells": [
+            {"file": row["file"], "sha256": row["file_sha256"]}
+            for row in report["runs"]
+        ],
+    }
+    completion_path = directory / "MILESTONE_EVAL_COMPLETE.json"
+    if completion_path.exists():
+        recorded = load_object(completion_path, "milestone completion")
+        if {key: recorded.get(key) for key in core} != core:
+            raise MilestoneEvalError("existing milestone completion is stale")
+    else:
+        atomic_json(completion_path, {**core, "completed_utc": utc_now()})
+
+
+def validate_completion(
+    path: str | Path, expected_sha256: str | None = None
+) -> dict[str, Any]:
+    path = Path(path).expanduser().resolve()
+    if expected_sha256 is not None and sha256(path) != need_sha(
+        expected_sha256, "expected milestone completion SHA-256"
+    ):
+        raise MilestoneEvalError("milestone completion SHA-256 mismatch")
+    completion = load_object(path, "milestone completion")
+    if completion.get("schema_version") != SCHEMA_VERSION:
+        raise MilestoneEvalError("unsupported milestone completion schema")
+    directory = path.parent
+    report = analyze(directory)
+    stored = load_object(directory / "ANALYSIS.json", "milestone analysis")
+    if stored != report:
+        raise MilestoneEvalError("stored milestone analysis is stale")
+    if sha256(directory / "ANALYSIS.json") != completion.get("analysis_sha256"):
+        raise MilestoneEvalError("milestone analysis hash chain is invalid")
+    if sha256(directory / "MILESTONE_EVAL_MANIFEST.json") != completion.get(
+        "milestone_eval_manifest_sha256"
+    ):
+        raise MilestoneEvalError("milestone manifest hash chain is invalid")
+    expected_cells_chain = [
+        {"file": row["file"], "sha256": row["file_sha256"]} for row in report["runs"]
+    ]
+    if completion.get("cells") != expected_cells_chain:
+        raise MilestoneEvalError("milestone completion cell chain is invalid")
+    return report
+
+
+def write_status(
+    path: Path, state: str, completed: int, total: int, message: str
+) -> None:
+    atomic_json(
+        path,
+        {
+            "schema_version": SCHEMA_VERSION,
+            "state": state,
+            "completed_cells": completed,
+            "total_cells": total,
+            "message": message,
+            "pid": os.getpid(),
+            "updated_utc": utc_now(),
+        },
+    )
+
+
+def run_matrix(root: Path, directory: Path, plan: dict[str, Any]) -> None:
+    plan_path = directory / "MILESTONE_EVAL_MANIFEST.json"
+    cells = expected_cells(plan)
+    status_path = directory / "MILESTONE_EVAL_STATUS.json"
+    completed = 0
+    for expected in cells:
+        cell_path = directory / expected["path"]
+        if cell_path.exists():
+            validate_cell(cell_path, plan, expected)
+        else:
+            write_status(
+                status_path,
+                "running",
+                completed,
+                len(cells),
+                (
+                    f"running seed {expected['training_seed']} target "
+                    f"{expected['target_steps']} anchor {expected['anchor']} "
+                    f"orientation {expected['orientation']}"
+                ),
+            )
+            command = [
+                str(root / "vendor/PufferLib/.venv/bin/python"),
+                str(Path(__file__).resolve()),
+                "--run-cell",
+                str(plan_path),
+                str(cell_path),
+            ]
+            result = subprocess.run(
+                command,
+                cwd=root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                check=False,
+                timeout=3600,
+            )
+            if result.returncode != 0:
+                raise MilestoneEvalError(
+                    f"milestone cell exited {result.returncode}: {cell_path}\n"
+                    f"{result.stdout[-4000:]}"
+                )
+            validate_cell(cell_path, plan, expected)
+        completed += 1
+        write_status(status_path, "running", completed, len(cells), "cell validated")
+    complete(directory)
+    write_status(
+        status_path,
+        "complete",
+        len(cells),
+        len(cells),
+        "milestone matrix complete and validated",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", type=Path)
+    parser.add_argument("--plan-only", action="store_true")
+    parser.add_argument("--run-cell", nargs=2, metavar=("PLAN", "CELL"))
+    parser.add_argument("--validate-complete", type=Path)
+    parser.add_argument("--expected-complete-sha256")
+    args = parser.parse_args(argv)
+    try:
+        root = Path(__file__).resolve().parents[1]
+        if args.run_cell:
+            if (
+                args.spec
+                or args.plan_only
+                or args.validate_complete
+                or args.expected_complete_sha256
+            ):
+                raise MilestoneEvalError("--run-cell cannot be combined")
+            return run_cell(root, Path(args.run_cell[0]), Path(args.run_cell[1]))
+        if args.validate_complete:
+            if args.spec or args.plan_only:
+                raise MilestoneEvalError("--validate-complete cannot be combined")
+            report = validate_completion(
+                args.validate_complete, args.expected_complete_sha256
+            )
+            print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
+            return 0
+        if args.expected_complete_sha256:
+            raise MilestoneEvalError(
+                "--expected-complete-sha256 requires --validate-complete"
+            )
+        if not args.spec:
+            parser.error("--spec is required")
+        spec = validate_spec(args.spec.expanduser().resolve())
+        directory = Path(spec["out_dir"])
+        directory.mkdir(parents=True, exist_ok=True)
+        lock_path = directory / ".milestone-eval.lock"
+        with lock_path.open("a+") as lock:
+            try:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                raise MilestoneEvalError(
+                    "another milestone evaluator holds the output lock"
+                ) from exc
+            with Path("/tmp/bloodbowl-rl-reward-ablation.lock").open("a+") as gpu_lock:
+                try:
+                    fcntl.flock(gpu_lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError as exc:
+                    raise MilestoneEvalError(
+                        "training/evaluation GPU lock is already held"
+                    ) from exc
+                plan = freeze_manifest(spec)
+                if args.plan_only:
+                    print(
+                        "MILESTONE EVAL PLAN VERIFIED: "
+                        f"{directory / 'MILESTONE_EVAL_MANIFEST.json'}"
+                    )
+                    return 0
+                run_matrix(root, directory, plan)
+                print(f"MILESTONE EVAL COMPLETE: {directory}")
+                return 0
+    except (
+        OSError,
+        subprocess.TimeoutExpired,
+        MilestoneEvalError,
+        analyze_reward_screen.AnalysisError,
+        ValueError,
+    ) as exc:
+        print(f"milestone evaluator failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -31,6 +31,24 @@ import run_reward_candidate_transfer
 SCHEMA_VERSION = 1
 EXPECTED_NATIVE_BYTES = 16_066_560
 CONTROL_SEEDS = (42, 43, 44)
+FIXED_TARGET_STEPS = (
+    0,
+    1_000_000_000,
+    2_000_000_000,
+    4_000_000_000,
+    6_000_000_000,
+    8_000_000_000,
+    10_000_000_000,
+    12_000_000_000,
+)
+FIXED_MAX_TARGET_GAP_STEPS = 50_000_000
+FIXED_GAMES_PER_CELL = 2_048
+FIXED_ANCHOR_SHA256 = {
+    "statmatch1": "85315d26a40f26a387ef28742b7f3306583ca73b488aae01e06c72566f5ab435",
+    "league7b": "2bf0815f506ac98e4972744903164673d40bee27b0b0c9197268b4c094fcdec1",
+    "exploiter1": "6373cfa349bab8eee133933d42b353e796d2693e4e85b5a285c999647b11771a",
+    "gen1": "62f6fcbc111e3b319ac0158358f0211e8aaf460c88f49eee86ff4639a148945a",
+}
 INTEGRITY_KEYS = (
     "reward_clip_frac",
     "reward_clip_frac_nonzero",
@@ -168,6 +186,23 @@ def validate_spec(path: Path) -> dict[str, Any]:
     )
     if screen_complete.name != "SCREEN_COMPLETE.json":
         raise MilestoneEvalError("screen completion must be SCREEN_COMPLETE.json")
+    try:
+        out_dir.relative_to(screen_complete.parent)
+    except ValueError:
+        try:
+            screen_complete.parent.relative_to(out_dir)
+        except ValueError:
+            pass
+        else:
+            raise MilestoneEvalError(
+                "out_dir must not contain the source screen artifact tree"
+            )
+    else:
+        raise MilestoneEvalError(
+            "out_dir must be separate from the source screen artifact tree"
+        )
+    if out_dir == root:
+        raise MilestoneEvalError("out_dir cannot be the checkout root")
     expected_screen_sha = need_sha(
         raw.get("screen_complete_sha256"), "screen completion SHA-256"
     )
@@ -184,16 +219,28 @@ def validate_spec(path: Path) -> dict[str, Any]:
         raise MilestoneEvalError(
             "target_steps must be unique increasing nonnegative integers starting at 0"
         )
+    if tuple(targets) != FIXED_TARGET_STEPS:
+        raise MilestoneEvalError(
+            "target_steps differ from the predeclared 0/1/2/4/6/8/10/12B protocol"
+        )
     max_gap = positive_int(raw.get("max_target_gap_steps"), "max_target_gap_steps")
+    if max_gap != FIXED_MAX_TARGET_GAP_STEPS:
+        raise MilestoneEvalError(
+            f"max_target_gap_steps must be {FIXED_MAX_TARGET_GAP_STEPS}"
+        )
     games = positive_int(raw.get("games_per_cell"), "games_per_cell")
-    if games < 1_000:
-        raise MilestoneEvalError("games_per_cell must be at least 1000")
+    if games != FIXED_GAMES_PER_CELL:
+        raise MilestoneEvalError(
+            f"games_per_cell must be the predeclared {FIXED_GAMES_PER_CELL}"
+        )
     orientations = raw.get("orientations")
     if orientations != [0, 1]:
         raise MilestoneEvalError("orientations must be exactly [0, 1]")
     anchors_raw = raw.get("anchors")
-    if not isinstance(anchors_raw, list) or len(anchors_raw) < 2:
-        raise MilestoneEvalError("at least two anchors are required")
+    if not isinstance(anchors_raw, list) or len(anchors_raw) != len(
+        FIXED_ANCHOR_SHA256
+    ):
+        raise MilestoneEvalError("the exact four predeclared anchors are required")
     anchors = []
     names: set[str] = set()
     hashes: set[str] = set()
@@ -227,6 +274,11 @@ def validate_spec(path: Path) -> dict[str, Any]:
         hashes.add(expected)
         anchors.append(
             {"name": name, "path": str(anchor), "bytes": size, "sha256": expected}
+        )
+    observed_anchors = {record["name"]: record["sha256"] for record in anchors}
+    if observed_anchors != FIXED_ANCHOR_SHA256:
+        raise MilestoneEvalError(
+            "anchor names/hashes differ from the predeclared transfer set"
         )
     return {
         "schema_version": SCHEMA_VERSION,
@@ -313,6 +365,7 @@ def implementation_identity(root: Path) -> dict[str, Any]:
         "selfplay": root / "vendor/PufferLib/pufferlib/selfplay.py",
         "runner": Path(__file__).resolve(),
         "screen_analyzer": root / "tools/analyze_reward_screen.py",
+        "tree_hasher": root / "tools/run_reward_candidate_transfer.py",
     }
     for label, path in files.items():
         if not path.is_file():
@@ -482,6 +535,19 @@ def freeze_manifest(spec: dict[str, Any]) -> dict[str, Any]:
     report, screen_manifest = source_screen(spec)
     root = Path(spec["root"])
     checkpoints = resolve_checkpoints(spec, report, screen_manifest)
+    focal_hashes = {
+        record["native_sha256"]
+        for seed_records in checkpoints.values()
+        for record in seed_records
+    }
+    overlap = sorted(
+        anchor["name"] for anchor in spec["anchors"] if anchor["sha256"] in focal_hashes
+    )
+    if overlap:
+        raise MilestoneEvalError(
+            "transfer anchors duplicate a warm/milestone checkpoint: "
+            + ", ".join(overlap)
+        )
     core = {
         "schema_version": SCHEMA_VERSION,
         "matrix_id": spec["matrix_id"],
@@ -649,6 +715,7 @@ def verify_implementation(plan: dict[str, Any]) -> None:
         "selfplay",
         "runner",
         "screen_analyzer",
+        "tree_hasher",
     ):
         path = Path(implementation[f"{key}_path"])
         if not path.is_file() or sha256(path) != implementation[f"{key}_sha256"]:
@@ -684,6 +751,26 @@ def require_idle_gpu() -> None:
         raise MilestoneEvalError(
             "evaluation GPU is not exclusive; existing compute owners: "
             + "; ".join(owners)
+        )
+    viewer = subprocess.run(
+        ["pgrep", "-af", "[f]ollow_latest.py"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        timeout=10,
+    )
+    if viewer.returncode not in (0, 1):
+        raise MilestoneEvalError(
+            f"cannot prove BBTV is quiescent: {viewer.stdout[-1000:]}"
+        )
+    viewer_owners = [
+        line.strip() for line in viewer.stdout.splitlines() if line.strip()
+    ]
+    if viewer_owners:
+        raise MilestoneEvalError(
+            "BBTV follower is active; pause it explicitly before evaluation: "
+            + "; ".join(viewer_owners)
         )
 
 
@@ -958,6 +1045,10 @@ def validate_completion(
     path: str | Path, expected_sha256: str | None = None
 ) -> dict[str, Any]:
     path = Path(path).expanduser().resolve()
+    if path.name != "MILESTONE_EVAL_COMPLETE.json":
+        raise MilestoneEvalError(
+            "completion must be named MILESTONE_EVAL_COMPLETE.json"
+        )
     if expected_sha256 is not None and sha256(path) != need_sha(
         expected_sha256, "expected milestone completion SHA-256"
     ):
@@ -976,6 +1067,8 @@ def validate_completion(
         "milestone_eval_manifest_sha256"
     ):
         raise MilestoneEvalError("milestone manifest hash chain is invalid")
+    if completion.get("screen_complete_sha256") != report["screen_complete_sha256"]:
+        raise MilestoneEvalError("milestone source-screen hash chain is invalid")
     expected_cells_chain = [
         {"file": row["file"], "sha256": row["file_sha256"]} for row in report["runs"]
     ]

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -552,10 +552,14 @@ def freeze_manifest(spec: dict[str, Any]) -> dict[str, Any]:
     core = {
         "schema_version": SCHEMA_VERSION,
         "matrix_id": spec["matrix_id"],
+        "root": spec["root"],
         "spec": spec["spec_path"],
         "spec_sha256": spec["spec_sha256"],
         "screen_complete": spec["screen_complete"],
         "screen_complete_sha256": spec["screen_complete_sha256"],
+        "screen_manifest": str(
+            (Path(spec["screen_complete"]).parent / "SCREEN_MANIFEST.json").resolve()
+        ),
         "screen_manifest_sha256": report["screen"]["manifest_sha256"],
         "profile": "control-final",
         "training_seeds": list(CONTROL_SEEDS),
@@ -589,6 +593,47 @@ def checkpoint_record(plan: dict[str, Any], seed: int, target: int) -> dict[str,
     if len(matches) != 1:
         raise MilestoneEvalError(f"missing/duplicate seed {seed} target {target}")
     return matches[0]
+
+
+def validate_plan_contract(plan: dict[str, Any]) -> None:
+    if plan.get("schema_version") != SCHEMA_VERSION:
+        raise MilestoneEvalError("unsupported milestone manifest schema")
+    if plan.get("profile") != "control-final":
+        raise MilestoneEvalError("milestone manifest is not control-final")
+    if plan.get("training_seeds") != list(CONTROL_SEEDS):
+        raise MilestoneEvalError("milestone manifest seeds differ from 42/43/44")
+    if tuple(plan.get("target_steps", ())) != FIXED_TARGET_STEPS:
+        raise MilestoneEvalError("milestone manifest target steps drifted")
+    if plan.get("max_target_gap_steps") != FIXED_MAX_TARGET_GAP_STEPS:
+        raise MilestoneEvalError("milestone manifest target-gap contract drifted")
+    if plan.get("games_per_cell") != FIXED_GAMES_PER_CELL:
+        raise MilestoneEvalError("milestone manifest game count drifted")
+    if plan.get("orientations") != [0, 1]:
+        raise MilestoneEvalError("milestone manifest orientations drifted")
+    anchors = plan.get("anchors")
+    if (
+        not isinstance(anchors, list)
+        or {
+            record.get("name"): record.get("sha256")
+            for record in anchors
+            if isinstance(record, dict)
+        }
+        != FIXED_ANCHOR_SHA256
+    ):
+        raise MilestoneEvalError("milestone manifest anchor contract drifted")
+    checkpoints = plan.get("checkpoints")
+    if not isinstance(checkpoints, dict) or set(checkpoints) != {
+        str(seed) for seed in CONTROL_SEEDS
+    }:
+        raise MilestoneEvalError("milestone manifest checkpoint seeds are incomplete")
+    for seed in CONTROL_SEEDS:
+        records = checkpoints[str(seed)]
+        if not isinstance(records, list) or [
+            record.get("target_steps") for record in records if isinstance(record, dict)
+        ] != list(FIXED_TARGET_STEPS):
+            raise MilestoneEvalError(
+                f"milestone manifest seed {seed} targets are incomplete"
+            )
 
 
 def cell_filename(seed: int, target: int, anchor: str, orientation: int) -> str:
@@ -730,6 +775,67 @@ def verify_implementation(plan: dict[str, Any]) -> None:
         raise MilestoneEvalError("implementation drift before cell: config_tree")
 
 
+def verify_file_identity(path_value: Any, expected: Any, label: str) -> Path:
+    path = absolute_file(path_value, label)
+    if sha256(path) != need_sha(expected, f"{label} SHA-256"):
+        raise MilestoneEvalError(f"{label} SHA-256 drift")
+    return path
+
+
+def verify_plan_sources(
+    plan: dict[str, Any], expected: dict[str, Any] | None = None
+) -> None:
+    validate_plan_contract(plan)
+    verify_file_identity(plan.get("spec"), plan.get("spec_sha256"), "milestone spec")
+    verify_file_identity(
+        plan.get("screen_complete"),
+        plan.get("screen_complete_sha256"),
+        "source screen completion",
+    )
+    verify_file_identity(
+        plan.get("screen_manifest"),
+        plan.get("screen_manifest_sha256"),
+        "source screen manifest",
+    )
+    seeds = (
+        [expected["training_seed"]]
+        if expected is not None
+        else list(plan["training_seeds"])
+    )
+    targets = (
+        [expected["target_steps"]]
+        if expected is not None
+        else list(plan["target_steps"])
+    )
+    for seed in seeds:
+        for target in targets:
+            checkpoint = checkpoint_record(plan, seed, target)
+            verify_file_identity(
+                checkpoint.get("screen_result"),
+                checkpoint.get("screen_result_sha256"),
+                f"seed {seed} screen result",
+            )
+            verify_file_identity(
+                checkpoint.get("run_manifest"),
+                checkpoint.get("run_manifest_sha256"),
+                f"seed {seed} run manifest",
+            )
+            verify_file_identity(
+                checkpoint.get("native"),
+                checkpoint.get("native_sha256"),
+                f"seed {seed} target {target} checkpoint",
+            )
+    anchor_names = (
+        [expected["anchor"]]
+        if expected is not None
+        else [record["name"] for record in plan["anchors"]]
+    )
+    for name in anchor_names:
+        anchor = next(record for record in plan["anchors"] if record["name"] == name)
+        verify_file_identity(anchor.get("path"), anchor.get("sha256"), f"anchor {name}")
+    verify_implementation(plan)
+
+
 def require_idle_gpu() -> None:
     result = subprocess.run(
         [
@@ -777,13 +883,14 @@ def require_idle_gpu() -> None:
 
 def run_cell(root: Path, plan_path: Path, cell_path: Path) -> int:
     plan = load_object(plan_path, "milestone manifest")
+    validate_plan_contract(plan)
     expected = next(
         (row for row in expected_cells(plan) if row["path"] == cell_path.name), None
     )
     if expected is None:
         raise MilestoneEvalError(f"unplanned milestone cell: {cell_path}")
+    verify_plan_sources(plan, expected)
     require_idle_gpu()
-    verify_implementation(plan)
     checkpoint = checkpoint_record(
         plan, expected["training_seed"], expected["target_steps"]
     )
@@ -975,6 +1082,7 @@ def analyze(directory: str | Path) -> dict[str, Any]:
     directory = Path(directory).expanduser().resolve()
     plan_path = directory / "MILESTONE_EVAL_MANIFEST.json"
     plan = load_object(plan_path, "milestone manifest")
+    validate_plan_contract(plan)
     rows = [
         validate_cell(directory / expected["path"], plan, expected)
         for expected in expected_cells(plan)
@@ -1125,6 +1233,8 @@ def validate_completion(
     if completion.get("schema_version") != SCHEMA_VERSION:
         raise MilestoneEvalError("unsupported milestone completion schema")
     directory = path.parent
+    plan = load_object(directory / "MILESTONE_EVAL_MANIFEST.json", "milestone manifest")
+    verify_plan_sources(plan)
     report = analyze(directory)
     stored = load_object(directory / "ANALYSIS.json", "milestone analysis")
     if stored != report:

--- a/tools/test_run_checkpoint_milestone_eval.py
+++ b/tools/test_run_checkpoint_milestone_eval.py
@@ -237,7 +237,17 @@ class MilestoneEvalTests(unittest.TestCase):
                 with self.assertRaises(milestone.MilestoneEvalError):
                     milestone.validate_completion(completion)
 
-    def test_terminal_is_fixed_nominee_when_curve_never_plateaus_early(self):
+    def test_plan_contract_rejects_reordered_anchor_seed_strata(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            plan = self.synthetic_plan(directory)
+            plan["anchors"].reverse()
+            with self.assertRaisesRegex(
+                milestone.MilestoneEvalError, "anchor contract drifted"
+            ):
+                milestone.validate_plan_contract(plan)
+
+    def test_nonterminal_fallback_remains_distinct_from_terminal(self):
         points = [
             {"target_steps": 0, "embedded_steps": 0, "macro_score": 0.4},
             {"target_steps": 1, "embedded_steps": 1, "macro_score": 0.50},
@@ -245,10 +255,8 @@ class MilestoneEvalTests(unittest.TestCase):
             {"target_steps": 4, "embedded_steps": 4, "macro_score": 0.56},
         ]
         nomination = milestone.nominate(points)
-        # The terminal point satisfies the fixed rule vacuously; this keeps a
-        # monotonically rising curve on its exact final checkpoint.
-        self.assertEqual(nomination["target_steps"], 4)
-        self.assertFalse(nomination["exploratory"])
+        self.assertEqual(nomination["target_steps"], 2)
+        self.assertTrue(nomination["exploratory"])
 
     def test_idle_gpu_gate_fails_closed_on_existing_owner(self):
         with mock.patch.object(

--- a/tools/test_run_checkpoint_milestone_eval.py
+++ b/tools/test_run_checkpoint_milestone_eval.py
@@ -69,19 +69,14 @@ class MilestoneEvalTests(unittest.TestCase):
     def synthetic_plan(self, directory: Path) -> dict:
         anchors = [
             {
-                "name": "alpha",
-                "path": "/tmp/alpha.bin",
+                "name": name,
+                "path": f"/tmp/{name}.bin",
                 "bytes": milestone.EXPECTED_NATIVE_BYTES,
-                "sha256": "a" * 64,
-            },
-            {
-                "name": "beta",
-                "path": "/tmp/beta.bin",
-                "bytes": milestone.EXPECTED_NATIVE_BYTES,
-                "sha256": "b" * 64,
-            },
+                "sha256": checkpoint_sha,
+            }
+            for name, checkpoint_sha in milestone.FIXED_ANCHOR_SHA256.items()
         ]
-        targets = [0, 1_000, 2_000, 4_000]
+        targets = list(milestone.FIXED_TARGET_STEPS)
         checkpoints = {
             str(seed): [
                 {
@@ -100,9 +95,11 @@ class MilestoneEvalTests(unittest.TestCase):
         plan = {
             "schema_version": 1,
             "matrix_id": "test-matrix",
+            "profile": "control-final",
             "training_seeds": list(milestone.CONTROL_SEEDS),
             "target_steps": targets,
-            "games_per_cell": 1_000,
+            "max_target_gap_steps": milestone.FIXED_MAX_TARGET_GAP_STEPS,
+            "games_per_cell": milestone.FIXED_GAMES_PER_CELL,
             "orientations": [0, 1],
             "anchors": anchors,
             "checkpoints": checkpoints,
@@ -134,8 +131,8 @@ class MilestoneEvalTests(unittest.TestCase):
                 "anchor": expected["anchor"],
                 "orientation": expected["orientation"],
                 "match_seed": expected["match_seed"],
-                "games_requested": 1_000,
-                "games": 1_000,
+                "games_requested": milestone.FIXED_GAMES_PER_CELL,
+                "games": milestone.FIXED_GAMES_PER_CELL,
                 "focal_score": score,
                 "opponent_score": 1.0 - score,
                 "draw_rate": 0.4,
@@ -160,15 +157,24 @@ class MilestoneEvalTests(unittest.TestCase):
             self.write_cells(
                 directory,
                 plan,
-                {0: 0.40, 1_000: 0.50, 2_000: 0.51, 4_000: 0.505},
+                {
+                    0: 0.40,
+                    1_000_000_000: 0.50,
+                    2_000_000_000: 0.51,
+                    4_000_000_000: 0.505,
+                    6_000_000_000: 0.505,
+                    8_000_000_000: 0.505,
+                    10_000_000_000: 0.505,
+                    12_000_000_000: 0.505,
+                },
             )
             report = milestone.analyze(directory)
-            self.assertEqual(report["cell_count"], 48)
-            self.assertEqual(report["total_games"], 48_000)
+            self.assertEqual(report["cell_count"], 192)
+            self.assertEqual(report["total_games"], 393_216)
             points = report["trajectories"]["42"]
             self.assertAlmostEqual(points[2]["score_delta_warm"], 0.11)
             nomination = report["stage_b_nominations"]["42"]
-            self.assertEqual(nomination["target_steps"], 1_000)
+            self.assertEqual(nomination["target_steps"], 1_000_000_000)
             self.assertFalse(nomination["exploratory"])
             aggregate = report["aggregate_trajectory"][2]
             self.assertAlmostEqual(aggregate["score_delta_warm"]["mean"], 0.11)
@@ -189,7 +195,7 @@ class MilestoneEvalTests(unittest.TestCase):
             self.write_cells(
                 directory,
                 plan,
-                {0: 0.40, 1_000: 0.50, 2_000: 0.51, 4_000: 0.505},
+                {target: 0.5 for target in milestone.FIXED_TARGET_STEPS},
             )
             expected = milestone.expected_cells(plan)[0]
             path = directory / expected["path"]
@@ -211,14 +217,15 @@ class MilestoneEvalTests(unittest.TestCase):
             self.write_cells(
                 directory,
                 plan,
-                {0: 0.40, 1_000: 0.50, 2_000: 0.51, 4_000: 0.505},
+                {target: 0.5 for target in milestone.FIXED_TARGET_STEPS},
             )
             milestone.complete(directory)
             completion = directory / "MILESTONE_EVAL_COMPLETE.json"
-            report = milestone.validate_completion(
-                completion, milestone.sha256(completion)
-            )
-            self.assertEqual(report["total_games"], 48_000)
+            with mock.patch.object(milestone, "verify_plan_sources"):
+                report = milestone.validate_completion(
+                    completion, milestone.sha256(completion)
+                )
+            self.assertEqual(report["total_games"], 393_216)
             first = directory / milestone.expected_cells(plan)[0]["path"]
             cell = json.loads(first.read_text(encoding="utf-8"))
             cell["focal_score"] += 0.01
@@ -226,8 +233,9 @@ class MilestoneEvalTests(unittest.TestCase):
                 json.dumps(cell, indent=2, sort_keys=True) + "\n",
                 encoding="utf-8",
             )
-            with self.assertRaises(milestone.MilestoneEvalError):
-                milestone.validate_completion(completion)
+            with mock.patch.object(milestone, "verify_plan_sources"):
+                with self.assertRaises(milestone.MilestoneEvalError):
+                    milestone.validate_completion(completion)
 
     def test_terminal_is_fixed_nominee_when_curve_never_plateaus_early(self):
         points = [

--- a/tools/test_run_checkpoint_milestone_eval.py
+++ b/tools/test_run_checkpoint_milestone_eval.py
@@ -83,23 +83,24 @@ class MilestoneEvalTests(unittest.TestCase):
         ]
         targets = [0, 1_000, 2_000, 4_000]
         checkpoints = {
-            "42": [
+            str(seed): [
                 {
-                    "training_seed": 42,
+                    "training_seed": seed,
                     "target_steps": target,
                     "embedded_steps": target if target else 0,
-                    "native": f"/tmp/{target}.bin",
+                    "native": f"/tmp/s{seed}-{target}.bin",
                     "native_bytes": milestone.EXPECTED_NATIVE_BYTES,
-                    "native_sha256": f"{index + 1:064x}",
+                    "native_sha256": f"{seed * 100 + index + 1:064x}",
                     "source": "warm" if target == 0 else "interval",
                 }
                 for index, target in enumerate(targets)
             ]
+            for seed in milestone.CONTROL_SEEDS
         }
         plan = {
             "schema_version": 1,
             "matrix_id": "test-matrix",
-            "training_seeds": [42],
+            "training_seeds": list(milestone.CONTROL_SEEDS),
             "target_steps": targets,
             "games_per_cell": 1_000,
             "orientations": [0, 1],
@@ -162,13 +163,24 @@ class MilestoneEvalTests(unittest.TestCase):
                 {0: 0.40, 1_000: 0.50, 2_000: 0.51, 4_000: 0.505},
             )
             report = milestone.analyze(directory)
-            self.assertEqual(report["cell_count"], 16)
-            self.assertEqual(report["total_games"], 16_000)
+            self.assertEqual(report["cell_count"], 48)
+            self.assertEqual(report["total_games"], 48_000)
             points = report["trajectories"]["42"]
             self.assertAlmostEqual(points[2]["score_delta_warm"], 0.11)
             nomination = report["stage_b_nominations"]["42"]
             self.assertEqual(nomination["target_steps"], 1_000)
             self.assertFalse(nomination["exploratory"])
+            aggregate = report["aggregate_trajectory"][2]
+            self.assertAlmostEqual(aggregate["score_delta_warm"]["mean"], 0.11)
+            self.assertEqual(aggregate["score"]["clusters"], 3)
+
+    def test_exact_cluster_bootstrap_uses_all_seed_resamples(self):
+        summary = milestone.exact_cluster_bootstrap([0.4, 0.5, 0.6])
+        self.assertAlmostEqual(summary["mean"], 0.5)
+        self.assertEqual(summary["clusters"], 3)
+        self.assertEqual(summary["exact_resamples"], 27)
+        self.assertLess(summary["lower_95"], 0.5)
+        self.assertGreater(summary["upper_95"], 0.5)
 
     def test_nonzero_integrity_is_rejected(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -206,7 +218,7 @@ class MilestoneEvalTests(unittest.TestCase):
             report = milestone.validate_completion(
                 completion, milestone.sha256(completion)
             )
-            self.assertEqual(report["total_games"], 16_000)
+            self.assertEqual(report["total_games"], 48_000)
             first = directory / milestone.expected_cells(plan)[0]["path"]
             cell = json.loads(first.read_text(encoding="utf-8"))
             cell["focal_score"] += 0.01

--- a/tools/test_run_checkpoint_milestone_eval.py
+++ b/tools/test_run_checkpoint_milestone_eval.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+TOOLS = Path(__file__).resolve().parent
+sys.path.insert(0, str(TOOLS))
+
+import run_checkpoint_milestone_eval as milestone  # noqa: E402
+
+
+ZERO_INTEGRITY = {key: 0.0 for key in milestone.INTEGRITY_KEYS}
+
+
+class MilestoneEvalTests(unittest.TestCase):
+    def test_resolve_target_uses_greatest_step_not_above_target(self):
+        rows = [
+            (100, Path("100.bin")),
+            (200, Path("200.bin")),
+            (300, Path("300.bin")),
+        ]
+        self.assertEqual(
+            milestone.resolve_target(rows, 250, 60),
+            (200, Path("200.bin")),
+        )
+        with self.assertRaisesRegex(
+            milestone.MilestoneEvalError, "gap exceeds contract"
+        ):
+            milestone.resolve_target(rows, 250, 49)
+        with self.assertRaisesRegex(
+            milestone.MilestoneEvalError, "no checkpoint exists"
+        ):
+            milestone.resolve_target(rows, 50, 60)
+
+    def test_expected_cells_reuses_match_seed_across_milestones(self):
+        plan = {
+            "training_seeds": [42, 43],
+            "target_steps": [0, 1_000, 2_000],
+            "anchors": [
+                {"name": "alpha"},
+                {"name": "beta"},
+            ],
+            "orientations": [0, 1],
+        }
+        rows = milestone.expected_cells(plan)
+        self.assertEqual(len(rows), 2 * 3 * 2 * 2)
+        stratum = [
+            row
+            for row in rows
+            if row["training_seed"] == 42
+            and row["anchor"] == "alpha"
+            and row["orientation"] == 1
+        ]
+        self.assertEqual(
+            {row["match_seed"] for row in stratum},
+            {30_001},
+        )
+        self.assertEqual(
+            {row["target_steps"] for row in stratum},
+            {0, 1_000, 2_000},
+        )
+
+    def synthetic_plan(self, directory: Path) -> dict:
+        anchors = [
+            {
+                "name": "alpha",
+                "path": "/tmp/alpha.bin",
+                "bytes": milestone.EXPECTED_NATIVE_BYTES,
+                "sha256": "a" * 64,
+            },
+            {
+                "name": "beta",
+                "path": "/tmp/beta.bin",
+                "bytes": milestone.EXPECTED_NATIVE_BYTES,
+                "sha256": "b" * 64,
+            },
+        ]
+        targets = [0, 1_000, 2_000, 4_000]
+        checkpoints = {
+            "42": [
+                {
+                    "training_seed": 42,
+                    "target_steps": target,
+                    "embedded_steps": target if target else 0,
+                    "native": f"/tmp/{target}.bin",
+                    "native_bytes": milestone.EXPECTED_NATIVE_BYTES,
+                    "native_sha256": f"{index + 1:064x}",
+                    "source": "warm" if target == 0 else "interval",
+                }
+                for index, target in enumerate(targets)
+            ]
+        }
+        plan = {
+            "schema_version": 1,
+            "matrix_id": "test-matrix",
+            "training_seeds": [42],
+            "target_steps": targets,
+            "games_per_cell": 1_000,
+            "orientations": [0, 1],
+            "anchors": anchors,
+            "checkpoints": checkpoints,
+            "implementation": {},
+            "screen_complete_sha256": "c" * 64,
+        }
+        (directory / "MILESTONE_EVAL_MANIFEST.json").write_text(
+            json.dumps(plan, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return plan
+
+    def write_cells(self, directory: Path, plan: dict, scores: dict[int, float]):
+        manifest_sha = milestone.sha256(directory / "MILESTONE_EVAL_MANIFEST.json")
+        for expected in milestone.expected_cells(plan):
+            checkpoint = milestone.checkpoint_record(
+                plan, expected["training_seed"], expected["target_steps"]
+            )
+            anchor = next(
+                row for row in plan["anchors"] if row["name"] == expected["anchor"]
+            )
+            score = scores[expected["target_steps"]]
+            cell = {
+                "schema_version": 1,
+                "milestone_eval_manifest_sha256": manifest_sha,
+                "training_seed": expected["training_seed"],
+                "target_steps": expected["target_steps"],
+                "embedded_steps": checkpoint["embedded_steps"],
+                "anchor": expected["anchor"],
+                "orientation": expected["orientation"],
+                "match_seed": expected["match_seed"],
+                "games_requested": 1_000,
+                "games": 1_000,
+                "focal_score": score,
+                "opponent_score": 1.0 - score,
+                "draw_rate": 0.4,
+                "focal_win_rate": score - 0.2,
+                "focal_loss_rate": 0.8 - score,
+                "focal_tds": 1.0 + score,
+                "opponent_tds": 1.5 - score,
+                "focal_checkpoint_sha256": checkpoint["native_sha256"],
+                "anchor_checkpoint_sha256": anchor["sha256"],
+                "implementation": {},
+                "integrity": dict(ZERO_INTEGRITY),
+            }
+            (directory / expected["path"]).write_text(
+                json.dumps(cell, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+    def test_analysis_applies_fixed_plateau_nomination(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            plan = self.synthetic_plan(directory)
+            self.write_cells(
+                directory,
+                plan,
+                {0: 0.40, 1_000: 0.50, 2_000: 0.51, 4_000: 0.505},
+            )
+            report = milestone.analyze(directory)
+            self.assertEqual(report["cell_count"], 16)
+            self.assertEqual(report["total_games"], 16_000)
+            points = report["trajectories"]["42"]
+            self.assertAlmostEqual(points[2]["score_delta_warm"], 0.11)
+            nomination = report["stage_b_nominations"]["42"]
+            self.assertEqual(nomination["target_steps"], 1_000)
+            self.assertFalse(nomination["exploratory"])
+
+    def test_nonzero_integrity_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            plan = self.synthetic_plan(directory)
+            self.write_cells(
+                directory,
+                plan,
+                {0: 0.40, 1_000: 0.50, 2_000: 0.51, 4_000: 0.505},
+            )
+            expected = milestone.expected_cells(plan)[0]
+            path = directory / expected["path"]
+            cell = json.loads(path.read_text(encoding="utf-8"))
+            cell["integrity"]["reward_clip_episodes"] = 1.0
+            path.write_text(
+                json.dumps(cell, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                milestone.MilestoneEvalError, "integrity counters nonzero"
+            ):
+                milestone.validate_cell(path, plan, expected)
+
+    def test_completion_revalidates_manifest_analysis_and_every_cell(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            plan = self.synthetic_plan(directory)
+            self.write_cells(
+                directory,
+                plan,
+                {0: 0.40, 1_000: 0.50, 2_000: 0.51, 4_000: 0.505},
+            )
+            milestone.complete(directory)
+            completion = directory / "MILESTONE_EVAL_COMPLETE.json"
+            report = milestone.validate_completion(
+                completion, milestone.sha256(completion)
+            )
+            self.assertEqual(report["total_games"], 16_000)
+            first = directory / milestone.expected_cells(plan)[0]["path"]
+            cell = json.loads(first.read_text(encoding="utf-8"))
+            cell["focal_score"] += 0.01
+            first.write_text(
+                json.dumps(cell, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(milestone.MilestoneEvalError):
+                milestone.validate_completion(completion)
+
+    def test_terminal_is_fixed_nominee_when_curve_never_plateaus_early(self):
+        points = [
+            {"target_steps": 0, "embedded_steps": 0, "macro_score": 0.4},
+            {"target_steps": 1, "embedded_steps": 1, "macro_score": 0.50},
+            {"target_steps": 2, "embedded_steps": 2, "macro_score": 0.53},
+            {"target_steps": 4, "embedded_steps": 4, "macro_score": 0.56},
+        ]
+        nomination = milestone.nominate(points)
+        # The terminal point satisfies the fixed rule vacuously; this keeps a
+        # monotonically rising curve on its exact final checkpoint.
+        self.assertEqual(nomination["target_steps"], 4)
+        self.assertFalse(nomination["exploratory"])
+
+    def test_idle_gpu_gate_fails_closed_on_existing_owner(self):
+        with mock.patch.object(
+            milestone.subprocess,
+            "run",
+            return_value=SimpleNamespace(
+                returncode=0, stdout="431596, python\n453879, python\n"
+            ),
+        ):
+            with self.assertRaisesRegex(
+                milestone.MilestoneEvalError, "GPU is not exclusive"
+            ):
+                milestone.require_idle_gpu()
+
+    def test_idle_gpu_gate_accepts_empty_compute_inventory(self):
+        with mock.patch.object(
+            milestone.subprocess,
+            "run",
+            return_value=SimpleNamespace(returncode=0, stdout=""),
+        ):
+            milestone.require_idle_gpu()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_run_checkpoint_milestone_eval.py
+++ b/tools/test_run_checkpoint_milestone_eval.py
@@ -251,6 +251,23 @@ class MilestoneEvalTests(unittest.TestCase):
         ):
             milestone.require_idle_gpu()
 
+    def test_idle_gpu_gate_requires_bbtv_to_be_explicitly_quiesced(self):
+        with mock.patch.object(
+            milestone.subprocess,
+            "run",
+            side_effect=[
+                SimpleNamespace(returncode=0, stdout=""),
+                SimpleNamespace(
+                    returncode=0,
+                    stdout="453879 python stream_backend/follow_latest.py\n",
+                ),
+            ],
+        ):
+            with self.assertRaisesRegex(
+                milestone.MilestoneEvalError, "BBTV follower is active"
+            ):
+                milestone.require_idle_gpu()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Outcome\n\nAdds a post-run, fail-closed evaluator for the vacation R0 control screens and a predeclared 0/1/2/4/6/8/10/12B protocol. It explicitly separates in-pool dashboard evidence, lineage-connected unseen checkpoints, scripted probes, and roster stratification.\n\n## Safety\n\n- accepts only an accepted, revalidated `control-final` completion\n- resolves native checkpoints by embedded step, never mtime\n- freezes hashes for spec, screen/results/run manifests, implementation/config, checkpoints, anchors, cells, analysis, and completion\n- uses common match seeds and both native backend roles\n- rejects nonzero integrity counters and undersampled cells\n- requires an exclusive idle GPU and never stops training or BBTV implicitly\n- cannot change rewards, queues, checkpoints, production defaults, or promotion state\n- not deployed into the pinned live audit checkout while training is active\n\n## Verification\n\n- `python3 -m unittest discover -s tools -p "test_*.py"` — 157 passed, 2 skipped\n- `ruff check tools/run_checkpoint_milestone_eval.py tools/test_run_checkpoint_milestone_eval.py`\n- `ruff format --check tools/run_checkpoint_milestone_eval.py tools/test_run_checkpoint_milestone_eval.py`\n- `python3 -m compileall -q tools/run_checkpoint_milestone_eval.py tools/test_run_checkpoint_milestone_eval.py`\n- `git diff --check origin/main...HEAD`\n