### PR TITLE
Preserve milestone behavior diagnostics

### DIFF
--- a/docs/plans/r0-milestone-evaluation.md
+++ b/docs/plans/r0-milestone-evaluation.md
@@ -99,9 +99,25 @@ For every lineage, seed, and frozen milestone:
   possession, ball movement, dodge/Rush/pickup/pass/handoff attempts, and
   knockdown outcomes; and
 - report focal and opponent block volume from the existing per-team counters.
-  The other behavior metrics are currently match-level aggregates over both
-  policies. Keep them labelled `joint_behavior`: they diagnose trajectory drift
-  under fixed opponents but cannot be attributed to the focal policy alone.
+
+The other behavior metrics are currently match-level aggregates over both
+policies. Keep them labelled `joint_behavior`: they diagnose trajectory drift
+under fixed opponents but cannot be attributed to the focal policy alone.
+
+Telemetry preflight recorded 2026-07-15 before the first evaluation:
+
+- the current native `Log` and a live schema-2 panel contain every fixed
+  behavior key. `bbe_finish_episode` constructs the joint panel from explicit
+  match-level counters or sums over both team arrays; only
+  `blocks_thrown_t0/t1` retain a team slot;
+- the runner's single orientation mapping loads the focal checkpoint as policy
+  A/team 0 for orientation 0 and policy B/team 1 for orientation 1. Every cell
+  records that focal-team identity and restart validation rechecks it; and
+- a live panel reported total blocks `12.8000001907` versus per-team sum
+  `12.7999997139` (absolute float32 difference below `5e-7`). The cell contract
+  allows `2e-4` absolute drift, then fails closed. The module identity and this
+  arithmetic are revalidated for every future cell, so later binding or
+  telemetry drift cannot silently pass on the strength of this preflight.
 
 At eight checkpoints, three seeds, four anchors, two backend roles, and 2,048
 games, Stage A is 393,216 games per ancestry. This is descriptive trajectory

--- a/docs/plans/r0-milestone-evaluation.md
+++ b/docs/plans/r0-milestone-evaluation.md
@@ -93,7 +93,15 @@ For every lineage, seed, and frozen milestone:
   implementation/config hashes, and zero clip, non-finite, error, demo, and
   fallback counters;
 - store W/D/L-equivalent match score, draw rate, TD for/against, games, all
-  integrity fields, raw environment metrics, and immutable cell hashes.
+  integrity fields, raw environment metrics, and immutable cell hashes;
+- reject a cell that omits or contains invalid values for the fixed behavior
+  panel: illegal repairs, block volume and dice tiers, carrier targeting,
+  possession, ball movement, dodge/Rush/pickup/pass/handoff attempts, and
+  knockdown outcomes; and
+- report focal and opponent block volume from the existing per-team counters.
+  The other behavior metrics are currently match-level aggregates over both
+  policies. Keep them labelled `joint_behavior`: they diagnose trajectory drift
+  under fixed opponents but cannot be attributed to the focal policy alone.
 
 At eight checkpoints, three seeds, four anchors, two backend roles, and 2,048
 games, Stage A is 393,216 games per ancestry. This is descriptive trajectory
@@ -107,6 +115,8 @@ For each milestone report:
 - per-anchor and per-backend-role means;
 - score, TD-for, and TD-against change from the ancestry warm checkpoint;
 - change from the preceding frozen milestone;
+- validated joint-behavior means and warm deltas, plus focal/opponent block
+  volume; and
 - in-pool dashboard trajectory beside, never merged with, transfer results.
 
 Treat seeds, anchors, roles, and checkpoints as repeated strata rather than

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -61,6 +61,45 @@ INTEGRITY_KEYS = (
     "demo_episodes",
     "demo_fallbacks",
 )
+# Existing native match telemetry needed to distinguish a score-only plateau
+# from behavior drift. These are match-level (both policies), except the two
+# explicitly side-split block-volume counters. They must therefore be reported
+# as joint diagnostics, never mislabelled as focal-policy-only measurements.
+BEHAVIOR_METRIC_KEYS = (
+    "illegal_frac",
+    "blocks_thrown",
+    "blocks_thrown_t0",
+    "blocks_thrown_t1",
+    "blocks_vs_carrier",
+    "carrier_block_frac",
+    "block_1d_frac",
+    "block_2d_frac",
+    "block_3d_frac",
+    "block_2dred_frac",
+    "block_3dred_frac",
+    "possession_rate",
+    "ball_fwd_adv",
+    "ball_path_len",
+    "dodge_attempts",
+    "gfi_attempts",
+    "pickup_attempts",
+    "pickup_success",
+    "pass_attempts",
+    "handoff_attempts",
+    "knockdowns_inflicted",
+    "knockdowns_own",
+    "carrier_knockdowns",
+)
+BEHAVIOR_FRACTION_KEYS = (
+    "illegal_frac",
+    "carrier_block_frac",
+    "block_1d_frac",
+    "block_2d_frac",
+    "block_3d_frac",
+    "block_2dred_frac",
+    "block_3dred_frac",
+    "possession_rate",
+)
 NAME_PATTERN = re.compile(r"[a-z][a-z0-9_-]{0,63}")
 SHA_PATTERN = re.compile(r"[0-9a-f]{64}")
 SPEC_KEYS = {
@@ -737,6 +776,49 @@ def validate_cell(
     bad = {key: value for key, value in parsed_integrity.items() if value != 0.0}
     if bad:
         raise MilestoneEvalError(f"{path.name} integrity counters nonzero: {bad}")
+    raw_metrics = cell.get("raw_env_metrics")
+    if not isinstance(raw_metrics, dict):
+        raise MilestoneEvalError(
+            f"{path.name} raw environment behavior metrics are missing"
+        )
+    missing_behavior = [key for key in BEHAVIOR_METRIC_KEYS if key not in raw_metrics]
+    if missing_behavior:
+        raise MilestoneEvalError(
+            f"{path.name} raw environment behavior metrics are incomplete: "
+            + ", ".join(missing_behavior)
+        )
+    behavior = {
+        key: finite(raw_metrics[key], f"{path.name} raw_env_metrics.{key}")
+        for key in BEHAVIOR_METRIC_KEYS
+    }
+    negative = {key: value for key, value in behavior.items() if value < 0.0}
+    if negative:
+        raise MilestoneEvalError(
+            f"{path.name} raw environment behavior metrics are negative: {negative}"
+        )
+    bad_fractions = {
+        key: behavior[key]
+        for key in BEHAVIOR_FRACTION_KEYS
+        if behavior[key] > 1.0 + 1e-6
+    }
+    if bad_fractions:
+        raise MilestoneEvalError(
+            f"{path.name} raw environment behavior fractions are invalid: "
+            f"{bad_fractions}"
+        )
+    if (
+        abs(
+            behavior["blocks_thrown_t0"]
+            + behavior["blocks_thrown_t1"]
+            - behavior["blocks_thrown"]
+        )
+        > 2e-4
+    ):
+        raise MilestoneEvalError(
+            f"{path.name} per-side block volume does not sum to total"
+        )
+    focal_team = expected["orientation"]
+    opponent_team = 1 - focal_team
     return {
         **identity,
         "embedded_steps": checkpoint["embedded_steps"],
@@ -750,6 +832,9 @@ def validate_cell(
         "opponent_tds": opponent_tds,
         "focal_checkpoint_sha256": checkpoint["native_sha256"],
         "anchor_checkpoint_sha256": anchor["sha256"],
+        "joint_behavior": behavior,
+        "focal_blocks_thrown": behavior[f"blocks_thrown_t{focal_team}"],
+        "opponent_blocks_thrown": behavior[f"blocks_thrown_t{opponent_team}"],
         "file": path.name,
         "file_sha256": sha256(path),
     }
@@ -1119,6 +1204,12 @@ def analyze(directory: str | Path) -> dict[str, Any]:
                 "macro_score": mean([row["focal_score"] for row in cells]),
                 "macro_tds_for": mean([row["focal_tds"] for row in cells]),
                 "macro_tds_against": mean([row["opponent_tds"] for row in cells]),
+                "macro_focal_blocks_thrown": mean(
+                    [row["focal_blocks_thrown"] for row in cells]
+                ),
+                "macro_opponent_blocks_thrown": mean(
+                    [row["opponent_blocks_thrown"] for row in cells]
+                ),
                 "by_anchor": {
                     anchor["name"]: mean(
                         [
@@ -1139,6 +1230,10 @@ def analyze(directory: str | Path) -> dict[str, Any]:
                     )
                     for orientation in plan["orientations"]
                 },
+                "joint_behavior": {
+                    key: mean([row["joint_behavior"][key] for row in cells])
+                    for key in BEHAVIOR_METRIC_KEYS
+                },
             }
             if points:
                 point["score_delta_previous"] = (
@@ -1152,6 +1247,13 @@ def analyze(directory: str | Path) -> dict[str, Any]:
             point["tds_against_delta_warm"] = (
                 point["macro_tds_against"] - warm["macro_tds_against"]
             )
+            point["focal_blocks_thrown_delta_warm"] = (
+                point["macro_focal_blocks_thrown"] - warm["macro_focal_blocks_thrown"]
+            )
+            point["joint_behavior_delta_warm"] = {
+                key: point["joint_behavior"][key] - warm["joint_behavior"][key]
+                for key in BEHAVIOR_METRIC_KEYS
+            }
         trajectories[str(seed)] = points
         nominations[str(seed)] = nominate(points)
     aggregate_trajectory = []
@@ -1199,6 +1301,9 @@ def analyze(directory: str | Path) -> dict[str, Any]:
         "stage_b_nominations": nominations,
         "warning": (
             "These anchors are unseen exact checkpoints but lineage-connected. "
+            "joint_behavior contains match-level metrics for both policies; "
+            "it diagnoses behavior drift but cannot be attributed to the focal "
+            "policy alone. "
             "The fixed nomination compresses Stage B evaluation; it is not a "
             "reward or production promotion gate. Exact ordinary bootstrap "
             "intervals use only three seed strata and must be read with the "

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -1066,6 +1066,10 @@ def build_cell_payload(
         "anchor_checkpoint_sha256": anchor["sha256"],
         "policy_a": policy_a,
         "policy_b": policy_b,
+        # ``run_cell`` calls verify_plan_sources before match/assembly; that
+        # re-hashes every live implementation file and the config tree against
+        # this frozen identity. Recording the plan value here therefore records
+        # the identity just observed, not an unchecked claim.
         "implementation": plan["implementation"],
         "integrity": integrity,
         "raw_env_metrics": {

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -90,6 +90,10 @@ BEHAVIOR_METRIC_KEYS = (
     "knockdowns_own",
     "carrier_knockdowns",
 )
+SIDE_BEHAVIOR_METRIC_KEYS = ("blocks_thrown_t0", "blocks_thrown_t1")
+JOINT_BEHAVIOR_METRIC_KEYS = tuple(
+    key for key in BEHAVIOR_METRIC_KEYS if key not in SIDE_BEHAVIOR_METRIC_KEYS
+)
 BEHAVIOR_FRACTION_KEYS = (
     "illegal_frac",
     "carrier_block_frac",
@@ -685,6 +689,13 @@ def cell_filename(seed: int, target: int, anchor: str, orientation: int) -> str:
     return f"s{seed}-t{target:012d}-{anchor}-o{orientation}.json"
 
 
+def focal_team_for_orientation(orientation: Any) -> int:
+    """Map the declared backend orientation to the focal policy's team slot."""
+    if isinstance(orientation, bool) or orientation not in (0, 1):
+        raise MilestoneEvalError(f"invalid milestone orientation: {orientation!r}")
+    return int(orientation)
+
+
 def expected_cells(plan: dict[str, Any]) -> list[dict[str, Any]]:
     rows = []
     for seed_index, seed in enumerate(plan["training_seeds"]):
@@ -697,6 +708,7 @@ def expected_cells(plan: dict[str, Any]) -> list[dict[str, Any]]:
                             "target_steps": target,
                             "anchor": anchor["name"],
                             "orientation": orientation,
+                            "focal_team": focal_team_for_orientation(orientation),
                             # Common across milestones in the same stratum.
                             "match_seed": (
                                 30_000
@@ -723,6 +735,7 @@ def validate_cell(
         "target_steps": expected["target_steps"],
         "anchor": expected["anchor"],
         "orientation": expected["orientation"],
+        "focal_team": expected["focal_team"],
         "match_seed": expected["match_seed"],
         "games_requested": plan["games_per_cell"],
         "milestone_eval_manifest_sha256": sha256(
@@ -740,6 +753,25 @@ def validate_cell(
         plan, expected["training_seed"], expected["target_steps"]
     )
     anchor = next(x for x in plan["anchors"] if x["name"] == expected["anchor"])
+    focal_team = focal_team_for_orientation(expected["orientation"])
+    if expected["focal_team"] != focal_team:
+        raise MilestoneEvalError(f"{path.name} focal-team mapping drift")
+    focal_path = checkpoint["native"]
+    anchor_path = anchor["path"]
+    expected_policy_a, expected_policy_b = (
+        (focal_path, anchor_path) if focal_team == 0 else (anchor_path, focal_path)
+    )
+    path_identity = {
+        "focal_checkpoint": focal_path,
+        "anchor_checkpoint": anchor_path,
+        "policy_a": expected_policy_a,
+        "policy_b": expected_policy_b,
+    }
+    for key, value in path_identity.items():
+        if cell.get(key) != value:
+            raise MilestoneEvalError(
+                f"{path.name} {key}={cell.get(key)!r}, expected {value!r}"
+            )
     if cell.get("focal_checkpoint_sha256") != checkpoint["native_sha256"]:
         raise MilestoneEvalError(f"{path.name} focal checkpoint drift")
     if cell.get("anchor_checkpoint_sha256") != anchor["sha256"]:
@@ -817,7 +849,6 @@ def validate_cell(
         raise MilestoneEvalError(
             f"{path.name} per-side block volume does not sum to total"
         )
-    focal_team = expected["orientation"]
     opponent_team = 1 - focal_team
     return {
         **identity,
@@ -832,7 +863,7 @@ def validate_cell(
         "opponent_tds": opponent_tds,
         "focal_checkpoint_sha256": checkpoint["native_sha256"],
         "anchor_checkpoint_sha256": anchor["sha256"],
-        "joint_behavior": behavior,
+        "joint_behavior": {key: behavior[key] for key in JOINT_BEHAVIOR_METRIC_KEYS},
         "focal_blocks_thrown": behavior[f"blocks_thrown_t{focal_team}"],
         "opponent_blocks_thrown": behavior[f"blocks_thrown_t{opponent_team}"],
         "file": path.name,
@@ -1020,7 +1051,10 @@ def run_cell(root: Path, plan_path: Path, cell_path: Path) -> int:
     args["vec"]["num_threads"] = 16
     focal_path = checkpoint["native"]
     anchor_path = anchor["path"]
-    if expected["orientation"] == 0:
+    focal_team = focal_team_for_orientation(expected["orientation"])
+    if expected["focal_team"] != focal_team:
+        raise MilestoneEvalError("cell focal-team mapping drift")
+    if focal_team == 0:
         policy_a, policy_b = focal_path, anchor_path
         focal_key, opponent_key = "env/slot_0_score", "env/slot_1_score"
         focal_tds_key, opponent_tds_key = "env/tds_t0", "env/tds_t1"
@@ -1049,6 +1083,7 @@ def run_cell(root: Path, plan_path: Path, cell_path: Path) -> int:
         focal_tds_key,
         opponent_tds_key,
         *(f"env/{key}" for key in INTEGRITY_KEYS),
+        *(f"env/{key}" for key in BEHAVIOR_METRIC_KEYS),
     ]
     missing = [key for key in required if key not in numeric]
     if missing:
@@ -1072,6 +1107,7 @@ def run_cell(root: Path, plan_path: Path, cell_path: Path) -> int:
                     "target_steps",
                     "anchor",
                     "orientation",
+                    "focal_team",
                     "match_seed",
                 )
             },
@@ -1232,7 +1268,7 @@ def analyze(directory: str | Path) -> dict[str, Any]:
                 },
                 "joint_behavior": {
                     key: mean([row["joint_behavior"][key] for row in cells])
-                    for key in BEHAVIOR_METRIC_KEYS
+                    for key in JOINT_BEHAVIOR_METRIC_KEYS
                 },
             }
             if points:
@@ -1250,9 +1286,13 @@ def analyze(directory: str | Path) -> dict[str, Any]:
             point["focal_blocks_thrown_delta_warm"] = (
                 point["macro_focal_blocks_thrown"] - warm["macro_focal_blocks_thrown"]
             )
+            point["opponent_blocks_thrown_delta_warm"] = (
+                point["macro_opponent_blocks_thrown"]
+                - warm["macro_opponent_blocks_thrown"]
+            )
             point["joint_behavior_delta_warm"] = {
                 key: point["joint_behavior"][key] - warm["joint_behavior"][key]
-                for key in BEHAVIOR_METRIC_KEYS
+                for key in JOINT_BEHAVIOR_METRIC_KEYS
             }
         trajectories[str(seed)] = points
         nominations[str(seed)] = nominate(points)

--- a/tools/run_checkpoint_milestone_eval.py
+++ b/tools/run_checkpoint_milestone_eval.py
@@ -696,6 +696,15 @@ def focal_team_for_orientation(orientation: Any) -> int:
     return int(orientation)
 
 
+def policy_paths_for_orientation(
+    orientation: Any, focal_path: str, anchor_path: str
+) -> tuple[int, str, str]:
+    focal_team = focal_team_for_orientation(orientation)
+    if focal_team == 0:
+        return focal_team, focal_path, anchor_path
+    return focal_team, anchor_path, focal_path
+
+
 def expected_cells(plan: dict[str, Any]) -> list[dict[str, Any]]:
     rows = []
     for seed_index, seed in enumerate(plan["training_seeds"]):
@@ -753,14 +762,13 @@ def validate_cell(
         plan, expected["training_seed"], expected["target_steps"]
     )
     anchor = next(x for x in plan["anchors"] if x["name"] == expected["anchor"])
-    focal_team = focal_team_for_orientation(expected["orientation"])
+    focal_team, expected_policy_a, expected_policy_b = policy_paths_for_orientation(
+        expected["orientation"], checkpoint["native"], anchor["path"]
+    )
     if expected["focal_team"] != focal_team:
         raise MilestoneEvalError(f"{path.name} focal-team mapping drift")
     focal_path = checkpoint["native"]
     anchor_path = anchor["path"]
-    expected_policy_a, expected_policy_b = (
-        (focal_path, anchor_path) if focal_team == 0 else (anchor_path, focal_path)
-    )
     path_identity = {
         "focal_checkpoint": focal_path,
         "anchor_checkpoint": anchor_path,
@@ -838,6 +846,8 @@ def validate_cell(
             f"{path.name} raw environment behavior fractions are invalid: "
             f"{bad_fractions}"
         )
+    if behavior["pickup_success"] > behavior["pickup_attempts"] + 1e-6:
+        raise MilestoneEvalError(f"{path.name} pickup successes exceed pickup attempts")
     if (
         abs(
             behavior["blocks_thrown_t0"]
@@ -1003,6 +1013,69 @@ def require_idle_gpu() -> None:
         )
 
 
+def build_cell_payload(
+    plan_path: Path,
+    plan: dict[str, Any],
+    expected: dict[str, Any],
+    checkpoint: dict[str, Any],
+    anchor: dict[str, Any],
+    numeric: dict[str, float],
+    integrity: dict[str, float],
+) -> dict[str, Any]:
+    """Assemble the exact producer schema consumed by ``validate_cell``."""
+    focal_path = checkpoint["native"]
+    anchor_path = anchor["path"]
+    focal_team, policy_a, policy_b = policy_paths_for_orientation(
+        expected["orientation"], focal_path, anchor_path
+    )
+    if expected["focal_team"] != focal_team:
+        raise MilestoneEvalError("cell focal-team mapping drift")
+    opponent_team = 1 - focal_team
+    focal_key = f"env/slot_{focal_team}_score"
+    opponent_key = f"env/slot_{opponent_team}_score"
+    focal_tds_key = f"env/tds_t{focal_team}"
+    opponent_tds_key = f"env/tds_t{opponent_team}"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_utc": utc_now(),
+        "milestone_eval_manifest_sha256": sha256(plan_path),
+        **{
+            key: expected[key]
+            for key in (
+                "training_seed",
+                "target_steps",
+                "anchor",
+                "orientation",
+                "focal_team",
+                "match_seed",
+            )
+        },
+        "embedded_steps": checkpoint["embedded_steps"],
+        "games_requested": plan["games_per_cell"],
+        "games": numeric["env/n"],
+        "focal_score": numeric[focal_key],
+        "opponent_score": numeric[opponent_key],
+        "draw_rate": numeric["env/draw_rate"],
+        "focal_win_rate": numeric[focal_key] - 0.5 * numeric["env/draw_rate"],
+        "focal_loss_rate": numeric[opponent_key] - 0.5 * numeric["env/draw_rate"],
+        "focal_tds": numeric[focal_tds_key],
+        "opponent_tds": numeric[opponent_tds_key],
+        "focal_checkpoint": focal_path,
+        "focal_checkpoint_sha256": checkpoint["native_sha256"],
+        "anchor_checkpoint": anchor_path,
+        "anchor_checkpoint_sha256": anchor["sha256"],
+        "policy_a": policy_a,
+        "policy_b": policy_b,
+        "implementation": plan["implementation"],
+        "integrity": integrity,
+        "raw_env_metrics": {
+            key.removeprefix("env/"): value
+            for key, value in numeric.items()
+            if key.startswith("env/")
+        },
+    }
+
+
 def run_cell(root: Path, plan_path: Path, cell_path: Path) -> int:
     plan = load_object(plan_path, "milestone manifest")
     validate_plan_contract(plan)
@@ -1051,17 +1124,16 @@ def run_cell(root: Path, plan_path: Path, cell_path: Path) -> int:
     args["vec"]["num_threads"] = 16
     focal_path = checkpoint["native"]
     anchor_path = anchor["path"]
-    focal_team = focal_team_for_orientation(expected["orientation"])
+    focal_team, policy_a, policy_b = policy_paths_for_orientation(
+        expected["orientation"], focal_path, anchor_path
+    )
     if expected["focal_team"] != focal_team:
         raise MilestoneEvalError("cell focal-team mapping drift")
-    if focal_team == 0:
-        policy_a, policy_b = focal_path, anchor_path
-        focal_key, opponent_key = "env/slot_0_score", "env/slot_1_score"
-        focal_tds_key, opponent_tds_key = "env/tds_t0", "env/tds_t1"
-    else:
-        policy_a, policy_b = anchor_path, focal_path
-        focal_key, opponent_key = "env/slot_1_score", "env/slot_0_score"
-        focal_tds_key, opponent_tds_key = "env/tds_t1", "env/tds_t0"
+    opponent_team = 1 - focal_team
+    focal_key = f"env/slot_{focal_team}_score"
+    opponent_key = f"env/slot_{opponent_team}_score"
+    focal_tds_key = f"env/tds_t{focal_team}"
+    opponent_tds_key = f"env/tds_t{opponent_team}"
     logs = pufferl.match(
         env_name="bloodbowl",
         policy_a_path=policy_a,
@@ -1096,45 +1168,15 @@ def run_cell(root: Path, plan_path: Path, cell_path: Path) -> int:
         raise MilestoneEvalError(f"match integrity counters nonzero: {bad}")
     atomic_json(
         cell_path,
-        {
-            "schema_version": SCHEMA_VERSION,
-            "created_utc": utc_now(),
-            "milestone_eval_manifest_sha256": sha256(plan_path),
-            **{
-                key: expected[key]
-                for key in (
-                    "training_seed",
-                    "target_steps",
-                    "anchor",
-                    "orientation",
-                    "focal_team",
-                    "match_seed",
-                )
-            },
-            "embedded_steps": checkpoint["embedded_steps"],
-            "games_requested": plan["games_per_cell"],
-            "games": numeric["env/n"],
-            "focal_score": numeric[focal_key],
-            "opponent_score": numeric[opponent_key],
-            "draw_rate": numeric["env/draw_rate"],
-            "focal_win_rate": (numeric[focal_key] - 0.5 * numeric["env/draw_rate"]),
-            "focal_loss_rate": (numeric[opponent_key] - 0.5 * numeric["env/draw_rate"]),
-            "focal_tds": numeric[focal_tds_key],
-            "opponent_tds": numeric[opponent_tds_key],
-            "focal_checkpoint": focal_path,
-            "focal_checkpoint_sha256": checkpoint["native_sha256"],
-            "anchor_checkpoint": anchor_path,
-            "anchor_checkpoint_sha256": anchor["sha256"],
-            "policy_a": policy_a,
-            "policy_b": policy_b,
-            "implementation": implementation,
-            "integrity": integrity,
-            "raw_env_metrics": {
-                key.removeprefix("env/"): value
-                for key, value in numeric.items()
-                if key.startswith("env/")
-            },
-        },
+        build_cell_payload(
+            plan_path,
+            plan,
+            expected,
+            checkpoint,
+            anchor,
+            numeric,
+            integrity,
+        ),
     )
     validate_cell(cell_path, plan, expected)
     return 0

--- a/tools/test_run_checkpoint_milestone_eval.py
+++ b/tools/test_run_checkpoint_milestone_eval.py
@@ -20,13 +20,19 @@ ZERO_INTEGRITY = {key: 0.0 for key in milestone.INTEGRITY_KEYS}
 
 class MilestoneEvalTests(unittest.TestCase):
     @staticmethod
-    def behavior_metrics(target: int) -> dict[str, float]:
+    def behavior_metrics(target: int, orientation: int) -> dict[str, float]:
         progress = target / 1_000_000_000
+        if orientation == 0:
+            blocks_t0 = 4.0 + progress
+            blocks_t1 = 6.0
+        else:
+            blocks_t0 = 3.0
+            blocks_t1 = 8.0 + 2.0 * progress
         return {
             "illegal_frac": 0.10,
-            "blocks_thrown": 10.0 + progress,
-            "blocks_thrown_t0": 4.0 + progress,
-            "blocks_thrown_t1": 6.0,
+            "blocks_thrown": blocks_t0 + blocks_t1,
+            "blocks_thrown_t0": blocks_t0,
+            "blocks_thrown_t1": blocks_t1,
             "blocks_vs_carrier": 1.0,
             "carrier_block_frac": 0.10,
             "block_1d_frac": 0.20,
@@ -151,6 +157,13 @@ class MilestoneEvalTests(unittest.TestCase):
                 row for row in plan["anchors"] if row["name"] == expected["anchor"]
             )
             score = scores[expected["target_steps"]]
+            focal_path = checkpoint["native"]
+            anchor_path = anchor["path"]
+            policy_a, policy_b = (
+                (focal_path, anchor_path)
+                if expected["focal_team"] == 0
+                else (anchor_path, focal_path)
+            )
             cell = {
                 "schema_version": 1,
                 "milestone_eval_manifest_sha256": manifest_sha,
@@ -159,6 +172,7 @@ class MilestoneEvalTests(unittest.TestCase):
                 "embedded_steps": checkpoint["embedded_steps"],
                 "anchor": expected["anchor"],
                 "orientation": expected["orientation"],
+                "focal_team": expected["focal_team"],
                 "match_seed": expected["match_seed"],
                 "games_requested": milestone.FIXED_GAMES_PER_CELL,
                 "games": milestone.FIXED_GAMES_PER_CELL,
@@ -169,11 +183,17 @@ class MilestoneEvalTests(unittest.TestCase):
                 "focal_loss_rate": 0.8 - score,
                 "focal_tds": 1.0 + score,
                 "opponent_tds": 1.5 - score,
+                "focal_checkpoint": focal_path,
                 "focal_checkpoint_sha256": checkpoint["native_sha256"],
+                "anchor_checkpoint": anchor_path,
                 "anchor_checkpoint_sha256": anchor["sha256"],
+                "policy_a": policy_a,
+                "policy_b": policy_b,
                 "implementation": {},
                 "integrity": dict(ZERO_INTEGRITY),
-                "raw_env_metrics": self.behavior_metrics(expected["target_steps"]),
+                "raw_env_metrics": self.behavior_metrics(
+                    expected["target_steps"], expected["orientation"]
+                ),
             }
             (directory / expected["path"]).write_text(
                 json.dumps(cell, indent=2, sort_keys=True) + "\n",
@@ -210,11 +230,19 @@ class MilestoneEvalTests(unittest.TestCase):
             self.assertAlmostEqual(aggregate["score_delta_warm"]["mean"], 0.11)
             self.assertAlmostEqual(
                 points[2]["joint_behavior_delta_warm"]["blocks_thrown"],
-                2.0,
+                3.0,
             )
             self.assertAlmostEqual(
                 points[2]["focal_blocks_thrown_delta_warm"],
-                1.0,
+                3.0,
+            )
+            self.assertAlmostEqual(
+                points[2]["opponent_blocks_thrown_delta_warm"],
+                0.0,
+            )
+            self.assertNotIn(
+                "blocks_thrown_t0",
+                points[2]["joint_behavior"],
             )
             self.assertEqual(aggregate["score"]["clusters"], 3)
 
@@ -241,6 +269,64 @@ class MilestoneEvalTests(unittest.TestCase):
                 "raw environment behavior metrics",
             ):
                 milestone.validate_cell(path, plan, expected)
+            cell["raw_env_metrics"] = []
+            path.write_text(
+                json.dumps(cell, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                milestone.MilestoneEvalError,
+                "raw environment behavior metrics",
+            ):
+                milestone.validate_cell(path, plan, expected)
+
+    def test_orientation_maps_focal_and_opponent_block_slots(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            plan = self.synthetic_plan(directory)
+            self.write_cells(
+                directory,
+                plan,
+                {target: 0.5 for target in milestone.FIXED_TARGET_STEPS},
+            )
+            expected = [
+                row
+                for row in milestone.expected_cells(plan)
+                if row["training_seed"] == 42
+                and row["target_steps"] == 0
+                and row["anchor"] == "statmatch1"
+            ]
+            rows = {
+                row["orientation"]: milestone.validate_cell(
+                    directory / row["path"], plan, row
+                )
+                for row in expected
+            }
+            self.assertEqual(rows[0]["focal_blocks_thrown"], 4.0)
+            self.assertEqual(rows[0]["opponent_blocks_thrown"], 6.0)
+            self.assertEqual(rows[1]["focal_blocks_thrown"], 8.0)
+            self.assertEqual(rows[1]["opponent_blocks_thrown"], 3.0)
+            orientation_one = next(row for row in expected if row["orientation"] == 1)
+            path = directory / orientation_one["path"]
+            cell = json.loads(path.read_text(encoding="utf-8"))
+            cell["policy_a"], cell["policy_b"] = (
+                cell["policy_b"],
+                cell["policy_a"],
+            )
+            path.write_text(
+                json.dumps(cell, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                milestone.MilestoneEvalError,
+                "policy_a=",
+            ):
+                milestone.validate_cell(path, plan, orientation_one)
+            with self.assertRaisesRegex(
+                milestone.MilestoneEvalError,
+                "invalid milestone orientation",
+            ):
+                milestone.focal_team_for_orientation(2)
 
     def test_invalid_behavior_metrics_are_rejected(self):
         mutations = (
@@ -251,6 +337,14 @@ class MilestoneEvalTests(unittest.TestCase):
             (
                 "fractions are invalid",
                 lambda metrics: metrics.__setitem__("illegal_frac", 1.1),
+            ),
+            (
+                "metrics are negative",
+                lambda metrics: metrics.__setitem__("pass_attempts", -0.1),
+            ),
+            (
+                "metrics are incomplete",
+                lambda metrics: metrics.pop("handoff_attempts"),
             ),
             (
                 "block volume does not sum",

--- a/tools/test_run_checkpoint_milestone_eval.py
+++ b/tools/test_run_checkpoint_milestone_eval.py
@@ -19,6 +19,35 @@ ZERO_INTEGRITY = {key: 0.0 for key in milestone.INTEGRITY_KEYS}
 
 
 class MilestoneEvalTests(unittest.TestCase):
+    @staticmethod
+    def behavior_metrics(target: int) -> dict[str, float]:
+        progress = target / 1_000_000_000
+        return {
+            "illegal_frac": 0.10,
+            "blocks_thrown": 10.0 + progress,
+            "blocks_thrown_t0": 4.0 + progress,
+            "blocks_thrown_t1": 6.0,
+            "blocks_vs_carrier": 1.0,
+            "carrier_block_frac": 0.10,
+            "block_1d_frac": 0.20,
+            "block_2d_frac": 0.60,
+            "block_3d_frac": 0.10,
+            "block_2dred_frac": 0.08,
+            "block_3dred_frac": 0.02,
+            "possession_rate": 0.40,
+            "ball_fwd_adv": 8.0,
+            "ball_path_len": 10.0,
+            "dodge_attempts": 20.0,
+            "gfi_attempts": 18.0,
+            "pickup_attempts": 4.0,
+            "pickup_success": 3.0,
+            "pass_attempts": 0.02,
+            "handoff_attempts": 0.01,
+            "knockdowns_inflicted": 5.0,
+            "knockdowns_own": 2.0,
+            "carrier_knockdowns": 0.5,
+        }
+
     def test_resolve_target_uses_greatest_step_not_above_target(self):
         rows = [
             (100, Path("100.bin")),
@@ -144,6 +173,7 @@ class MilestoneEvalTests(unittest.TestCase):
                 "anchor_checkpoint_sha256": anchor["sha256"],
                 "implementation": {},
                 "integrity": dict(ZERO_INTEGRITY),
+                "raw_env_metrics": self.behavior_metrics(expected["target_steps"]),
             }
             (directory / expected["path"]).write_text(
                 json.dumps(cell, indent=2, sort_keys=True) + "\n",
@@ -178,7 +208,76 @@ class MilestoneEvalTests(unittest.TestCase):
             self.assertFalse(nomination["exploratory"])
             aggregate = report["aggregate_trajectory"][2]
             self.assertAlmostEqual(aggregate["score_delta_warm"]["mean"], 0.11)
+            self.assertAlmostEqual(
+                points[2]["joint_behavior_delta_warm"]["blocks_thrown"],
+                2.0,
+            )
+            self.assertAlmostEqual(
+                points[2]["focal_blocks_thrown_delta_warm"],
+                1.0,
+            )
             self.assertEqual(aggregate["score"]["clusters"], 3)
+
+    def test_cell_without_behavior_metrics_is_rejected(self):
+        """Stage-A cells must preserve the protocol's raw behavior evidence."""
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            plan = self.synthetic_plan(directory)
+            self.write_cells(
+                directory,
+                plan,
+                {target: 0.5 for target in milestone.FIXED_TARGET_STEPS},
+            )
+            expected = milestone.expected_cells(plan)[0]
+            path = directory / expected["path"]
+            cell = json.loads(path.read_text(encoding="utf-8"))
+            del cell["raw_env_metrics"]
+            path.write_text(
+                json.dumps(cell, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(
+                milestone.MilestoneEvalError,
+                "raw environment behavior metrics",
+            ):
+                milestone.validate_cell(path, plan, expected)
+
+    def test_invalid_behavior_metrics_are_rejected(self):
+        mutations = (
+            (
+                "must be finite",
+                lambda metrics: metrics.__setitem__("gfi_attempts", float("nan")),
+            ),
+            (
+                "fractions are invalid",
+                lambda metrics: metrics.__setitem__("illegal_frac", 1.1),
+            ),
+            (
+                "block volume does not sum",
+                lambda metrics: metrics.__setitem__("blocks_thrown_t0", 99.0),
+            ),
+        )
+        for message, mutate in mutations:
+            with self.subTest(
+                message=message
+            ), tempfile.TemporaryDirectory() as temporary:
+                directory = Path(temporary)
+                plan = self.synthetic_plan(directory)
+                self.write_cells(
+                    directory,
+                    plan,
+                    {target: 0.5 for target in milestone.FIXED_TARGET_STEPS},
+                )
+                expected = milestone.expected_cells(plan)[0]
+                path = directory / expected["path"]
+                cell = json.loads(path.read_text(encoding="utf-8"))
+                mutate(cell["raw_env_metrics"])
+                path.write_text(
+                    json.dumps(cell, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+                with self.assertRaisesRegex(milestone.MilestoneEvalError, message):
+                    milestone.validate_cell(path, plan, expected)
 
     def test_exact_cluster_bootstrap_uses_all_seed_resamples(self):
         summary = milestone.exact_cluster_bootstrap([0.4, 0.5, 0.6])

--- a/tools/test_run_checkpoint_milestone_eval.py
+++ b/tools/test_run_checkpoint_milestone_eval.py
@@ -148,7 +148,7 @@ class MilestoneEvalTests(unittest.TestCase):
         return plan
 
     def write_cells(self, directory: Path, plan: dict, scores: dict[int, float]):
-        manifest_sha = milestone.sha256(directory / "MILESTONE_EVAL_MANIFEST.json")
+        manifest_path = directory / "MILESTONE_EVAL_MANIFEST.json"
         for expected in milestone.expected_cells(plan):
             checkpoint = milestone.checkpoint_record(
                 plan, expected["training_seed"], expected["target_steps"]
@@ -157,44 +157,32 @@ class MilestoneEvalTests(unittest.TestCase):
                 row for row in plan["anchors"] if row["name"] == expected["anchor"]
             )
             score = scores[expected["target_steps"]]
-            focal_path = checkpoint["native"]
-            anchor_path = anchor["path"]
-            policy_a, policy_b = (
-                (focal_path, anchor_path)
-                if expected["focal_team"] == 0
-                else (anchor_path, focal_path)
-            )
-            cell = {
-                "schema_version": 1,
-                "milestone_eval_manifest_sha256": manifest_sha,
-                "training_seed": expected["training_seed"],
-                "target_steps": expected["target_steps"],
-                "embedded_steps": checkpoint["embedded_steps"],
-                "anchor": expected["anchor"],
-                "orientation": expected["orientation"],
-                "focal_team": expected["focal_team"],
-                "match_seed": expected["match_seed"],
-                "games_requested": milestone.FIXED_GAMES_PER_CELL,
-                "games": milestone.FIXED_GAMES_PER_CELL,
-                "focal_score": score,
-                "opponent_score": 1.0 - score,
-                "draw_rate": 0.4,
-                "focal_win_rate": score - 0.2,
-                "focal_loss_rate": 0.8 - score,
-                "focal_tds": 1.0 + score,
-                "opponent_tds": 1.5 - score,
-                "focal_checkpoint": focal_path,
-                "focal_checkpoint_sha256": checkpoint["native_sha256"],
-                "anchor_checkpoint": anchor_path,
-                "anchor_checkpoint_sha256": anchor["sha256"],
-                "policy_a": policy_a,
-                "policy_b": policy_b,
-                "implementation": {},
-                "integrity": dict(ZERO_INTEGRITY),
-                "raw_env_metrics": self.behavior_metrics(
-                    expected["target_steps"], expected["orientation"]
-                ),
+            focal_team = expected["focal_team"]
+            opponent_team = 1 - focal_team
+            numeric = {
+                "env/n": float(milestone.FIXED_GAMES_PER_CELL),
+                f"env/slot_{focal_team}_score": score,
+                f"env/slot_{opponent_team}_score": 1.0 - score,
+                "env/draw_rate": 0.4,
+                f"env/tds_t{focal_team}": 1.0 + score,
+                f"env/tds_t{opponent_team}": 1.5 - score,
+                **{f"env/{key}": value for key, value in ZERO_INTEGRITY.items()},
+                **{
+                    f"env/{key}": value
+                    for key, value in self.behavior_metrics(
+                        expected["target_steps"], expected["orientation"]
+                    ).items()
+                },
             }
+            cell = milestone.build_cell_payload(
+                manifest_path,
+                plan,
+                expected,
+                checkpoint,
+                anchor,
+                numeric,
+                dict(ZERO_INTEGRITY),
+            )
             (directory / expected["path"]).write_text(
                 json.dumps(cell, indent=2, sort_keys=True) + "\n",
                 encoding="utf-8",
@@ -322,11 +310,12 @@ class MilestoneEvalTests(unittest.TestCase):
                 "policy_a=",
             ):
                 milestone.validate_cell(path, plan, orientation_one)
-            with self.assertRaisesRegex(
-                milestone.MilestoneEvalError,
-                "invalid milestone orientation",
-            ):
-                milestone.focal_team_for_orientation(2)
+            for invalid in (2, True, False):
+                with self.subTest(invalid=invalid), self.assertRaisesRegex(
+                    milestone.MilestoneEvalError,
+                    "invalid milestone orientation",
+                ):
+                    milestone.focal_team_for_orientation(invalid)
 
     def test_invalid_behavior_metrics_are_rejected(self):
         mutations = (
@@ -349,6 +338,10 @@ class MilestoneEvalTests(unittest.TestCase):
             (
                 "block volume does not sum",
                 lambda metrics: metrics.__setitem__("blocks_thrown_t0", 99.0),
+            ),
+            (
+                "pickup successes exceed pickup attempts",
+                lambda metrics: metrics.__setitem__("pickup_success", 99.0),
             ),
         )
         for message, mutate in mutations:


### PR DESCRIPTION
## Summary
- fail closed when Stage-A milestone cells omit or corrupt the predeclared behavior telemetry
- preserve validated joint-behavior trajectories and focal/opponent block-volume deltas in the final report
- make orientation-to-team mapping and policy path identity explicit and swap-tested
- generate test cells through the production payload assembler so producer and validator schemas cannot drift
- document the live telemetry-key, semantics, and float-tolerance preflight

## Evidence
- BH-001 reproduced: a cell without raw behavior metrics previously validated successfully
- 171 Python reward/replay/queue/evaluator contract tests pass (2 platform skips)
- Ruff lint/format and whitespace checks pass
- 392 engine, 27 reward, and 2 contact-bot tests pass normally and under ASan/UBSan
- exact current native panel contains all 23 required fields; per-team block sum differed from total by less than 5e-7
- three bounded tools-disabled Fable reviews drove the focal mapping, swap-sensitive tests, joint-label correction, and producer/validator unification

This changes only the separate post-run evaluator and protocol. It does not modify or deploy into the active frozen training queue, and it cannot promote a checkpoint or reward.