### PR TITLE
Harden demo state bank loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,11 @@ changes a reward, active queue, production default, or promotion verdict.
   The strict non-empty BB2025 allowlist has 9,118 replay IDs and 1,622,231
   joined records. See `runs/replay-audit-20260713/`.
 - Never mix BB2020 records into BB2025 training or evaluation.
+- A BBS1 match-size/fingerprint match proves build compatibility, not record
+  integrity. Preserve `bbe_state_bank_match_valid`: before a demo record can
+  enter reset selection it must have bounded procedure/team/enum indices,
+  bidirectionally consistent grid/player coordinates, and a valid ball state.
+  New bank writers and readers must fail closed on malformed raw snapshots.
 - The historical BBS state bank is mixed by source replay: 123 of 15,471
   records come from 42 BB2020 replay IDs. Before any future replay-state
   scenario/curriculum, run `tools/filter_state_bank.py` with the pinned mixed-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ newer evidence wins.
   the hash-pinned, manifest-producing `tools/filter_state_bank.py` subset: 15,348
   records from 5,328 strict BB2025 IDs. It remains all half one and opening-
   censored; filtering edition does not create passing or late-game coverage.
+  The BBS1 fingerprint is an ABI/build guard, not content validation; preserve
+  the loader's bounds, enum, grid/player, and ball-state checks for every raw
+  snapshot before it can enter curriculum reset selection.
 - **Strict-bank scenario coverage (D192):** `bank_scenario_scan` and
   `report_scenario_coverage.py` classify overlapping S1–S6 opportunity
   structures only; they do not label actions, outcomes, regret, or curriculum

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ LIB      := $(BUILD)/libbb.a
 TESTBIN  := $(BUILD)/bb_tests
 PUFFER_REWARD_TESTBIN := $(BUILD)/puffer_reward_tests
 PUFFER_CONTACT_TESTBIN := $(BUILD)/puffer_contact_bot_tests
-PUFFER_TESTBINS := $(PUFFER_REWARD_TESTBIN) $(PUFFER_CONTACT_TESTBIN)
+PUFFER_STATE_BANK_TESTBIN := $(BUILD)/puffer_state_bank_tests
+PUFFER_TESTBINS := $(PUFFER_REWARD_TESTBIN) $(PUFFER_CONTACT_TESTBIN) $(PUFFER_STATE_BANK_TESTBIN)
 
 .PHONY: all test asan fuzz coverage coverage-run lockstep ballstats blockstats human-ball-advancement blockev-mc scenario-scan clean
 
@@ -54,10 +55,14 @@ $(PUFFER_REWARD_TESTBIN): puffer/bloodbowl/test_reward_send_off.c puffer/bloodbo
 $(PUFFER_CONTACT_TESTBIN): puffer/bloodbowl/test_contact_bot.c puffer/bloodbowl/bloodbowl.h puffer/bloodbowl/contact_bot.h engine/tests/bb_test.h
 	$(CC) $(CFLAGS) -Iengine/tests -Ipuffer/bloodbowl -Wno-unused-function $< -o $@ -lm $(LDFLAGS)
 
+$(PUFFER_STATE_BANK_TESTBIN): puffer/bloodbowl/test_state_bank.c puffer/bloodbowl/bloodbowl.h engine/tests/bb_test.h engine/tests/bb_fixtures.h
+	$(CC) $(CFLAGS) -Iengine/tests -Ipuffer/bloodbowl -Wno-unused-function $< -o $@ -lm $(LDFLAGS)
+
 test: $(TESTBIN) $(PUFFER_TESTBINS)
 	./$(TESTBIN) $(TEST)
 	./$(PUFFER_REWARD_TESTBIN) $(TEST)
 	./$(PUFFER_CONTACT_TESTBIN) $(TEST)
+	./$(PUFFER_STATE_BANK_TESTBIN) $(TEST)
 
 blockev-mc: $(OBJ)
 	$(CC) $(CFLAGS) -Iengine/tests tools/blockev_mc.c $(OBJ) -o $(BUILD)/blockev_mc -lm

--- a/puffer/bloodbowl/bloodbowl.h
+++ b/puffer/bloodbowl/bloodbowl.h
@@ -1407,6 +1407,70 @@ static uint32_t bbe_le32(const uint8_t* b) {
            ((uint32_t)b[3] << 24);
 }
 
+// BBS1's fingerprint rejects snapshots from a different engine build, but it
+// does not authenticate each raw bb_match record. Reject index-bearing bytes
+// that reset, observation encoding, reward pricing, or procedure dispatch may
+// dereference before a banked state reaches those paths. This is structural
+// validation for trusted, locally built banks, not a general wire format.
+static int bbe_state_bank_match_valid(const bb_match* match) {
+    if (match->status != BB_STATUS_DECISION || match->stack_top == 0 ||
+        match->stack_top > BB_STACK_MAX ||
+        match->team_id[0] >= BB_TEAM_COUNT ||
+        match->team_id[1] >= BB_TEAM_COUNT ||
+        match->active_team > BB_AWAY || match->kicking_team > BB_AWAY ||
+        match->decision_team > BB_AWAY ||
+        match->weather > BB_WEATHER_BLIZZARD) {
+        return 0;
+    }
+
+    for (int depth = 0; depth < match->stack_top; depth++) {
+        if (match->stack[depth].proc <= BB_PROC_NONE ||
+            match->stack[depth].proc >= BB_PROC_COUNT) {
+            return 0;
+        }
+    }
+
+    for (int slot = 0; slot < BB_NUM_PLAYERS; slot++) {
+        const bb_player* player = &match->players[slot];
+        if (player->position_id >= BB_MAX_POSITIONS ||
+            player->location > BB_LOC_ABSENT ||
+            player->stance > BB_STANCE_STUNNED_USED) {
+            return 0;
+        }
+        if (player->location == BB_LOC_ON_PITCH &&
+            (!bb_on_pitch_xy(player->x, player->y) ||
+             match->grid[player->x][player->y] != slot + 1)) {
+            return 0;
+        }
+    }
+
+    for (int x = 0; x < BB_PITCH_LEN; x++) {
+        for (int y = 0; y < BB_PITCH_WID; y++) {
+            uint8_t value = match->grid[x][y];
+            if (value == 0) continue;
+            int slot = value - 1;
+            if (slot >= BB_NUM_PLAYERS ||
+                match->players[slot].location != BB_LOC_ON_PITCH ||
+                match->players[slot].x != x ||
+                match->players[slot].y != y) {
+                return 0;
+            }
+        }
+    }
+
+    if (match->ball.state > BB_BALL_IN_AIR) return 0;
+    if (match->ball.state == BB_BALL_ON_GROUND &&
+        !bb_on_pitch_xy(match->ball.x, match->ball.y)) {
+        return 0;
+    }
+    if (match->ball.state == BB_BALL_HELD &&
+        (match->ball.carrier >= BB_NUM_PLAYERS ||
+         match->players[match->ball.carrier].location != BB_LOC_ON_PITCH)) {
+        return 0;
+    }
+    return 1;
+}
+
 // Load the bank once. Call sites: the binding's init entry points (before
 // any stepping thread exists) and, for standalone callers (driver, tests),
 // lazily from the first bbe_reset_match with demo_reset_pct > 0.
@@ -1450,23 +1514,7 @@ static void bbe_state_bank_load(void) {
             fread(&bank[kept], sizeof(bb_match), 1, f) != 1) {
             break;
         }
-        // Resumable points only; anything else would error out of c_step.
-        // Index-bearing bytes are validated too: reward pricing and obs
-        // encoding index team/position tables with them, and the BBS1
-        // fingerprint guards the engine BUILD, not record content (panel).
-        if (bank[kept].status == BB_STATUS_DECISION &&
-            bank[kept].stack_top > 0 &&
-            bank[kept].team_id[0] < BB_TEAM_COUNT &&
-            bank[kept].team_id[1] < BB_TEAM_COUNT) {
-            int ok = 1;
-            for (int s = 0; s < BB_NUM_PLAYERS; s++) {
-                if (bank[kept].players[s].position_id >= BB_MAX_POSITIONS) {
-                    ok = 0;
-                    break;
-                }
-            }
-            kept += ok;
-        }
+        kept += bbe_state_bank_match_valid(&bank[kept]);
     }
     fclose(f);
     if (kept == 0) {

--- a/puffer/bloodbowl/test_state_bank.c
+++ b/puffer/bloodbowl/test_state_bank.c
@@ -1,0 +1,115 @@
+#define BB_TEST_MAIN
+#include "bb_test.h"
+#include "bloodbowl.h"
+#include "bb_fixtures.h"
+
+#include <unistd.h>
+
+static void write_le32(FILE* file, uint32_t value) {
+    uint8_t bytes[4] = {
+        (uint8_t)value,
+        (uint8_t)(value >> 8),
+        (uint8_t)(value >> 16),
+        (uint8_t)(value >> 24),
+    };
+    BB_CHECK_EQ(fwrite(bytes, 1, sizeof bytes, file), sizeof bytes);
+}
+
+static void write_state_bank(const char* path, const bb_match* match) {
+    FILE* file = fopen(path, "wb");
+    BB_CHECK(file != NULL);
+    if (file == NULL) return;
+
+    BB_CHECK_EQ(fwrite("BBS1", 1, 4, file), 4);
+    write_le32(file, 1u);
+    write_le32(file, (uint32_t)sizeof(bb_match));
+    write_le32(file, bbe_state_fingerprint());
+    uint8_t metadata[BBE_STATE_BANK_REC_META] = {0};
+    BB_CHECK_EQ(fwrite(metadata, 1, sizeof metadata, file), sizeof metadata);
+    BB_CHECK_EQ(fwrite(match, sizeof *match, 1, file), 1);
+    BB_CHECK_EQ(fclose(file), 0);
+}
+
+static void reset_state_bank_loader(const char* path) {
+    free(bbe_state_bank);
+    bbe_state_bank = NULL;
+    bbe_state_bank_n = 0;
+    bbe_state_bank_tried = 0;
+    bbe_state_bank_path = path;
+}
+
+static bb_match valid_bank_match(void) {
+    bb_match match;
+    fx_match_midturn(&match, BB_HOME, 2);
+    fx_lineman(&match, BB_HOME, 0, 8, 7);
+    fx_lineman(&match, BB_AWAY, 0, 17, 7);
+    bb_rng rng;
+    bb_rng_seed(&rng, 0xB4A6u, 3);
+    BB_CHECK_EQ(fx_run(&match, &rng), BB_STATUS_DECISION);
+    return match;
+}
+
+static int load_one(const char* path, const bb_match* match) {
+    write_state_bank(path, match);
+    reset_state_bank_loader(path);
+    bbe_state_bank_load();
+    return bbe_state_bank_n;
+}
+
+BB_TEST(state_bank_rejects_unsafe_record_content) {
+    char path[256];
+    snprintf(path, sizeof path, "/tmp/bloodbowl-state-bank-%ld.bbs",
+             (long)getpid());
+
+    bb_match valid = valid_bank_match();
+    BB_CHECK_EQ(load_one(path, &valid), 1);
+
+    bb_match bad_stack = valid;
+    bad_stack.stack_top = BB_STACK_MAX + 1;
+    BB_CHECK_EQ(load_one(path, &bad_stack), 0);
+
+    bb_match bad_player_coord = valid;
+    bad_player_coord.players[0].x = BB_PITCH_LEN;
+    BB_CHECK_EQ(load_one(path, &bad_player_coord), 0);
+
+    bb_match bad_player_enum = valid;
+    bad_player_enum.players[0].location = BB_LOC_ABSENT + 1;
+    BB_CHECK_EQ(load_one(path, &bad_player_enum), 0);
+
+    bb_match bad_grid = valid;
+    bad_grid.grid[8][7] = BB_NUM_PLAYERS + 1;
+    BB_CHECK_EQ(load_one(path, &bad_grid), 0);
+
+    bb_match bad_ball = valid;
+    bad_ball.ball.state = BB_BALL_HELD;
+    bad_ball.ball.carrier = BB_NUM_PLAYERS;
+    BB_CHECK_EQ(load_one(path, &bad_ball), 0);
+
+    bb_match bad_ground_ball = valid;
+    bad_ground_ball.ball.state = BB_BALL_ON_GROUND;
+    bad_ground_ball.ball.x = BB_PITCH_LEN;
+    BB_CHECK_EQ(load_one(path, &bad_ground_ball), 0);
+
+    bb_match bad_proc = valid;
+    bad_proc.stack[0].proc = BB_PROC_COUNT;
+    BB_CHECK_EQ(load_one(path, &bad_proc), 0);
+
+    bb_match bad_team_selector = valid;
+    bad_team_selector.active_team = BB_AWAY + 1;
+    BB_CHECK_EQ(load_one(path, &bad_team_selector), 0);
+
+    bad_team_selector = valid;
+    bad_team_selector.kicking_team = BB_AWAY + 1;
+    BB_CHECK_EQ(load_one(path, &bad_team_selector), 0);
+
+    bad_team_selector = valid;
+    bad_team_selector.decision_team = BB_AWAY + 1;
+    BB_CHECK_EQ(load_one(path, &bad_team_selector), 0);
+
+    bb_match bad_weather = valid;
+    bad_weather.weather = BB_WEATHER_BLIZZARD + 1;
+    BB_CHECK_EQ(load_one(path, &bad_weather), 0);
+
+    reset_state_bank_loader(BBE_STATE_BANK_PATH);
+    BB_CHECK_EQ(remove(path), 0);
+}


### PR DESCRIPTION
## Summary

- reject structurally unsafe raw BBS1 snapshots before curriculum reset selection
- validate procedure/team/enum indices, bidirectional pitch occupancy, coordinates, and ball state
- add a focused state-bank ingestion test target and preserve the invariant in AGENTS.md and CLAUDE.md

## Confirmed bug

The pre-fix regression accepted five unsafe mutations: stack_top above BB_STACK_MAX, an on-pitch player outside the pitch, an invalid grid slot, an invalid held-ball carrier, and a procedure ID at BB_PROC_COUNT. These records can later reach array indexing or dispatch during reset and observation generation.

## Verification

- make test: 401 engine + 37 reward + 2 contact-bot + 1 loader tests, all green
- make asan: same suite under ASan/UBSan, all green
- historical 34,840,708-byte BBS1 bank: all 15,471 records retained; two forced demo-reset episodes completed with zero fallback
- git diff --check

## Operational boundary

This is not deployed into or rebuilt on the occupied RTX 2070 training checkout. It is a prerequisite for future authored fixture banks.