### PR TITLE
Gate training on obs-v5 checkpoint lineage

### DIFF
--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -277,10 +277,15 @@ for immutable experiment manifests, result files, or completion proofs.
 Select checkpoints by embedded step plus manifest/hash, not newest mtime. Verify
 observation lineage, source/module identity, size, and architecture before
 loading. Current source uses obs-v5 at 2782 bytes. Obs-v4 is also 2782 bytes but
-semantically incompatible; active historical/live v4 runs remain valid only in
-their deliberately pinned v4 runtime. Flat checkpoint shape cannot distinguish
-v4 from v5. Older obs-v3 is shape-incompatible unless deliberately converted
-with the correct `--obs-size 1612`.
+semantically incompatible. For current training, require the canonical adjacent
+checkpoint lineage sidecar and validate it with `tools/checkpoint_lineage.py`;
+never authorize by size or filename. Qualification-only checkpoints are not
+warm starts or pool seeds. The exact-action canary runs with `WARM` and `POOL`
+unset and zero frozen banks; inherited shell variables must be removed.
+Active historical/live v4 runs remain valid only in their deliberately pinned
+v4 runtime. Flat checkpoint shape cannot distinguish v4 from v5. Older obs-v3
+is shape-incompatible unless deliberately converted with the correct
+`--obs-size 1612`.
 
 Native↔Torch conversion is lossy with respect to biases: native-to-Torch
 zero-fills them and Torch-to-native drops them. Apply conversions symmetrically,

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -117,8 +117,8 @@ checkpoints, and remember that stopped instances can be reclaimed.
   **`training/bc_v4.bin`** (val exact 0.508, D53) and the 2.09M v4 pairs under
   `validation/pairs_v4` remain valid only in an explicitly pinned obs-v4 runtime.
   Never warm-start or evaluate them under the current v5 runtime merely because
-  the shape loads. New obs-v5 exports use BBP v3; the streaming loader rejects a
-  mixed v2/v3 corpus even though both lineages have 2782-byte observations.
+  the shape loads. New exact-action obs-v5 exports use BBP v4; current BC/action
+  training rejects BBP v1-v3 even though the tensor dimensions still match.
 - **OBS SIZE SYNC POINTS — all three must agree:**
   1. `BBE_OBS_SIZE` in `puffer/bloodbowl/bloodbowl.h` (~line 96)
   2. `#define OBS_SIZE` in `puffer/bloodbowl/binding.c` line 8
@@ -130,6 +130,17 @@ checkpoints, and remember that stopped instances can be reclaimed.
   obs-v5 are instead same-shape but semantically incompatible. Flat checkpoints
   do not carry an observation-lineage header, so require a pinned source/module
   identity and external manifest; never infer compatibility from dimensions.
+- Current checkpoints require the canonical adjacent `.lineage.json` produced
+  and validated by `tools/checkpoint_lineage.py`. It binds the checkpoint hash,
+  obs-v5/exact-joint-v1 ABI, policy shape, producer manifest, source/module/
+  Puffer patch identities, and ancestry eligibility. Missing, mismatched, or
+  qualification-only sidecars are not accepted warm starts or pool seeds.
+  `tools/build_league.py` requires and copies eligible lineage by default;
+  `--legacy-unlabeled` is for historical reconstruction only.
+- The `exact-action-canary` is a fixed fresh-initialization qualification run.
+  Launch it with both `WARM` and `POOL` absent (use `env -u WARM -u POOL` when
+  the shell may inherit them). It uses zero frozen banks, and its output is
+  permanently marked qualification-only; do not continue from it.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,6 +499,15 @@ changes a reward, active queue, production default, or promotion verdict.
   Blob size cannot distinguish v4 from v5; require source/module provenance and
   do not warm-start, mix replay observations, or directly compare curves across
   that boundary without a separately reviewed bridge. See `docs/obs-v5-spec.md`.
+  Current flat checkpoints require the canonical
+  `<checkpoint>.lineage.json` sidecar; `tools/checkpoint_lineage.py` binds the
+  blob to obs-v5, exact-joint-v1, policy shape, source/module/Puffer-patch
+  identities, producer manifest, and ancestry eligibility. Same-size unlabeled
+  blobs fail closed. `tools/build_league.py` copies only eligible sidecars by
+  default; `--legacy-unlabeled` is historical reconstruction only and does not
+  make a pool admissible to repaired launchers. The 50M exact-action canary must
+  run fresh with `WARM` and `POOL` unset, zero frozen banks, and its
+  qualification-only checkpoint must never become ancestry.
 - Apply the audited Puffer patches in repository order and test them. Important
   patches include the env phase contract, eval episode gate, dynamic metrics-key
   fix, trusted Torch load, and exact joint-action changes. For Blood Bowl,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,15 @@ newer evidence wins.
 
 ### Obs / checkpoints / build
 - **obs-v5 = 2782 bytes** (obs-v4 probability planes plus decision-window truth; spec `docs/obs-v5-spec.md`). Rolled block faces are visible at reroll/choose windows, TEST kind and active movement expenditure are explicit, invalid ball coordinates zero, and Touchback placements are spatially addressable. **Three OBS_SIZE sync points must agree** (static asserts catch 2 of 3): `BBE_OBS_SIZE` in `puffer/bloodbowl/bloodbowl.h`, `#define OBS_SIZE` in `puffer/bloodbowl/binding.c:8`, `--obs-size` in `training/convert_checkpoint.py` (default 2782; v3 ckpts need `--obs-size 1612`). Obs-v4 has the same shape but different semantics: blob size cannot distinguish it, so require source/module provenance and no v4 warm-start, replay mixing, or direct curve comparison without a reviewed bridge. Obs-v3 and older checkpoints remain input-shape **incompatible**.
+- **Current checkpoint lineage is external and mandatory.** A flat blob has no
+  header; require its canonical `.lineage.json` from
+  `tools/checkpoint_lineage.py`, which binds obs-v5/exact-joint-v1, policy
+  shape, checkpoint hash, producer manifest, source/module/Puffer patch hashes,
+  and eligibility. Repaired warm/pool launchers reject missing, mismatched, or
+  qualification-only sidecars. Build current pools with `tools/build_league.py`;
+  `--legacy-unlabeled` is historical reconstruction only. Launch the disposable
+  exact-action canary with `WARM` and `POOL` unset: it is fresh, pool-free, and
+  permanently ineligible as ancestry.
 - **`puffer/bloodbowl/` is the SOURCE OF TRUTH; `vendor/PufferLib/ocean/bloodbowl/` is an installed snapshot** written by `tools/install_puffer_env.sh` — the build compiles the snapshot, NOT your edit. The snapshot can lag (the Mac checkout's may still say 1612). Drift guard: `tools/install_puffer_env.sh --check` (exit 1 = re-install). Run it before any build on a training box.
 - After ANY env code change, ON THE TARGET: `bash tools/install_puffer_env.sh`,
   `bash tools/install_puffer_env.sh --check`, then

--- a/docs/obs-v5-spec.md
+++ b/docs/obs-v5-spec.md
@@ -97,6 +97,14 @@ names an offered engine action (or an explicit macro-move env action).
   semantically interchangeable with obs-v5 despite shape compatibility.
 - Do not warm-start a v5 run from v4, compare their curves as one lineage, or
   merge their replay pairs without a separately reviewed bridge experiment.
+- Current flat checkpoints require the canonical adjacent `.lineage.json` from
+  `tools/checkpoint_lineage.py`. The record binds checkpoint content,
+  obs-v5/exact-joint-v1 semantics, policy shape, producer manifest,
+  source/module/Puffer-patch identities, and ancestry eligibility. Blob size,
+  output-head sizes, filename, and location are never lineage evidence.
+- The 50M exact-action canary starts fresh with no warm checkpoint, no external
+  pool, and zero frozen banks. Its lineage is qualification-only and must be
+  rejected as a warm start, pool seed, promotion candidate, or causal result.
 - Re-extract behavioral-cloning observations under v5 before treating replay
   supervision as information-set matched.
 - Existing live v4 runs and BBTV viewers keep their pinned builds until normal

--- a/docs/plans/exact-action-error-budget.md
+++ b/docs/plans/exact-action-error-budget.md
@@ -79,14 +79,17 @@ canary is disposable qualification evidence, not a warm start or a result cell.
 Launch that stage only through the dedicated one-arm profile:
 
 ```bash
-WARM=/abs/warm.bin POOL=/abs/pool STEPS=50000000 \
+env -u WARM -u POOL STEPS=50000000 \
   SCREEN_PROFILE=exact-action-canary PREFIX=exact-action-canary-v1 \
   bash tools/run_reward_screen.sh
 ```
 
 The profile accepts exactly 50M requested steps, freezes R0, seed 42, and one
-arm, rejects candidate-selection inputs, and records `qualification_only: true`
-in `SCREEN_MANIFEST.json`.
+arm, rejects candidate-selection and legacy warm/pool inputs, uses deterministic
+fresh obs-v5 initialization with no frozen banks, and records
+`qualification_only: true` in `SCREEN_MANIFEST.json`. Its checkpoint receives a
+hash-bound lineage sidecar that makes it permanently ineligible as a warm start
+or pool seed.
 
 ## Success criteria
 

--- a/docs/plans/fresh-obs-v5-qualification-lineage.md
+++ b/docs/plans/fresh-obs-v5-qualification-lineage.md
@@ -1,0 +1,161 @@
+# Fresh obs-v5 qualification and checkpoint lineage
+
+Status: source implementation and local verification complete, 2026-07-21.
+Source-only work remains isolated from the active RTX 2070 recovery queue and
+BBTV. This plan does not authorize deployment or reuse a qualification
+checkpoint as training ancestry.
+
+Base: `origin/main` at `c7eb510b604de7fbda030dd0b6a5b82a095fc42d`.
+
+## Why this tranche is next
+
+D217 made obs-v5 a semantic ABI break while deliberately retaining obs-v4's
+2,782-byte tensor shape. D218 changed the behavior policy from marginal heads
+plus decoder repair to exact sequential joint-action sampling without changing
+the three output-head sizes. Blob size therefore cannot distinguish either
+boundary.
+
+D219's next deployment stage is a 50M-step `exact-action-canary`, but the
+current screen and arm launchers require the historical obs-v4 warm checkpoint
+and four-bank marginal-action pool for every profile. Those inputs are
+guaranteed to be the wrong lineage for the repaired runtime even though they
+pass every byte-size check. A canary launched under that contract could not
+qualify obs-v5 or exact-action training.
+
+This tranche repairs the authorization boundary before GPU work resumes. The
+canary becomes deterministic fresh obs-v5 self-play with no warm checkpoint or
+frozen pool. Any later non-fresh v5 launch must present content-addressed
+lineage records; an unlabeled same-size blob fails closed.
+
+## Frozen compatibility contract
+
+The accepted repaired lineage is:
+
+- observation ABI `obs-v5`, semantic version `5`;
+- action ABI `exact-joint-v1`;
+- policy hidden size `512`, three layers, expansion factor `1`;
+- native flat-fp32 checkpoint size `16,066,560` bytes;
+- exact installed environment source, imported module, Puffer patch bundle,
+  and producing run-manifest identities.
+
+An `exact-action-canary`:
+
+- requires `WARM` and `POOL` to be absent;
+- uses fixed fresh initialization and the frozen seed;
+- disables frozen banks and external league preseeding;
+- records `qualification_only: true` and cannot produce promotable ancestry;
+- omits both `--load-model-path` and `--selfplay.league-preseed` from the
+  effective trainer command.
+
+Historical analysis remains readable. This contract changes launch admission,
+not old artifacts or their interpretation.
+
+## Test-first implementation slices
+
+1. Add launcher regressions proving the canary rejects either legacy input
+   before artifact creation and emits a fresh, pool-free command contract.
+2. Add one small `checkpoint_lineage.py` authority that writes and validates
+   canonical, content-addressed lineage sidecars. Cover missing, malformed,
+   hash-mismatched, ABI-mismatched, implementation-mismatched, and
+   qualification-only inputs.
+3. Split the arm launcher into explicit `fresh-v5-qualification` and
+   `lineage-v5` bootstrap modes. Fresh qualification has no external assets;
+   lineage-v5 requires a valid warm sidecar and valid sidecars for every pool
+   bank before trainer construction.
+4. Freeze bootstrap/ABI/ancestry fields into screen and arm manifests, then
+   validate them again when materializing results or recovering an arm.
+5. Publish a lineage sidecar for each accepted final checkpoint, binding it to
+   the checkpoint, producing run manifest, source/module/patch identities, and
+   qualification status.
+6. Make `build_league.py` require and copy accepted lineage sidecars for current
+   v5 pools; retain an explicitly named legacy-analysis mode only for historical
+   reconstruction outside accepted training launchers.
+7. Update D217-D219 operating guidance after the executable contract passes.
+
+## Acceptance tests
+
+- Canary plus `WARM` or `POOL` fails before creating `OUT_DIR`.
+- Canary without either input reaches plan validation and its frozen command
+  contains no warm load, league preseed, or frozen-bank allocation.
+- Its screen and run manifests state fresh obs-v5/exact-joint initialization,
+  fixed policy shape, fixed seed, zero frozen banks, and qualification-only.
+- Same-size synthetic obs-v4/marginal checkpoint sidecars are rejected.
+- Missing, malformed, noncanonical, hash-drifted, ABI-drifted, policy-drifted,
+  source/module/patch-drifted, and qualification-only ancestry are rejected.
+- One unlabeled or incompatible pool bank rejects the whole pool before any
+  output is committed.
+- Mutating any checkpoint or implementation identity invalidates the sidecar.
+- Accepted result materialization writes a deterministic lineage sidecar and
+  recovery recomputes and compares it instead of trusting its presence.
+- Existing historical analysis tests remain green.
+
+Run:
+
+```text
+python3 -m unittest tools.test_checkpoint_lineage
+python3 -m unittest tools.test_experiment_contracts
+python3 -m unittest tools.test_build_league
+python3 -m unittest discover -s tools -p 'test_*.py'
+PYTHONPATH=training python3.11 -m unittest discover -s training -p 'test_*.py'
+make test
+make asan
+git diff --check
+```
+
+Vendored install/build and CUDA command execution remain deployment-boundary
+checks because the active machine is still occupied by the immutable baseline.
+
+## Source verification record
+
+- Fresh pinned PufferLib install: exact-action patch applied cleanly; both CPU
+  and CUDA bindings expose environment hash, observation ABI/version, action
+  ABI, and exact-action source hash.
+- Tools: 231 tests passed, 2 skips for the absent vendored checkout.
+- Training: 30 tests passed under Python 3.11, 1 absent-vendor skip.
+- Native: 442 engine tests plus 63 focused Puffer tests passed normally and
+  under ASan/UBSan.
+- `bash -n`, substantive ShellCheck diagnostics, Python compilation, and
+  `git diff --check` passed.
+- Independent Fable and Codex reviews found no P0/P1 implementation defect
+  after fixes. Review findings led to fixed checkpoint byte-size authority,
+  non-overridable semantic constants, compiled-module contract binding,
+  accepted-result-only eligible publication, and atomic pool publication.
+
+The positive end-to-end canary plan and result write/recovery paths still need
+execution against the freshly built GPU runtime. Source tests cover their
+components and rejection paths, but source-string assertions are not accepted
+as deployment proof. These are mandatory zero-error deployment gates before
+the 50M canary, alongside the recurrent and exact-support CUDA smokes.
+
+## Rollout
+
+1. Merge this source-only tranche after hosted checks and independent review.
+2. Ship recurrent evaluation-state hardening and its zero-update qualifier.
+3. Wait for the active baseline's atomic completion evidence.
+4. Build the repaired runtime in a fresh isolated checkout and verify imported
+   source/module/patch identities.
+5. Pass construction, recurrent, exact-support, and zero-update CUDA smokes.
+6. Run the disposable fresh 50M canary under the zero error budget.
+7. Separately create accepted obs-v5 training ancestry and a same-lineage pool
+   before any long causal comparison.
+
+## Risks and simplification review
+
+- Do not infer lineage from path, filename, timestamp, byte count, tensor
+  dimensions, or a source-tree checkout alone.
+- Do not let qualification-only output become a warm start by copying or
+  renaming it; eligibility is inside the hash-bound sidecar.
+- Keep one canonical JSON representation and one validator shared by launch,
+  pool construction, result publication, and recovery.
+- Validate all inputs before writing a pool or launching a trainer.
+- Keep historical reconstruction explicit and outside accepted v5 launch
+  paths; there is no automatic upgrade from legacy artifacts.
+
+## Explicitly out of scope
+
+- Bridging or converting obs-v4 weights to obs-v5.
+- Reusing the canary checkpoint for a long run, reward comparison, promotion,
+  or frozen pool.
+- Generating the eventual obs-v5 BC anchor or training pool.
+- Recurrent-state repair, decision-cap truncation, rewards, rules, BBTV, live
+  services, or the active recovery queue.

--- a/tools/build_league.py
+++ b/tools/build_league.py
@@ -38,9 +38,9 @@ checks the byte size but only fprintf-warns and RETURNS on mismatch (the
 bank silently keeps its previous weights), so this tool hard-verifies every
 seed's size up front. 16,066,560 bytes = the current bloodbowl policy (obs
 2782 = obs v5, heads {30,33,391}, hidden 512, 3 layers —
-training/test_convert_checkpoint.py). Older lineages require an explicit
-override: obs-v3 (1612) is 13,670,400 bytes and obs-v2 (832) is 12,072,960
-bytes.
+training/test_convert_checkpoint.py). Historical obs-v3 (13,670,400-byte) and
+obs-v2 (12,072,960-byte) pools require both an explicit size and the
+`--legacy-unlabeled` reconstruction mode; current launchers reject them.
 
 Usage:
     tools/build_league.py --out <run-dir> --seeds name0=/path/a.bin \

--- a/tools/build_league.py
+++ b/tools/build_league.py
@@ -29,13 +29,15 @@ pre-existing pool, hence training/selfplay_league.patch (skips the bootstrap
 and seeds each bank from this manifest when [selfplay] league_preseed names
 this pool dir).
 
-Seed files must be CUDA flat-fp32 weight blobs — the save_weights format
+Seed files must be CUDA flat-fp32 weight blobs with eligible obs-v5/exact-action
+lineage sidecars — the save_weights format
 (vendor/PufferLib/src/bindings.cu:180: raw fwrite of master_weights, no
-header). pufferl_load_frozen_bank (vendor/PufferLib/src/pufferlib.cu:1830)
+header). Semantic compatibility comes from the sidecar, not blob size.
+pufferl_load_frozen_bank (vendor/PufferLib/src/pufferlib.cu:1830)
 checks the byte size but only fprintf-warns and RETURNS on mismatch (the
 bank silently keeps its previous weights), so this tool hard-verifies every
 seed's size up front. 16,066,560 bytes = the current bloodbowl policy (obs
-2782 = obs v4, heads {30,33,391}, hidden 512, 3 layers —
+2782 = obs v5, heads {30,33,391}, hidden 512, 3 layers —
 training/test_convert_checkpoint.py). Older lineages require an explicit
 override: obs-v3 (1612) is 13,670,400 bytes and obs-v2 (832) is 12,072,960
 bytes.
@@ -57,9 +59,14 @@ import json
 import os
 import shutil
 import sys
+import tempfile
+
+from checkpoint_lineage import (
+    LineageError, lineage_digest, sidecar_path, validate_lineage,
+)
 
 # Current Blood Bowl CUDA flat blob: 4,016,640 fp32 params (obs 2782 = obs
-# v4 / heads {30,33,391} / hidden 512 / 3 layers). Size pinned by
+# v5 / heads {30,33,391} / hidden 512 / 3 layers). Size pinned by
 # training/test_convert_checkpoint.py. Older obs-v3 (13,670,400 bytes) and
 # obs-v2 (12,072,960 bytes) lineages require an explicit --expect-bytes.
 DEFAULT_EXPECT_BYTES = 16_066_560
@@ -86,7 +93,8 @@ def parse_seed_args(seed_args):
     return seeds
 
 
-def build_league(out_dir, seeds, expect_bytes=DEFAULT_EXPECT_BYTES):
+def build_league(out_dir, seeds, expect_bytes=DEFAULT_EXPECT_BYTES,
+                 allow_legacy_unlabeled=False):
     '''Create <out_dir>/pool with seed .bins + league_seeds.json.
 
     Returns the manifest dict. Raises LeagueError on any validation failure
@@ -97,6 +105,7 @@ def build_league(out_dir, seeds, expect_bytes=DEFAULT_EXPECT_BYTES):
 
     # Validate sources before writing anything.
     sources = {}
+    lineages = {}
     for name, path in seeds:
         if not os.path.isfile(path):
             raise LeagueError(f'seed {name!r}: {path} does not exist')
@@ -111,44 +120,75 @@ def build_league(out_dir, seeds, expect_bytes=DEFAULT_EXPECT_BYTES):
             print(f'warning: seed {name!r} duplicates source of '
                   f'{sources[real]!r} ({real})', file=sys.stderr)
         sources.setdefault(real, name)
+        if not allow_legacy_unlabeled:
+            lineage = sidecar_path(path)
+            try:
+                payload = validate_lineage(
+                    path, lineage, require_eligible=True)
+            except LineageError as exc:
+                raise LeagueError(f'seed {name!r}: {exc}') from exc
+            lineages[real] = (lineage, lineage_digest(payload))
 
+    out_dir = os.path.abspath(out_dir)
     pool_dir = os.path.join(out_dir, 'pool')
-    os.makedirs(pool_dir, exist_ok=True)
-    leftovers = [f for f in os.listdir(pool_dir)
-                 if f.endswith('.bin') or f == MANIFEST_NAME]
-    if leftovers:
+    if os.path.isdir(pool_dir) and os.listdir(pool_dir):
         raise LeagueError(
-            f'{pool_dir} already contains pool entries {sorted(leftovers)} — '
+            f'{pool_dir} already contains entries {sorted(os.listdir(pool_dir))} — '
             f'refusing to mix leagues; use a fresh --out dir')
+    if os.path.exists(pool_dir) and not os.path.isdir(pool_dir):
+        raise LeagueError(f'{pool_dir} exists and is not a directory')
+    os.makedirs(out_dir, exist_ok=True)
+    if os.path.isdir(pool_dir):
+        os.rmdir(pool_dir)
+    staging_dir = tempfile.mkdtemp(prefix='.pool.tmp.', dir=out_dir)
 
-    entries = []
-    for bank, (name, path) in enumerate(seeds):
-        # Naming convention: selfplay.py:171/:247 f'{global_step:016d}.bin'.
-        fname = f'{bank:016d}.bin'
-        dest = os.path.join(pool_dir, fname)
-        shutil.copyfile(path, dest)
-        with open(dest, 'rb') as f:
-            blob = f.read()
-        if len(blob) != expect_bytes:
-            raise LeagueError(f'copy of seed {name!r} is {len(blob)} bytes')
-        entries.append({
-            'bank': bank,
-            'name': name,
-            'file': fname,
-            'source': os.path.abspath(path),
-            'bytes': len(blob),
-            'sha256': hashlib.sha256(blob).hexdigest(),
-        })
+    try:
+        entries = []
+        for bank, (name, path) in enumerate(seeds):
+            # Naming convention: selfplay.py:171/:247 f'{global_step:016d}.bin'.
+            fname = f'{bank:016d}.bin'
+            dest = os.path.join(staging_dir, fname)
+            shutil.copyfile(path, dest)
+            with open(dest, 'rb') as f:
+                blob = f.read()
+            if len(blob) != expect_bytes:
+                raise LeagueError(f'copy of seed {name!r} is {len(blob)} bytes')
+            entries.append({
+                'bank': bank,
+                'name': name,
+                'file': fname,
+                'source': os.path.abspath(path),
+                'bytes': len(blob),
+                'sha256': hashlib.sha256(blob).hexdigest(),
+            })
+            if not allow_legacy_unlabeled:
+                source_lineage, source_lineage_sha = lineages[os.path.realpath(path)]
+                lineage_name = fname + '.lineage.json'
+                shutil.copyfile(
+                    source_lineage, os.path.join(staging_dir, lineage_name))
+                entries[-1].update({
+                    'lineage_file': lineage_name,
+                    'lineage_sha256': source_lineage_sha,
+                })
 
-    manifest = {
-        'version': 1,
-        'created': datetime.datetime.now(datetime.timezone.utc).isoformat(),
-        'expected_bytes': expect_bytes,
-        'seeds': entries,
-    }
-    with open(os.path.join(pool_dir, MANIFEST_NAME), 'w') as f:
-        json.dump(manifest, f, indent=2)
-        f.write('\n')
+        manifest = {
+            'version': 1 if allow_legacy_unlabeled else 2,
+            'lineage_required': not allow_legacy_unlabeled,
+            'created': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            'expected_bytes': expect_bytes,
+            'seeds': entries,
+        }
+        with open(os.path.join(staging_dir, MANIFEST_NAME), 'w') as f:
+            json.dump(manifest, f, indent=2)
+            f.write('\n')
+        os.replace(staging_dir, pool_dir)
+        staging_dir = None
+    except Exception as exc:
+        if staging_dir is not None:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+        if isinstance(exc, LeagueError):
+            raise
+        raise LeagueError(f'could not publish league atomically: {exc}') from exc
     return manifest
 
 
@@ -162,11 +202,16 @@ def main(argv=None):
     ap.add_argument('--expect-bytes', type=int, default=DEFAULT_EXPECT_BYTES,
         help='required size of every seed .bin (flat-fp32 blob; '
              f'default {DEFAULT_EXPECT_BYTES})')
+    ap.add_argument('--legacy-unlabeled', action='store_true',
+        help='historical reconstruction only: permit checkpoints without '
+             'obs-v5/exact-action lineage; repaired launchers still reject it')
     args = ap.parse_args(argv)
 
     try:
         seeds = parse_seed_args(args.seeds)
-        manifest = build_league(args.out, seeds, args.expect_bytes)
+        manifest = build_league(
+            args.out, seeds, args.expect_bytes,
+            allow_legacy_unlabeled=args.legacy_unlabeled)
     except LeagueError as e:
         print(f'build_league: {e}', file=sys.stderr)
         return 1

--- a/tools/checkpoint_lineage.py
+++ b/tools/checkpoint_lineage.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Content-addressed policy lineage for current Blood Bowl checkpoints.
+
+Flat Puffer checkpoints carry no header, and obs-v4/obs-v5 plus marginal/exact
+action policies have identical tensor shapes. This module is the single launch
+authority for proving that a blob belongs to the current semantic lineage.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+OBSERVATION_ABI = "obs-v5"
+OBSERVATION_VERSION = 5
+ACTION_ABI = "exact-joint-v1"
+POLICY_HIDDEN_SIZE = 512
+POLICY_NUM_LAYERS = 3
+POLICY_EXPANSION_FACTOR = 1
+EXPECTED_CHECKPOINT_BYTES = 16_066_560
+ALLOWED_INITIALIZATIONS = frozenset(("fresh", "lineage-v5"))
+SHA256_KEYS = (
+    "source_sha256",
+    "compiled_module_sha256",
+    "puffer_patch_bundle_sha256",
+)
+
+
+class LineageError(RuntimeError):
+    pass
+
+
+def sha256_file(path):
+    path = Path(path)
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_bytes(payload):
+    return (json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ) + "\n").encode("utf-8")
+
+
+def sidecar_path(checkpoint):
+    return Path(str(Path(checkpoint)) + ".lineage.json")
+
+
+def _need_sha(value, label, allow_empty=False):
+    if allow_empty and value == "":
+        return value
+    if (not isinstance(value, str) or len(value) != 64 or
+            any(ch not in "0123456789abcdef" for ch in value)):
+        raise LineageError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _need_int(value, label):
+    if isinstance(value, bool):
+        raise LineageError(f"{label} must be an integer")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise LineageError(f"{label} must be an integer") from exc
+    if str(parsed) != str(value):
+        raise LineageError(f"{label} must be a canonical integer")
+    return parsed
+
+
+def _need_bool_string(value, label):
+    if str(value) not in ("0", "1"):
+        raise LineageError(f"{label} must be 0 or 1")
+    return str(value) == "1"
+
+
+def _load_object(path, label):
+    path = Path(path)
+    if not path.is_file():
+        raise LineageError(f"missing {label}: {path}")
+    raw = path.read_bytes()
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise LineageError(f"{label} is not valid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise LineageError(f"{label} must be a JSON object: {path}")
+    return payload, raw
+
+
+def lineage_from_run_manifest(checkpoint, run_manifest, *,
+                              allow_eligible_publication=False):
+    checkpoint = Path(checkpoint)
+    if not checkpoint.is_file():
+        raise LineageError(f"missing checkpoint: {checkpoint}")
+    manifest, manifest_raw = _load_object(run_manifest, "run manifest")
+    if manifest.get("schema_version") != 1:
+        raise LineageError(
+            f"unsupported run manifest schema: {manifest.get('schema_version')!r}")
+
+    observation_abi = manifest.get("observation_abi")
+    observation_version = _need_int(
+        manifest.get("observation_version"), "observation_version")
+    action_abi = manifest.get("action_abi")
+    if observation_abi != OBSERVATION_ABI:
+        raise LineageError(
+            f"observation_abi must be {OBSERVATION_ABI}, got {observation_abi!r}")
+    if observation_version != OBSERVATION_VERSION:
+        raise LineageError(
+            f"observation_version must be {OBSERVATION_VERSION}, "
+            f"got {observation_version}")
+    if action_abi != ACTION_ABI:
+        raise LineageError(
+            f"action_abi must be {ACTION_ABI}, got {action_abi!r}")
+
+    initialization = manifest.get("initialization")
+    if initialization not in ALLOWED_INITIALIZATIONS:
+        raise LineageError(
+            f"initialization must be one of {sorted(ALLOWED_INITIALIZATIONS)}, "
+            f"got {initialization!r}")
+    qualification_only = _need_bool_string(
+        manifest.get("qualification_only"), "qualification_only")
+    if qualification_only and initialization != "fresh":
+        raise LineageError("qualification-only output must use fresh initialization")
+    if initialization == "fresh" and not qualification_only:
+        raise LineageError(
+            "fresh initialization is reserved for qualification-only output")
+    expected_mode = (
+        "native_fresh_v5_qualification" if qualification_only
+        else "native_static_pool_reward_ablation")
+    if manifest.get("mode") != expected_mode:
+        raise LineageError(
+            f"run manifest mode must be {expected_mode}, got "
+            f"{manifest.get('mode')!r}")
+    if not qualification_only and not allow_eligible_publication:
+        raise LineageError(
+            "eligible lineage may only be published by accepted screen "
+            "result materialization")
+
+    policy = {
+        "hidden_size": _need_int(
+            manifest.get("policy_hidden_size"), "policy_hidden_size"),
+        "num_layers": _need_int(
+            manifest.get("policy_num_layers"), "policy_num_layers"),
+        "expansion_factor": _need_int(
+            manifest.get("policy_expansion_factor"),
+            "policy_expansion_factor"),
+    }
+    expected_policy = {
+        "hidden_size": POLICY_HIDDEN_SIZE,
+        "num_layers": POLICY_NUM_LAYERS,
+        "expansion_factor": POLICY_EXPANSION_FACTOR,
+    }
+    if policy != expected_policy:
+        raise LineageError(
+            f"policy shape mismatch: {policy!r} != {expected_policy!r}")
+
+    checkpoint_bytes = checkpoint.stat().st_size
+    expected_bytes = _need_int(
+        manifest.get("expected_checkpoint_bytes"),
+        "expected_checkpoint_bytes")
+    if expected_bytes != EXPECTED_CHECKPOINT_BYTES:
+        raise LineageError(
+            "expected_checkpoint_bytes must be "
+            f"{EXPECTED_CHECKPOINT_BYTES}, got {expected_bytes}")
+    if checkpoint_bytes != expected_bytes:
+        raise LineageError(
+            f"checkpoint is {checkpoint_bytes} bytes; run manifest expects "
+            f"{expected_bytes}")
+
+    implementation = {}
+    for key in SHA256_KEYS:
+        implementation[key] = _need_sha(manifest.get(key), key)
+
+    warm_lineage = _need_sha(
+        manifest.get("warm_lineage_sha256", ""),
+        "warm_lineage_sha256", allow_empty=True)
+    pool_lineage = _need_sha(
+        manifest.get("pool_lineage_bundle_sha256", ""),
+        "pool_lineage_bundle_sha256", allow_empty=True)
+    if initialization == "fresh" and (warm_lineage or pool_lineage):
+        raise LineageError("fresh initialization cannot declare warm/pool ancestry")
+    if initialization == "lineage-v5" and not (warm_lineage and pool_lineage):
+        raise LineageError("lineage-v5 requires warm and pool lineage digests")
+
+    screen_sha = _need_sha(
+        manifest.get("screen_manifest_sha256"), "screen_manifest_sha256")
+    seed = _need_int(manifest.get("seed"), "seed")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "checkpoint": {
+            "bytes": checkpoint_bytes,
+            "sha256": sha256_file(checkpoint),
+        },
+        "compatibility": {
+            "observation_abi": observation_abi,
+            "observation_version": observation_version,
+            "action_abi": action_abi,
+            "policy_hidden_size": policy["hidden_size"],
+            "policy_num_layers": policy["num_layers"],
+            "policy_expansion_factor": policy["expansion_factor"],
+        },
+        "implementation": implementation,
+        "producer": {
+            "run_manifest_sha256": hashlib.sha256(manifest_raw).hexdigest(),
+            "screen_manifest_sha256": screen_sha,
+            "seed": seed,
+        },
+        "ancestry": {
+            "initialization": initialization,
+            "qualification_only": qualification_only,
+            "eligible": not qualification_only,
+            "warm_lineage_sha256": warm_lineage,
+            "pool_lineage_bundle_sha256": pool_lineage,
+        },
+    }
+
+
+def write_lineage(path, payload, replace=False):
+    path = Path(path)
+    body = canonical_bytes(payload)
+    if path.exists():
+        if path.read_bytes() == body:
+            return path
+        if not replace:
+            raise LineageError(f"refusing to replace different lineage: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + f".tmp.{os.getpid()}")
+    try:
+        temporary.write_bytes(body)
+        temporary.replace(path)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+    return path
+
+
+def validate_lineage(checkpoint, sidecar=None, *, expected=None,
+                     require_eligible=True):
+    checkpoint = Path(checkpoint)
+    if not checkpoint.is_file():
+        raise LineageError(f"missing checkpoint: {checkpoint}")
+    sidecar = Path(sidecar) if sidecar is not None else sidecar_path(checkpoint)
+    payload, raw = _load_object(sidecar, "checkpoint lineage")
+    try:
+        canonical = canonical_bytes(payload)
+    except (TypeError, ValueError) as exc:
+        raise LineageError(f"checkpoint lineage is not canonical JSON: {sidecar}") from exc
+    if raw != canonical:
+        raise LineageError(f"checkpoint lineage is not canonical: {sidecar}")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise LineageError(
+            f"unsupported checkpoint lineage schema: {payload.get('schema_version')!r}")
+
+    checkpoint_record = payload.get("checkpoint")
+    compatibility = payload.get("compatibility")
+    implementation = payload.get("implementation")
+    producer = payload.get("producer")
+    ancestry = payload.get("ancestry")
+    for name, value in (
+        ("checkpoint", checkpoint_record),
+        ("compatibility", compatibility),
+        ("implementation", implementation),
+        ("producer", producer),
+        ("ancestry", ancestry),
+    ):
+        if not isinstance(value, dict):
+            raise LineageError(f"checkpoint lineage {name} must be an object")
+
+    actual_bytes = checkpoint.stat().st_size
+    actual_sha = sha256_file(checkpoint)
+    if actual_bytes != EXPECTED_CHECKPOINT_BYTES:
+        raise LineageError(
+            f"checkpoint is {actual_bytes} bytes; current ABI requires "
+            f"{EXPECTED_CHECKPOINT_BYTES}")
+    if checkpoint_record.get("bytes") != actual_bytes:
+        raise LineageError("checkpoint byte count differs from lineage")
+    if checkpoint_record.get("sha256") != actual_sha:
+        raise LineageError("checkpoint SHA-256 differs from lineage")
+    _need_sha(checkpoint_record.get("sha256"), "checkpoint.sha256")
+
+    frozen_expected = {
+        "observation_abi": OBSERVATION_ABI,
+        "observation_version": OBSERVATION_VERSION,
+        "action_abi": ACTION_ABI,
+        "policy_hidden_size": POLICY_HIDDEN_SIZE,
+        "policy_num_layers": POLICY_NUM_LAYERS,
+        "policy_expansion_factor": POLICY_EXPANSION_FACTOR,
+    }
+    if expected:
+        unsupported = sorted(set(expected) - set(SHA256_KEYS))
+        if unsupported:
+            raise LineageError(
+                "expected overrides are limited to implementation digests; "
+                f"unsupported keys: {unsupported}")
+        for key, value in expected.items():
+            _need_sha(value, key)
+        frozen_expected.update(expected)
+    for key, wanted in frozen_expected.items():
+        section = implementation if key in SHA256_KEYS else compatibility
+        actual = section.get(key)
+        if actual != wanted:
+            raise LineageError(
+                f"{key} lineage mismatch: {actual!r} != {wanted!r}")
+    for key in SHA256_KEYS:
+        _need_sha(implementation.get(key), key)
+    _need_sha(producer.get("run_manifest_sha256"),
+              "producer.run_manifest_sha256")
+    _need_sha(producer.get("screen_manifest_sha256"),
+              "producer.screen_manifest_sha256")
+    _need_int(producer.get("seed"), "producer.seed")
+
+    qualification_only = ancestry.get("qualification_only")
+    eligible = ancestry.get("eligible")
+    if not isinstance(qualification_only, bool) or not isinstance(eligible, bool):
+        raise LineageError("lineage eligibility fields must be booleans")
+    if eligible == qualification_only:
+        raise LineageError("lineage eligibility contradicts qualification status")
+    initialization = ancestry.get("initialization")
+    if initialization not in ALLOWED_INITIALIZATIONS:
+        raise LineageError(f"invalid lineage initialization: {initialization!r}")
+    warm_lineage = _need_sha(ancestry.get("warm_lineage_sha256", ""),
+                             "warm_lineage_sha256", allow_empty=True)
+    pool_lineage = _need_sha(
+        ancestry.get("pool_lineage_bundle_sha256", ""),
+        "pool_lineage_bundle_sha256", allow_empty=True)
+    if initialization == "fresh":
+        if not qualification_only or eligible or warm_lineage or pool_lineage:
+            raise LineageError(
+                "fresh lineage must be qualification-only, ineligible, and ancestry-free")
+    elif qualification_only or not eligible or not warm_lineage or not pool_lineage:
+        raise LineageError(
+            "lineage-v5 must be eligible and bind warm/pool ancestry")
+    if require_eligible and not eligible:
+        raise LineageError("qualification-only checkpoint is not eligible ancestry")
+    return payload
+
+
+def lineage_digest(payload_or_path):
+    if isinstance(payload_or_path, dict):
+        body = canonical_bytes(payload_or_path)
+    else:
+        body = Path(payload_or_path).read_bytes()
+    return hashlib.sha256(body).hexdigest()
+
+
+def _parse_expected(items):
+    result = {}
+    for item in items:
+        key, separator, value = item.partition("=")
+        if not separator or not key:
+            raise LineageError(f"invalid --expect {item!r}; use key=value")
+        if key not in SHA256_KEYS:
+            raise LineageError(
+                "--expect is limited to implementation digests; "
+                f"unsupported key: {key}")
+        result[key] = _need_sha(value, key)
+    return result
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    create = subparsers.add_parser("create")
+    create.add_argument("--checkpoint", required=True)
+    create.add_argument("--run-manifest", required=True)
+    create.add_argument("--out")
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--checkpoint", required=True)
+    validate.add_argument("--lineage")
+    validate.add_argument("--expect", action="append", default=[])
+    validate.add_argument("--allow-qualification", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "create":
+            payload = lineage_from_run_manifest(
+                args.checkpoint, args.run_manifest)
+            output = Path(args.out) if args.out else sidecar_path(args.checkpoint)
+            write_lineage(output, payload)
+            print(lineage_digest(payload), output)
+        else:
+            expected = _parse_expected(args.expect)
+            payload = validate_lineage(
+                args.checkpoint, args.lineage, expected=expected,
+                require_eligible=not args.allow_qualification)
+            print(lineage_digest(payload),
+                  Path(args.lineage) if args.lineage else sidecar_path(args.checkpoint))
+    except LineageError as exc:
+        parser.exit(1, f"checkpoint_lineage: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/install_puffer_env.sh
+++ b/tools/install_puffer_env.sh
@@ -121,15 +121,47 @@ if [ "$MODE" = "check" ]; then
     header_backend_hash="$(sed -n \
         's/^#define PUFFER_EXACT_ACTION_SOURCE_HASH "\([0-9a-f]*\)"$/\1/p' \
         "$PUFFER/src/exact_action_build_hash.h" 2>/dev/null || true)"
-    compiled_backend_hash="$(cd "$PUFFER" && "$PYBIN" -c \
-        'from pufferlib import _C; print(getattr(_C, "exact_action_source_hash", "<missing>"))' \
+    header_environment_hash="$(sed -n \
+        's/^#define PUFFER_ENV_SOURCE_HASH "\([0-9a-f]*\)"$/\1/p' \
+        "$PUFFER/src/exact_action_build_hash.h" 2>/dev/null || true)"
+    header_observation_abi="$(sed -n \
+        's/^#define PUFFER_OBSERVATION_ABI "\([^"]*\)"$/\1/p' \
+        "$PUFFER/src/exact_action_build_hash.h" 2>/dev/null || true)"
+    header_observation_version="$(sed -n \
+        's/^#define PUFFER_OBSERVATION_VERSION \([0-9][0-9]*\)$/\1/p' \
+        "$PUFFER/src/exact_action_build_hash.h" 2>/dev/null || true)"
+    header_action_abi="$(sed -n \
+        's/^#define PUFFER_ACTION_ABI "\([^"]*\)"$/\1/p' \
+        "$PUFFER/src/exact_action_build_hash.h" 2>/dev/null || true)"
+    compiled_contract="$(cd "$PUFFER" && "$PYBIN" -c \
+        'from pufferlib import _C; print(getattr(_C, "exact_action_source_hash", "<missing>"), getattr(_C, "environment_source_hash", "<missing>"), getattr(_C, "observation_abi", "<missing>"), getattr(_C, "observation_version", "<missing>"), getattr(_C, "action_abi", "<missing>"))' \
         2>/dev/null || true)"
+    read -r compiled_backend_hash compiled_environment_hash \
+        compiled_observation_abi compiled_observation_version \
+        compiled_action_abi <<< "$compiled_contract"
     if [ "$current_backend_hash" != "$header_backend_hash" ] || \
        [ "$current_backend_hash" != "$compiled_backend_hash" ]; then
         echo "drift check: exact-action source/module digest mismatch" >&2
         echo "  sources: $current_backend_hash" >&2
         echo "  header:  ${header_backend_hash:-<missing>}" >&2
         echo "  module:  ${compiled_backend_hash:-<missing>}" >&2
+        echo "  fix: reinstall, then rebuild PufferLib for bloodbowl" >&2
+        exit 1
+    fi
+    if [ "$want" != "$header_environment_hash" ] || \
+       [ "$want" != "$compiled_environment_hash" ] || \
+       [ "$header_observation_abi" != "obs-v5" ] || \
+       [ "$compiled_observation_abi" != "obs-v5" ] || \
+       [ "$header_observation_version" != "5" ] || \
+       [ "$compiled_observation_version" != "5" ] || \
+       [ "$header_action_abi" != "exact-joint-v1" ] || \
+       [ "$compiled_action_abi" != "exact-joint-v1" ]; then
+        echo "drift check: compiled observation/action lineage mismatch" >&2
+        echo "  environment source: $want" >&2
+        echo "  header/module source: ${header_environment_hash:-<missing>} / ${compiled_environment_hash:-<missing>}" >&2
+        echo "  header/module obs ABI: ${header_observation_abi:-<missing>} / ${compiled_observation_abi:-<missing>}" >&2
+        echo "  header/module obs: ${header_observation_version:-<missing>} / ${compiled_observation_version:-<missing>}" >&2
+        echo "  header/module action: ${header_action_abi:-<missing>} / ${compiled_action_abi:-<missing>}" >&2
         echo "  fix: reinstall, then rebuild PufferLib for bloodbowl" >&2
         exit 1
     fi
@@ -299,8 +331,10 @@ EXACT_BACKEND_HASH="$(exact_backend_hash)" || {
     echo "error: could not hash exact-action backend sources" >&2
     exit 1
 }
-printf '#pragma once\n#define PUFFER_EXACT_ACTION_SOURCE_HASH "%s"\n' \
-    "$EXACT_BACKEND_HASH" > "$PUFFER/src/exact_action_build_hash.h"
+INSTALLED_SOURCE_HASH="$(cat "$DST/.content_hash")"
+printf '#pragma once\n#define PUFFER_EXACT_ACTION_SOURCE_HASH "%s"\n#define PUFFER_ENV_SOURCE_HASH "%s"\n#define PUFFER_OBSERVATION_ABI "obs-v5"\n#define PUFFER_OBSERVATION_VERSION 5\n#define PUFFER_ACTION_ABI "exact-joint-v1"\n' \
+    "$EXACT_BACKEND_HASH" "$INSTALLED_SOURCE_HASH" \
+    > "$PUFFER/src/exact_action_build_hash.h"
 echo "recorded:   exact-action backend digest $EXACT_BACKEND_HASH"
 
 echo "installed: $DST"

--- a/tools/run_reward_ablation.sh
+++ b/tools/run_reward_ablation.sh
@@ -139,6 +139,10 @@ if [ "$STEPS" -le 0 ] || [ "$TOTAL_AGENTS" -le 0 ] || \
   echo "step/agent/buffer/byte/horizon/minibatch/checkpoint values must be positive" >&2
   exit 1
 fi
+if [ "$EXPECT_BYTES" -ne 16066560 ]; then
+  echo "obs-v5/exact-joint-v1 requires EXPECT_BYTES=16066560; got $EXPECT_BYTES" >&2
+  exit 1
+fi
 if [ $(( TOTAL_AGENTS % NUM_BUFFERS )) -ne 0 ]; then
   echo "TOTAL_AGENTS must be divisible by NUM_BUFFERS" >&2
   exit 1

--- a/tools/run_reward_ablation.sh
+++ b/tools/run_reward_ablation.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # Launch one native, static-pool reward-ablation arm from a complete manifest.
 #
-# Required:
+# Required for every mode:
 #   TAG=<unique arm tag>
 #   REWARD_MANIFEST=<puffer/config/rewards/*.json>
-#   WARM=<obs-v4 native flat-fp32 checkpoint>
-#   POOL=<directory containing league_seeds.json and exactly four seed blobs>
+#   BOOTSTRAP_MODE=fresh-v5-qualification|lineage-v5
+# lineage-v5 additionally requires WARM and POOL with eligible obs-v5 lineage
+# sidecars. fresh-v5-qualification forbids both inputs.
 #
 # Optional:
 #   STEPS=250000000 SEED=42 LOG=/tmp/$TAG.log
@@ -26,13 +27,33 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 : "${TAG:?TAG is required}"
 : "${REWARD_MANIFEST:?REWARD_MANIFEST is required}"
-: "${WARM:?WARM is required}"
-: "${POOL:?POOL is required}"
 
 if [ $# -ne 0 ]; then
   echo "trailing Puffer overrides are not allowed by this ablation contract" >&2
   exit 1
 fi
+
+: "${BOOTSTRAP_MODE:?BOOTSTRAP_MODE is required}"
+case "$BOOTSTRAP_MODE" in
+  fresh-v5-qualification)
+    [ -z "${WARM:-}" ] || {
+      echo "fresh-v5-qualification forbids WARM" >&2; exit 1; }
+    [ -z "${POOL:-}" ] || {
+      echo "fresh-v5-qualification forbids POOL" >&2; exit 1; }
+    WARM=""
+    POOL=""
+    QUALIFICATION_ONLY=1
+    ;;
+  lineage-v5)
+    : "${WARM:?WARM is required for lineage-v5}"
+    : "${POOL:?POOL is required for lineage-v5}"
+    QUALIFICATION_ONLY=0
+    ;;
+  *)
+    echo "BOOTSTRAP_MODE must be fresh-v5-qualification or lineage-v5" >&2
+    exit 1
+    ;;
+esac
 
 STEPS="${STEPS:-250000000}"
 SEED="${SEED:-42}"
@@ -55,7 +76,7 @@ VF_CLIP_COEF="${VF_CLIP_COEF:-0.5}"
 MAX_GRAD_NORM="${MAX_GRAD_NORM:-1.5}"
 DETACH="${DETACH:-1}"
 QUEUE_OWNED="${QUEUE_OWNED:-0}"
-EXPECTED_POOL_HASH="${EXPECTED_POOL_HASH:-18ec7cac858b71a6657003f454f19e232fb060f08b644c1e9e2f101076a9aac0}"
+EXPECTED_POOL_HASH="${EXPECTED_POOL_HASH:-}"
 SCREEN_MANIFEST_SHA256="${SCREEN_MANIFEST_SHA256:-}"
 EXPECTED_PUFFER_PATCH_BUNDLE_SHA256="${EXPECTED_PUFFER_PATCH_BUNDLE_SHA256:-}"
 LIVE_INTEGRITY_FAILURE="${LIVE_INTEGRITY_FAILURE:-}"
@@ -102,8 +123,8 @@ abspath() {
   esac
 }
 REWARD_MANIFEST="$(abspath "$REWARD_MANIFEST")"
-WARM="$(abspath "$WARM")"
-POOL="$(abspath "$POOL")"
+[ -z "$WARM" ] || WARM="$(abspath "$WARM")"
+[ -z "$POOL" ] || POOL="$(abspath "$POOL")"
 LOG="$(abspath "$LOG")"
 
 case "$STEPS:$SEED:$TOTAL_AGENTS:$NUM_BUFFERS:$EXPECT_BYTES:$HORIZON:$MINIBATCH_SIZE:$CHECKPOINT_STEPS" in
@@ -137,8 +158,19 @@ PYBIN="$ROOT/vendor/PufferLib/.venv/bin/python"
 PUFFER_BIN="$ROOT/vendor/PufferLib/.venv/bin/puffer"
 [ -x "$PYBIN" ] || { echo "vendored Python missing: $PYBIN" >&2; exit 1; }
 [ -x "$PUFFER_BIN" ] || { echo "vendored puffer entrypoint missing: $PUFFER_BIN" >&2; exit 1; }
-read -r FROZEN_PER_BANK HISTORICAL_GAME_SHARE < <(
-  "$PYBIN" - "$TOTAL_AGENTS" "$NUM_BUFFERS" "$FROZEN_BANK_PCT" <<'PY'
+if [ "$BOOTSTRAP_MODE" = "fresh-v5-qualification" ]; then
+  FROZEN_BANK_PCT=0
+  NUM_FROZEN_BANKS=0
+  FROZEN_PER_BANK=0
+  HISTORICAL_GAME_SHARE=0
+  [ -z "$EXPECTED_POOL_HASH" ] || {
+    echo "fresh-v5-qualification forbids EXPECTED_POOL_HASH" >&2; exit 1; }
+else
+  NUM_FROZEN_BANKS=4
+  [ -n "$EXPECTED_POOL_HASH" ] || {
+    echo "lineage-v5 requires EXPECTED_POOL_HASH" >&2; exit 1; }
+  read -r FROZEN_PER_BANK HISTORICAL_GAME_SHARE < <(
+    "$PYBIN" - "$TOTAL_AGENTS" "$NUM_BUFFERS" "$FROZEN_BANK_PCT" <<'PY'
 import math, sys
 total, buffers = map(int, sys.argv[1:3])
 try:
@@ -157,11 +189,14 @@ if total_frozen >= apb // 2:
         f"four banks reserve {total_frozen} rows/buffer, must be < {apb//2}")
 print(per_bank, total_frozen / (apb / 2.0))
 PY
-)
+  )
+fi
 
 [ -f "$REWARD_MANIFEST" ] || { echo "missing reward manifest: $REWARD_MANIFEST" >&2; exit 1; }
-[ -f "$WARM" ] || { echo "missing warm checkpoint: $WARM" >&2; exit 1; }
-[ -f "$POOL/league_seeds.json" ] || { echo "missing $POOL/league_seeds.json" >&2; exit 1; }
+if [ "$BOOTSTRAP_MODE" = "lineage-v5" ]; then
+  [ -f "$WARM" ] || { echo "missing warm checkpoint: $WARM" >&2; exit 1; }
+  [ -f "$POOL/league_seeds.json" ] || { echo "missing $POOL/league_seeds.json" >&2; exit 1; }
+fi
 
 RUN_MANIFEST="${LOG}.manifest.json"
 STATUS_FILE="${LOG}.status.json"
@@ -207,17 +242,24 @@ print(manifest["name"], digest)
 PY
 )
 
-warm_size=$(wc -c < "$WARM")
-if [ "$warm_size" -ne "$EXPECT_BYTES" ]; then
-  echo "warm checkpoint is $warm_size bytes; expected $EXPECT_BYTES" >&2
-  exit 1
-fi
+WARM_HASH=""
+WARM_LINEAGE_HASH=""
+POOL_HASH=""
+POOL_BANKS=0
+POOL_MANIFEST_HASH=""
+POOL_LINEAGE_BUNDLE_HASH=""
+warm_size=0
+if [ "$BOOTSTRAP_MODE" = "lineage-v5" ]; then
+  warm_size=$(wc -c < "$WARM")
+  if [ "$warm_size" -ne "$EXPECT_BYTES" ]; then
+    echo "warm checkpoint is $warm_size bytes; expected $EXPECT_BYTES" >&2
+    exit 1
+  fi
 
-# Validate the pool body, bank order, hashes, and architecture before any
-# trainer allocates GPU state. Print both the raw manifest hash and one
-# deterministic content-identity hash over the ordered banks.
-read -r POOL_HASH POOL_BANKS POOL_MANIFEST_HASH < <(
-  "$PYBIN" - "$POOL" "$EXPECT_BYTES" <<'PY'
+  # Validate the pool body, bank order, hashes, lineage paths, and architecture
+  # before any trainer allocates GPU state.
+  read -r POOL_HASH POOL_BANKS POOL_MANIFEST_HASH < <(
+    "$PYBIN" - "$POOL" "$EXPECT_BYTES" <<'PY'
 import hashlib, json, pathlib, sys
 pool = pathlib.Path(sys.argv[1])
 expect = int(sys.argv[2])
@@ -247,6 +289,15 @@ for index, seed in enumerate(seeds):
         raise SystemExit(f"{path}: {len(blob)} bytes, expected {expect}")
     if seed.get("bytes") != len(blob) or seed.get("sha256") != digest:
         raise SystemExit(f"{path}: manifest size/hash mismatch")
+    lineage_file = seed.get("lineage_file")
+    if not isinstance(lineage_file, str) or not lineage_file:
+        raise SystemExit(f"pool bank {index} lacks lineage_file")
+    lineage_path = pool / lineage_file
+    if not lineage_path.is_file():
+        raise SystemExit(f"pool bank {index} lineage is missing: {lineage_path}")
+    lineage_sha = seed.get("lineage_sha256")
+    if not isinstance(lineage_sha, str) or len(lineage_sha) != 64:
+        raise SystemExit(f"pool bank {index} lacks lineage_sha256")
     if digest in seen_hashes:
         raise SystemExit(f"pool bank {index} duplicates another checkpoint")
     seen_hashes.add(digest)
@@ -256,16 +307,18 @@ canonical = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
 print(hashlib.sha256(canonical).hexdigest(), len(seeds),
       hashlib.sha256(manifest_raw).hexdigest())
 PY
-)
-if [ "$POOL_HASH" != "$EXPECTED_POOL_HASH" ]; then
-  echo "pool identity $POOL_HASH does not match expected $EXPECTED_POOL_HASH" >&2
-  exit 1
+  )
+  if [ "$POOL_HASH" != "$EXPECTED_POOL_HASH" ]; then
+    echo "pool identity $POOL_HASH does not match expected $EXPECTED_POOL_HASH" >&2
+    exit 1
+  fi
 fi
 
 if ! /bin/bash "$ROOT/tools/install_puffer_env.sh" --check; then
   echo "installed Blood Bowl snapshot is stale; install and rebuild before launch" >&2
   exit 1
 fi
+SOURCE_HASH="$(cat ocean/bloodbowl/.content_hash)"
 grep -q '^league_preseed' config/bloodbowl.ini || {
   echo "installed config lacks league_preseed" >&2; exit 1; }
 grep -q 'league_preseed' pufferlib/selfplay.py || {
@@ -284,12 +337,31 @@ grep -q "'_puffer_schema': 2" pufferlib/pufferl.py || {
 probe="$($PYBIN - <<'PY'
 from pufferlib import _C
 print(getattr(_C, "env_name", None), int(bool(getattr(_C, "gpu", False))),
-      int(_C.precision_bytes))
+      int(_C.precision_bytes),
+      getattr(_C, "exact_action_source_hash", "<missing>"),
+      getattr(_C, "environment_source_hash", "<missing>"),
+      getattr(_C, "observation_abi", "<missing>"),
+      getattr(_C, "observation_version", "<missing>"),
+      getattr(_C, "action_abi", "<missing>"))
 PY
 )"
-read -r cenv cgpu precision <<< "$probe"
+read -r cenv cgpu precision COMPILED_EXACT_ACTION_SOURCE_HASH \
+  COMPILED_ENVIRONMENT_SOURCE_HASH COMPILED_OBSERVATION_ABI \
+  COMPILED_OBSERVATION_VERSION COMPILED_ACTION_ABI <<< "$probe"
 if [ "$cenv" != "bloodbowl" ] || [ "$cgpu" != "1" ]; then
   echo "invalid native build: env=$cenv gpu=$cgpu" >&2; exit 1
+fi
+if [[ ! "$COMPILED_EXACT_ACTION_SOURCE_HASH" =~ ^[0-9a-f]{64}$ ]] || \
+   [ "$COMPILED_ENVIRONMENT_SOURCE_HASH" != "$SOURCE_HASH" ] || \
+   [ "$COMPILED_OBSERVATION_ABI" != "obs-v5" ] || \
+   [ "$COMPILED_OBSERVATION_VERSION" != "5" ] || \
+   [ "$COMPILED_ACTION_ABI" != "exact-joint-v1" ]; then
+  echo "compiled native module does not satisfy the obs-v5/exact-action contract" >&2
+  echo "  exact-action source: ${COMPILED_EXACT_ACTION_SOURCE_HASH:-<missing>}" >&2
+  echo "  environment source: ${COMPILED_ENVIRONMENT_SOURCE_HASH:-<missing>} (expected $SOURCE_HASH)" >&2
+  echo "  observation: ${COMPILED_OBSERVATION_ABI:-<missing>} / ${COMPILED_OBSERVATION_VERSION:-<missing>}" >&2
+  echo "  action: ${COMPILED_ACTION_ABI:-<missing>}" >&2
+  exit 1
 fi
 if [ "${RIG_ALLOW_FLOAT:-0}" = "1" ] && [ "$precision" != "4" ]; then
   echo "RIG_ALLOW_FLOAT=1 requires the Turing fp32 build (precision_bytes=4); got $precision" >&2
@@ -306,7 +378,7 @@ fi
 . "$ROOT/tools/cpu_cap.sh"
 NUM_THREADS="${NUM_THREADS:-${OMP_NUM_THREADS:-8}}"
 
-WARM_HASH="$(sha256sum "$WARM" | awk '{print $1}')"
+[ -z "$WARM" ] || WARM_HASH="$(sha256sum "$WARM" | awk '{print $1}')"
 CONFIG_HASH="$(sha256sum config/bloodbowl.ini | awk '{print $1}')"
 DEFAULT_CONFIG_HASH="$(sha256sum config/default.ini | awk '{print $1}')"
 CONFIG_TREE_HASH="$("$PYBIN" - config <<'PY'
@@ -331,7 +403,6 @@ for child in sorted(root.rglob("*")):
 print(digest.hexdigest())
 PY
 )"
-SOURCE_HASH="$(cat ocean/bloodbowl/.content_hash)"
 MODULE_PATH="$("$PYBIN" -c 'from pufferlib import _C; print(_C.__file__)')"
 [ -f "$MODULE_PATH" ] || { echo "imported pufferlib module missing: $MODULE_PATH" >&2; exit 1; }
 MODULE_HASH="$(sha256sum "$MODULE_PATH" | awk '{print $1}')"
@@ -340,6 +411,7 @@ STATUS_WRAPPER="$ROOT/tools/trainer_status_wrapper.sh"
 STATUS_WRAPPER_HASH="$(sha256sum "$STATUS_WRAPPER" | awk '{print $1}')"
 LIVE_GUARD="$ROOT/tools/live_integrity_guard.py"
 LIVE_GUARD_HASH="$(sha256sum "$LIVE_GUARD" | awk '{print $1}')"
+CHECKPOINT_LINEAGE_HASH="$(sha256sum "$ROOT/tools/checkpoint_lineage.py" | awk '{print $1}')"
 PATCH_HASH="$({
   sha256sum "$ROOT/training/pufferl_env_dashboard_limit.patch"
   sha256sum "$ROOT/training/pufferl_env_json.patch"
@@ -364,11 +436,53 @@ VENDOR_SOURCE_HASH="$({
     src/bindings_cpu.cpp src/kernels.cu src/vecenv.h
 } | sha256sum | awk '{print $1}')"
 
+if [ "$BOOTSTRAP_MODE" = "lineage-v5" ]; then
+  read -r WARM_LINEAGE_HASH POOL_LINEAGE_BUNDLE_HASH < <(
+    "$PYBIN" - "$ROOT" "$WARM" "$POOL" "$SOURCE_HASH" \
+      "$MODULE_HASH" "$PATCH_HASH" <<'PY'
+import hashlib, json, pathlib, sys
+root, warm_path, pool_path, source_sha, module_sha, patch_sha = sys.argv[1:]
+sys.path.insert(0, str(pathlib.Path(root) / "tools"))
+from checkpoint_lineage import lineage_digest, sidecar_path, validate_lineage
+
+expected = {
+    "source_sha256": source_sha,
+    "compiled_module_sha256": module_sha,
+    "puffer_patch_bundle_sha256": patch_sha,
+}
+warm = pathlib.Path(warm_path)
+warm_payload = validate_lineage(
+    warm, sidecar_path(warm), expected=expected, require_eligible=True)
+pool = pathlib.Path(pool_path)
+manifest = json.loads((pool / "league_seeds.json").read_text(encoding="utf-8"))
+identities = []
+for index, seed in enumerate(manifest["seeds"]):
+    checkpoint = pool / seed["file"]
+    lineage = pool / seed["lineage_file"]
+    payload = validate_lineage(
+        checkpoint, lineage, expected=expected, require_eligible=True)
+    payload_sha = lineage_digest(payload)
+    if payload_sha != seed["lineage_sha256"]:
+        raise SystemExit(f"pool bank {index} lineage digest differs from manifest")
+    identities.append({
+        "bank": index,
+        "checkpoint_sha256": hashlib.sha256(checkpoint.read_bytes()).hexdigest(),
+        "lineage_sha256": payload_sha,
+    })
+bundle = hashlib.sha256(json.dumps(
+    identities, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+print(lineage_digest(warm_payload), bundle)
+PY
+  )
+fi
+
 echo "tag=$TAG seed=$SEED requested_steps=$STEPS final_steps=$FINAL_STEPS rollout_quantum=$ROLLOUT_QUANTUM"
+echo "bootstrap=$BOOTSTRAP_MODE observation_abi=obs-v5 observation_version=5 action_abi=exact-joint-v1 qualification_only=$QUALIFICATION_ONLY"
 echo "reward=$REWARD_NAME reward_sha256=$REWARD_HASH"
 echo "pool=$POOL pool_identity_sha256=$POOL_HASH pool_manifest_sha256=$POOL_MANIFEST_HASH banks=$POOL_BANKS pct=$FROZEN_BANK_PCT rows_per_bank=$FROZEN_PER_BANK historical_game_share=$HISTORICAL_GAME_SHARE"
 echo "warm=$WARM warm_sha256=$WARM_HASH"
 echo "source_sha256=$SOURCE_HASH config_sha256=$CONFIG_HASH module_sha256=$MODULE_HASH"
+echo "compiled_exact_action_source_sha256=$COMPILED_EXACT_ACTION_SOURCE_HASH compiled_observation=$COMPILED_OBSERVATION_ABI/$COMPILED_OBSERVATION_VERSION compiled_action=$COMPILED_ACTION_ABI"
 echo "native_precision_bytes=$precision total_agents=$TOTAL_AGENTS buffers=$NUM_BUFFERS threads=$NUM_THREADS horizon=$HORIZON minibatch=$MINIBATCH_SIZE"
 echo "lr=$LR ent_coef=$ENT_COEF gamma=$GAMMA gae_lambda=$GAE_LAMBDA replay_ratio=$REPLAY_RATIO log=$LOG"
 
@@ -377,13 +491,8 @@ CMD=("$PUFFER_BIN" train bloodbowl --tag "$TAG" \
   --train.gpus 1 --eval-episodes 10000 \
   --checkpoint-interval "$CHECKPOINT_INTERVAL" \
   --policy.hidden-size 512 --policy.num-layers 3 --policy.expansion-factor 1 \
-  --selfplay.enabled 1 --selfplay.league-preseed "$POOL" \
-  --selfplay.swap-winrate 1.1 --selfplay.opp-timeout-steps "$OPP_TIMEOUT" \
-  --selfplay.snapshot-interval 1000000000000 \
   --vec.total-agents "$TOTAL_AGENTS" --vec.num-buffers "$NUM_BUFFERS" \
   --vec.num-threads "$NUM_THREADS" \
-  --vec.num-frozen-banks 4 --vec.frozen-bank-pct "$FROZEN_BANK_PCT" \
-  --load-model-path "$WARM" \
   "${REWARD_ARGS[@]}" \
   --env.demo-reset-pct 0 --env.demo-endzone-maxdist 0 \
   --env.demo-pickup-maxdist 0 --env.demo-postkick-maxturn 0 \
@@ -400,6 +509,17 @@ CMD=("$PUFFER_BIN" train bloodbowl --tag "$TAG" \
   --train.update-epochs 1 --train.beta1 0.95 --train.beta2 0.999 \
   --train.eps 0.000000000001)
 
+if [ "$BOOTSTRAP_MODE" = "fresh-v5-qualification" ]; then
+  CMD+=(--selfplay.enabled 0 --vec.num-frozen-banks 0 \
+    --vec.frozen-bank-pct 0)
+else
+  CMD+=(--selfplay.enabled 1 --selfplay.league-preseed "$POOL" \
+    --selfplay.swap-winrate 1.1 --selfplay.opp-timeout-steps "$OPP_TIMEOUT" \
+    --selfplay.snapshot-interval 1000000000000 \
+    --vec.num-frozen-banks 4 --vec.frozen-bank-pct "$FROZEN_BANK_PCT" \
+    --load-model-path "$WARM")
+fi
+
 if [ "${DRY_RUN:-0}" = "1" ]; then
   printf 'DRY-RUN command:'
   printf ' %q' "${CMD[@]}"
@@ -409,21 +529,34 @@ fi
 
 META_ARGS=(
   tag "$TAG" seed "$SEED" requested_steps "$STEPS" final_steps "$FINAL_STEPS"
+  bootstrap_mode "$BOOTSTRAP_MODE" initialization \
+  "$([ "$QUALIFICATION_ONLY" = "1" ] && printf fresh || printf lineage-v5)" \
+  qualification_only "$QUALIFICATION_ONLY" observation_abi obs-v5 \
+  observation_version 5 action_abi exact-joint-v1 \
+  policy_hidden_size 512 policy_num_layers 3 policy_expansion_factor 1 \
   rollout_quantum "$ROLLOUT_QUANTUM" reward_name "$REWARD_NAME"
   reward_sha256 "$REWARD_HASH" reward_manifest "$REWARD_MANIFEST"
   pool "$POOL" pool_identity_sha256 "$POOL_HASH"
   pool_manifest_sha256 "$POOL_MANIFEST_HASH"
+  pool_lineage_bundle_sha256 "$POOL_LINEAGE_BUNDLE_HASH"
   historical_game_share "$HISTORICAL_GAME_SHARE"
-  frozen_bank_pct "$FROZEN_BANK_PCT" num_frozen_banks 4
+  frozen_bank_pct "$FROZEN_BANK_PCT" num_frozen_banks "$NUM_FROZEN_BANKS"
   expected_pool_hash "$EXPECTED_POOL_HASH"
-  warm "$WARM" warm_sha256 "$WARM_HASH" warm_bytes "$warm_size"
+  warm "$WARM" warm_sha256 "$WARM_HASH" warm_bytes "$warm_size" \
+  warm_lineage_sha256 "$WARM_LINEAGE_HASH"
   source_sha256 "$SOURCE_HASH" config_sha256 "$CONFIG_HASH"
+  compiled_exact_action_source_sha256 "$COMPILED_EXACT_ACTION_SOURCE_HASH"
+  compiled_environment_source_sha256 "$COMPILED_ENVIRONMENT_SOURCE_HASH"
+  compiled_observation_abi "$COMPILED_OBSERVATION_ABI"
+  compiled_observation_version "$COMPILED_OBSERVATION_VERSION"
+  compiled_action_abi "$COMPILED_ACTION_ABI"
   config_tree_sha256 "$CONFIG_TREE_HASH"
   default_config_sha256 "$DEFAULT_CONFIG_HASH"
   compiled_module "$MODULE_PATH" compiled_module_sha256 "$MODULE_HASH"
   launcher_sha256 "$LAUNCHER_HASH" puffer_patch_bundle_sha256 "$PATCH_HASH"
   status_wrapper_sha256 "$STATUS_WRAPPER_HASH"
   live_integrity_guard_sha256 "$LIVE_GUARD_HASH"
+  checkpoint_lineage_sha256 "$CHECKPOINT_LINEAGE_HASH"
   live_integrity_max_silence "$LIVE_INTEGRITY_MAX_SILENCE"
   live_integrity_poll_seconds "$LIVE_INTEGRITY_POLL_SECONDS"
   vendor_head "$VENDOR_HEAD" vendor_source_sha256 "$VENDOR_SOURCE_HASH"
@@ -447,7 +580,9 @@ if len(pairs) % 2:
 manifest = dict(zip(pairs[::2], pairs[1::2]))
 manifest.update({
     "schema_version": 1,
-    "mode": "native_static_pool_reward_ablation",
+    "mode": ("native_fresh_v5_qualification"
+             if manifest["bootstrap_mode"] == "fresh-v5-qualification"
+             else "native_static_pool_reward_ablation"),
     "command": sys.argv[split + 1:],
 })
 path.write_text(json.dumps(
@@ -508,8 +643,9 @@ echo "LAUNCHED pid=$PID"
       {
         echo "reward-ablation tag=$TAG"
         echo "reward=$REWARD_NAME sha256=$REWARD_HASH"
-        echo "pool=$POOL identity_sha256=$POOL_HASH manifest_sha256=$POOL_MANIFEST_HASH pct=$FROZEN_BANK_PCT"
-        echo "warm=$WARM sha256=$WARM_HASH seed=$SEED requested_steps=$STEPS final_steps=$FINAL_STEPS"
+        echo "bootstrap=$BOOTSTRAP_MODE qualification_only=$QUALIFICATION_ONLY obs=obs-v5 action=exact-joint-v1"
+        echo "pool=$POOL identity_sha256=$POOL_HASH manifest_sha256=$POOL_MANIFEST_HASH lineage_bundle_sha256=$POOL_LINEAGE_BUNDLE_HASH pct=$FROZEN_BANK_PCT"
+        echo "warm=$WARM sha256=$WARM_HASH lineage_sha256=$WARM_LINEAGE_HASH seed=$SEED requested_steps=$STEPS final_steps=$FINAL_STEPS"
         echo "run_manifest_sha256=$(sha256sum "$RUN_MANIFEST" | awk '{print $1}')"
       } > "${directory}PROFILE"
       cp "$RUN_MANIFEST" "${directory}RUN_MANIFEST.json"

--- a/tools/run_reward_screen.sh
+++ b/tools/run_reward_screen.sh
@@ -23,8 +23,6 @@ fi
 
 LAUNCH_CWD="$PWD"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-: "${WARM:?WARM is required}"
-: "${POOL:?POOL is required}"
 : "${STEPS:?STEPS is required (explicit experiment budget)}"
 : "${SCREEN_PROFILE:?SCREEN_PROFILE is required (distance-possession, possession-gain, exact-action-canary, paired-confirmation, paired-final, or control-final)}"
 CANDIDATE_ARM="${CANDIDATE_ARM:-}"
@@ -55,7 +53,8 @@ CLIP_COEF=0.2
 VF_COEF=1.0
 VF_CLIP_COEF=0.5
 MAX_GRAD_NORM=1.5
-EXPECTED_POOL_HASH=18ec7cac858b71a6657003f454f19e232fb060f08b644c1e9e2f101076a9aac0
+EXPECTED_POOL_HASH="${EXPECTED_POOL_HASH:-}"
+NUM_FROZEN_BANKS=4
 MIN_TRAIN_GAMES=1
 MIN_EVAL_GAMES=10000
 MAX_PANEL_SILENCE_SECONDS=180
@@ -109,22 +108,55 @@ case "$SCREEN_PROFILE" in
      exit 1 ;;
 esac
 
+if [ "$SCREEN_PROFILE" = "exact-action-canary" ]; then
+  # D217/D218: v4 and v5 have the same tensor sizes. An inherited or explicitly
+  # empty legacy variable must not silently authorize a same-size warm/pool.
+  [ "${WARM+x}" != x ] || {
+    echo "exact-action-canary forbids WARM; qualification uses fresh obs-v5 initialization" >&2
+    exit 1
+  }
+  [ "${POOL+x}" != x ] || {
+    echo "exact-action-canary forbids POOL; qualification uses fresh obs-v5 self-play" >&2
+    exit 1
+  }
+  WARM=""
+  POOL=""
+  BOOTSTRAP_MODE=fresh-v5-qualification
+  NUM_FROZEN_BANKS=0
+  FROZEN_BANK_PCT=0
+  EXPECTED_POOL_HASH=""
+else
+  : "${WARM:?WARM is required}"
+  : "${POOL:?POOL is required}"
+  BOOTSTRAP_MODE=lineage-v5
+fi
+
 abspath() {
   case "$1" in
     /*) printf '%s\n' "$1" ;;
     *) printf '%s\n' "$LAUNCH_CWD/$1" ;;
   esac
 }
-WARM="$(abspath "$WARM")"
-POOL="$(abspath "$POOL")"
+[ -z "$WARM" ] || WARM="$(abspath "$WARM")"
+[ -z "$POOL" ] || POOL="$(abspath "$POOL")"
 OUT_DIR="$(abspath "$OUT_DIR")"
 if [ -n "$TRANSFER_COMPLETE" ]; then
   TRANSFER_COMPLETE="$(abspath "$TRANSFER_COMPLETE")"
   [ -f "$TRANSFER_COMPLETE" ] || {
     echo "missing transfer completion: $TRANSFER_COMPLETE" >&2; exit 1; }
 fi
-[ -f "$WARM" ] || { echo "missing warm checkpoint: $WARM" >&2; exit 1; }
-[ -d "$POOL" ] || { echo "missing static pool: $POOL" >&2; exit 1; }
+if [ "$BOOTSTRAP_MODE" = "lineage-v5" ]; then
+  [ -f "$WARM" ] || { echo "missing warm checkpoint: $WARM" >&2; exit 1; }
+  [ -d "$POOL" ] || { echo "missing static pool: $POOL" >&2; exit 1; }
+  [ -n "$EXPECTED_POOL_HASH" ] || {
+    echo "lineage-v5 screen requires the explicit current EXPECTED_POOL_HASH" >&2
+    exit 1
+  }
+  [[ "$EXPECTED_POOL_HASH" =~ ^[0-9a-f]{64}$ ]] || {
+    echo "EXPECTED_POOL_HASH must be a lowercase SHA-256 digest" >&2
+    exit 1
+  }
+fi
 mkdir -p "$OUT_DIR"
 
 command -v flock >/dev/null 2>&1 || {
@@ -202,7 +234,8 @@ freeze_screen_manifest() {
     "$EXPECTED_POOL_HASH" "$MIN_TRAIN_GAMES" "$MIN_EVAL_GAMES" \
     "$SCREEN_PROFILE" "$CANDIDATE_ARM" "$TRANSFER_COMPLETE" \
     "$EXPECTED_TRANSFER_SHA256" "$ARM_DETACH" "$POLL_SECONDS" \
-    "$MAX_PANEL_SILENCE_SECONDS" <<'PY'
+    "$MAX_PANEL_SILENCE_SECONDS" "$BOOTSTRAP_MODE" \
+    "$NUM_FROZEN_BANKS" <<'PY'
 import datetime, hashlib, json, pathlib, subprocess, sys, sysconfig
 
 (
@@ -213,12 +246,20 @@ import datetime, hashlib, json, pathlib, subprocess, sys, sysconfig
     max_grad_norm, expected_pool_hash, min_train_games, min_eval_games,
     screen_profile, candidate_arm, transfer_complete_path,
     expected_transfer_sha, arm_detach, poll_seconds, max_panel_silence_seconds,
+    bootstrap_mode, num_frozen_banks,
 ) = sys.argv[1:]
 root = pathlib.Path(root_path).resolve()
 vendor = root / "vendor" / "PufferLib"
-warm = pathlib.Path(warm_path).resolve()
-pool = pathlib.Path(pool_path).resolve()
+warm = pathlib.Path(warm_path).resolve() if warm_path else None
+pool = pathlib.Path(pool_path).resolve() if pool_path else None
 destination = pathlib.Path(manifest_path)
+qualification_only = screen_profile == "exact-action-canary"
+if qualification_only != (bootstrap_mode == "fresh-v5-qualification"):
+    raise SystemExit("qualification profile/bootstrap mode mismatch")
+environment_header = root / "puffer/bloodbowl/bloodbowl.h"
+if "#define BBE_OBS_VERSION 5" not in environment_header.read_text(
+        encoding="utf-8"):
+    raise SystemExit("source tree does not declare obs-v5")
 
 def sha(path):
     return hashlib.sha256(pathlib.Path(path).read_bytes()).hexdigest()
@@ -276,44 +317,62 @@ settings = {
     "policy_hidden_size": "512",
     "policy_num_layers": "3",
     "policy_expansion_factor": "1",
+    "num_frozen_banks": num_frozen_banks,
     "arm_detach": arm_detach,
 }
 
 expect_size = int(expect_bytes)
-if warm.stat().st_size != expect_size:
-    raise SystemExit(
-        f"warm checkpoint is {warm.stat().st_size} bytes; expected {expect_size}")
-
-pool_manifest_path = pool / "league_seeds.json"
-pool_raw = pool_manifest_path.read_bytes()
-pool_manifest = json.loads(pool_raw)
-if pool_manifest.get("expected_bytes") != expect_size:
-    raise SystemExit("pool expected_bytes does not match screen checkpoint size")
-seeds = pool_manifest.get("seeds")
-if not isinstance(seeds, list) or len(seeds) != 4:
-    raise SystemExit("screen pool must contain exactly four banks")
-bank_identity = []
-for index, seed in enumerate(seeds):
-    if seed.get("bank") != index:
-        raise SystemExit(f"pool bank order mismatch at index {index}")
-    path = pool / seed["file"]
-    digest = sha(path)
-    size = path.stat().st_size
-    if size != expect_size or seed.get("bytes") != size or seed.get("sha256") != digest:
-        raise SystemExit(f"pool bank contract mismatch: {path}")
-    bank_identity.append({
-        "bank": index, "name": seed.get("name"), "file": str(path),
-        "bytes": size, "sha256": digest,
-    })
-identity_body = [
-    {key: bank[key] for key in ("bank", "name", "bytes", "sha256")}
-    for bank in bank_identity
-]
-pool_identity = hashlib.sha256(json.dumps(
-    identity_body, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
-if pool_identity != expected_pool_hash:
-    raise SystemExit(
-        f"pool identity {pool_identity} does not match {expected_pool_hash}")
+if qualification_only:
+    if warm is not None or pool is not None or int(num_frozen_banks) != 0:
+        raise SystemExit("fresh qualification cannot carry warm/pool/frozen banks")
+    pool_raw = b""
+    pool_identity = ""
+    bank_identity = []
+else:
+    if warm is None or pool is None or int(num_frozen_banks) != 4:
+        raise SystemExit("lineage-v5 screen requires warm and four-bank pool")
+    if warm.stat().st_size != expect_size:
+        raise SystemExit(
+            f"warm checkpoint is {warm.stat().st_size} bytes; expected {expect_size}")
+    pool_manifest_path = pool / "league_seeds.json"
+    pool_raw = pool_manifest_path.read_bytes()
+    pool_manifest = json.loads(pool_raw)
+    if pool_manifest.get("expected_bytes") != expect_size:
+        raise SystemExit("pool expected_bytes does not match screen checkpoint size")
+    seeds = pool_manifest.get("seeds")
+    if not isinstance(seeds, list) or len(seeds) != 4:
+        raise SystemExit("screen pool must contain exactly four banks")
+    bank_identity = []
+    for index, seed in enumerate(seeds):
+        if seed.get("bank") != index:
+            raise SystemExit(f"pool bank order mismatch at index {index}")
+        path = pool / seed["file"]
+        digest = sha(path)
+        size = path.stat().st_size
+        if size != expect_size or seed.get("bytes") != size or seed.get("sha256") != digest:
+            raise SystemExit(f"pool bank contract mismatch: {path}")
+        lineage_file = seed.get("lineage_file")
+        if not isinstance(lineage_file, str) or not lineage_file:
+            raise SystemExit(f"pool bank {index} lacks lineage_file")
+        lineage_manifest_sha = seed.get("lineage_sha256")
+        if (not isinstance(lineage_manifest_sha, str) or
+                len(lineage_manifest_sha) != 64):
+            raise SystemExit(f"pool bank {index} lacks lineage_sha256")
+        bank_identity.append({
+            "bank": index, "name": seed.get("name"), "file": str(path),
+            "bytes": size, "sha256": digest,
+            "lineage_file": str((pool / lineage_file).resolve()),
+            "manifest_lineage_sha256": lineage_manifest_sha,
+        })
+    identity_body = [
+        {key: bank[key] for key in ("bank", "name", "bytes", "sha256")}
+        for bank in bank_identity
+    ]
+    pool_identity = hashlib.sha256(json.dumps(
+        identity_body, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    if pool_identity != expected_pool_hash:
+        raise SystemExit(
+            f"pool identity {pool_identity} does not match {expected_pool_hash}")
 
 sys.path.insert(0, str(root / "tools"))
 from reward_manifest import load_manifest
@@ -321,6 +380,9 @@ from analyze_reward_candidate_transfer import (
     TransferError, validate_completion_evidence,
 )
 from live_integrity_guard import HARD_INTEGRITY_KEYS
+from checkpoint_lineage import (
+    lineage_digest, sidecar_path, validate_lineage,
+)
 if screen_profile == "distance-possession":
     reward_files = {
         "r0": root / "puffer/config/rewards/r0_full.json",
@@ -399,6 +461,46 @@ config = vendor / "config/bloodbowl.ini"
 source_hash_path = vendor / "ocean/bloodbowl/.content_hash"
 if not source_hash_path.is_file():
     raise SystemExit("installed Blood Bowl content hash is missing")
+source_hash = source_hash_path.read_text(encoding="utf-8").strip()
+module_probe = subprocess.run(
+    [sys.executable, "-c", """
+import json
+from pufferlib import _C
+print(json.dumps({
+    "module": _C.__file__,
+    "env_name": getattr(_C, "env_name", None),
+    "gpu": int(bool(getattr(_C, "gpu", False))),
+    "precision_bytes": int(getattr(_C, "precision_bytes", 0)),
+    "exact_action_source_sha256": getattr(
+        _C, "exact_action_source_hash", "<missing>"),
+    "environment_source_sha256": getattr(
+        _C, "environment_source_hash", "<missing>"),
+    "observation_abi": getattr(_C, "observation_abi", "<missing>"),
+    "observation_version": getattr(
+        _C, "observation_version", "<missing>"),
+    "action_abi": getattr(_C, "action_abi", "<missing>"),
+}, sort_keys=True))
+"""], cwd=vendor, text=True, stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE, check=False)
+if module_probe.returncode != 0:
+    raise SystemExit(
+        "could not interrogate compiled native module: " +
+        module_probe.stderr.strip())
+compiled_contract = json.loads(module_probe.stdout)
+if pathlib.Path(compiled_contract["module"]).resolve() != module.resolve():
+    raise SystemExit("imported native module differs from frozen module path")
+if (
+    compiled_contract["env_name"] != "bloodbowl" or
+    compiled_contract["gpu"] != 1 or
+    compiled_contract["precision_bytes"] != 4 or
+    compiled_contract["environment_source_sha256"] != source_hash or
+    compiled_contract["observation_abi"] != "obs-v5" or
+    compiled_contract["observation_version"] != 5 or
+    compiled_contract["action_abi"] != "exact-joint-v1" or
+    len(compiled_contract["exact_action_source_sha256"]) != 64
+):
+    raise SystemExit(
+        "compiled native module does not satisfy the frozen obs-v5/exact-action contract")
 
 patches = [
     root / "training/pufferl_env_dashboard_limit.patch",
@@ -426,6 +528,38 @@ vendor_head_result = subprocess.run(
 vendor_head = (vendor_head_result.stdout.strip()
                if vendor_head_result.returncode == 0 else "<not-a-git-checkout>")
 
+warm_identity = None
+pool_lineage_bundle_sha = ""
+if not qualification_only:
+    expected_lineage = {
+        "source_sha256": source_hash,
+        "compiled_module_sha256": sha(module),
+        "puffer_patch_bundle_sha256": patch_bundle_sha,
+    }
+    warm_payload = validate_lineage(
+        warm, sidecar_path(warm), expected=expected_lineage,
+        require_eligible=True)
+    warm_identity = {
+        "path": str(warm), "bytes": warm.stat().st_size, "sha256": sha(warm),
+        "lineage_path": str(sidecar_path(warm).resolve()),
+        "lineage_sha256": lineage_digest(warm_payload),
+    }
+    pool_lineages = []
+    for bank in bank_identity:
+        payload = validate_lineage(
+            bank["file"], bank["lineage_file"], expected=expected_lineage,
+            require_eligible=True)
+        bank["lineage_sha256"] = lineage_digest(payload)
+        if bank["lineage_sha256"] != bank["manifest_lineage_sha256"]:
+            raise SystemExit(
+                f"pool bank {bank['bank']} lineage digest differs from manifest")
+        pool_lineages.append({
+            "bank": bank["bank"], "checkpoint_sha256": bank["sha256"],
+            "lineage_sha256": bank["lineage_sha256"],
+        })
+    pool_lineage_bundle_sha = hashlib.sha256(json.dumps(
+        pool_lineages, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
 total = int(total_agents)
 buffers = int(num_buffers)
 rollout_quantum = total * int(horizon)
@@ -436,7 +570,10 @@ final_steps = train_epochs * rollout_quantum
 checkpoint_interval = (
     int(checkpoint_steps) + rollout_quantum // 2) // rollout_quantum
 per_bank = int((total // buffers) * float(frozen_bank_pct))
-historical_share = 4 * per_bank / ((total // buffers) / 2.0)
+historical_share = (
+    int(num_frozen_banks) * per_bank / ((total // buffers) / 2.0)
+    if int(num_frozen_banks) else 0.0
+)
 
 schedule = [
     {"index": index + 1, "arm": arm, "seed": seed}
@@ -447,10 +584,21 @@ launcher = root / "tools/run_reward_ablation.sh"
 screen_script = root / "tools/run_reward_screen.sh"
 game_stats = root / "tools/game_stats.py"
 live_integrity_guard = root / "tools/live_integrity_guard.py"
+checkpoint_lineage_tool = root / "tools/checkpoint_lineage.py"
 status_wrapper = root / "tools/trainer_status_wrapper.sh"
 contract = {
     "screen_profile": screen_profile,
-    "qualification_only": screen_profile == "exact-action-canary",
+    "qualification_only": qualification_only,
+    "bootstrap": {
+        "mode": bootstrap_mode,
+        "observation_abi": "obs-v5",
+        "observation_version": 5,
+        "action_abi": "exact-joint-v1",
+        "initialization": "fresh" if qualification_only else "lineage-v5",
+        "warm_lineage_sha256": (
+            "" if warm_identity is None else warm_identity["lineage_sha256"]),
+        "pool_lineage_bundle_sha256": pool_lineage_bundle_sha,
+    },
     "prefix": prefix,
     "out_dir": str(pathlib.Path(out_dir).resolve()),
     "requested_steps": int(steps),
@@ -458,13 +606,12 @@ contract = {
     "rollout_quantum": rollout_quantum,
     "schedule": schedule,
     "settings": settings,
-    "warm": {
-        "path": str(warm), "bytes": warm.stat().st_size, "sha256": sha(warm),
-    },
-    "pool": {
+    "warm": warm_identity,
+    "pool": None if qualification_only else {
         "path": str(pool),
         "manifest_sha256": hashlib.sha256(pool_raw).hexdigest(),
         "identity_sha256": pool_identity,
+        "lineage_bundle_sha256": pool_lineage_bundle_sha,
         "banks": bank_identity,
         "rows_per_bank": per_bank,
         "historical_game_share": str(historical_share),
@@ -480,6 +627,7 @@ contract = {
         "screen_script_sha256": sha(screen_script),
         "game_stats_sha256": sha(game_stats),
         "live_integrity_guard_sha256": sha(live_integrity_guard),
+        "checkpoint_lineage_sha256": sha(checkpoint_lineage_tool),
         "status_wrapper_sha256": sha(status_wrapper),
         "launcher_sha256": sha(launcher),
         "candidate_transfer_analyzer_sha256": sha(
@@ -491,6 +639,7 @@ contract = {
         "compiled_module": str(module.resolve()),
         "compiled_module_bytes": module.stat().st_size,
         "compiled_module_sha256": sha(module),
+        "compiled_semantic_contract": compiled_contract,
         "puffer_patch_bundle_sha256": patch_bundle_sha,
         "vendor_head": vendor_head,
         "vendor_source_sha256": vendor_source_sha,
@@ -649,6 +798,13 @@ if (
     != screen["implementation"]["live_integrity_guard_sha256"]
 ):
     raise SystemExit("live_integrity_guard.py changed after screen plan freeze")
+checkpoint_lineage_path = root / "tools/checkpoint_lineage.py"
+if (
+    not checkpoint_lineage_path.is_file()
+    or sha(checkpoint_lineage_path)
+    != screen["implementation"]["checkpoint_lineage_sha256"]
+):
+    raise SystemExit("checkpoint_lineage.py changed after screen plan freeze")
 
 sys.path.insert(0, str(root / "tools"))
 from game_stats import (
@@ -695,24 +851,45 @@ if run_dir_manifest.read_bytes() != run_manifest_path.read_bytes():
     raise SystemExit("run-directory and log-side manifests differ")
 _, expected_reward_sha = load_manifest(reward_manifest_path)
 expected_contract = {
-    "mode": "native_static_pool_reward_ablation",
+    "mode": ("native_fresh_v5_qualification"
+             if screen["qualification_only"]
+             else "native_static_pool_reward_ablation"),
     "tag": tag,
     "seed": str(int(seed)),
+    "bootstrap_mode": screen["bootstrap"]["mode"],
+    "initialization": screen["bootstrap"]["initialization"],
+    "qualification_only": "1" if screen["qualification_only"] else "0",
+    "observation_abi": "obs-v5",
+    "observation_version": "5",
+    "action_abi": "exact-joint-v1",
+    "policy_hidden_size": screen["settings"]["policy_hidden_size"],
+    "policy_num_layers": screen["settings"]["policy_num_layers"],
+    "policy_expansion_factor": screen["settings"]["policy_expansion_factor"],
     "requested_steps": str(int(requested_steps)),
     "reward_sha256": expected_reward_sha,
     "native_precision_bytes": "4",
     "screen_manifest_sha256": screen_manifest_sha,
-    "warm_sha256": screen["warm"]["sha256"],
-    "pool_identity_sha256": screen["pool"]["identity_sha256"],
-    "pool_manifest_sha256": screen["pool"]["manifest_sha256"],
+    "warm_sha256": "" if screen["warm"] is None else screen["warm"]["sha256"],
+    "warm_lineage_sha256": screen["bootstrap"]["warm_lineage_sha256"],
+    "pool_identity_sha256": (
+        "" if screen["pool"] is None else screen["pool"]["identity_sha256"]),
+    "pool_manifest_sha256": (
+        "" if screen["pool"] is None else screen["pool"]["manifest_sha256"]),
+    "pool_lineage_bundle_sha256": screen["bootstrap"]["pool_lineage_bundle_sha256"],
     "source_sha256": screen["implementation"]["source_sha256"],
     "config_sha256": screen["implementation"]["config_sha256"],
     "config_tree_sha256": screen["implementation"]["config_tree_sha256"],
     "default_config_sha256": screen["implementation"]["default_config_sha256"],
     "compiled_module_sha256": screen["implementation"]["compiled_module_sha256"],
+    "compiled_exact_action_source_sha256": screen["implementation"]["compiled_semantic_contract"]["exact_action_source_sha256"],
+    "compiled_environment_source_sha256": screen["implementation"]["compiled_semantic_contract"]["environment_source_sha256"],
+    "compiled_observation_abi": screen["implementation"]["compiled_semantic_contract"]["observation_abi"],
+    "compiled_observation_version": screen["implementation"]["compiled_semantic_contract"]["observation_version"],
+    "compiled_action_abi": screen["implementation"]["compiled_semantic_contract"]["action_abi"],
     "launcher_sha256": screen["implementation"]["launcher_sha256"],
     "status_wrapper_sha256": screen["implementation"]["status_wrapper_sha256"],
     "live_integrity_guard_sha256": screen["implementation"]["live_integrity_guard_sha256"],
+    "checkpoint_lineage_sha256": screen["implementation"]["checkpoint_lineage_sha256"],
     "live_integrity_max_silence": str(
         screen["error_budget"]["max_panel_silence_seconds"]),
     "live_integrity_poll_seconds": str(
@@ -720,11 +897,12 @@ expected_contract = {
     "puffer_patch_bundle_sha256": screen["implementation"]["puffer_patch_bundle_sha256"],
     "vendor_head": screen["implementation"]["vendor_head"],
     "vendor_source_sha256": screen["implementation"]["vendor_source_sha256"],
-    "historical_game_share": screen["pool"]["historical_game_share"],
+    "historical_game_share": (
+        "0" if screen["pool"] is None else screen["pool"]["historical_game_share"]),
     "frozen_bank_pct": screen["settings"]["frozen_bank_pct"],
-    "num_frozen_banks": "4",
+    "num_frozen_banks": screen["settings"]["num_frozen_banks"],
     "expected_pool_hash": screen["settings"]["expected_pool_hash"],
-    "warm_bytes": str(screen["warm"]["bytes"]),
+    "warm_bytes": "0" if screen["warm"] is None else str(screen["warm"]["bytes"]),
     "checkpoint_interval": screen["derived"]["checkpoint_interval"],
 }
 settings_to_manifest = {
@@ -760,8 +938,12 @@ def same_path(actual, expected, label):
 
 same_path(run_manifest["reward_manifest"], reward_manifest_path,
           "reward_manifest")
-same_path(run_manifest["warm"], warm_path, "warm")
-same_path(run_manifest["pool"], pool_path, "pool")
+if screen["qualification_only"]:
+    if run_manifest["warm"] or run_manifest["pool"]:
+        raise SystemExit("fresh qualification run manifest contains warm/pool paths")
+else:
+    same_path(run_manifest["warm"], warm_path, "warm")
+    same_path(run_manifest["pool"], pool_path, "pool")
 same_path(run_manifest["compiled_module"],
           screen["implementation"]["compiled_module"], "compiled_module")
 
@@ -791,6 +973,15 @@ expected_bytes = int(run_manifest["expected_checkpoint_bytes"])
 if checkpoint.stat().st_size != expected_bytes:
     raise SystemExit(
         f"final checkpoint is {checkpoint.stat().st_size} bytes; expected {expected_bytes}")
+
+from checkpoint_lineage import (
+    lineage_digest, lineage_from_run_manifest, sidecar_path, validate_lineage,
+    write_lineage,
+)
+lineage_payload = lineage_from_run_manifest(
+    checkpoint, run_manifest_path, allow_eligible_publication=True)
+lineage_path = sidecar_path(checkpoint)
+lineage_sha = lineage_digest(lineage_payload)
 
 integrity = HARD_INTEGRITY_KEYS
 required = (
@@ -838,6 +1029,21 @@ if bad_schema:
         "kind": "telemetry_schema", "observed": bad_schema, "minimum": 2,
     })
 
+if not failures:
+    if mode == "write":
+        write_lineage(lineage_path, lineage_payload)
+    recorded_lineage = validate_lineage(
+        checkpoint, lineage_path,
+        expected={
+            "source_sha256": screen["implementation"]["source_sha256"],
+            "compiled_module_sha256": screen["implementation"]["compiled_module_sha256"],
+            "puffer_patch_bundle_sha256": screen["implementation"]["puffer_patch_bundle_sha256"],
+        },
+        require_eligible=not screen["qualification_only"],
+    )
+    if recorded_lineage != lineage_payload:
+        raise SystemExit("checkpoint lineage differs from recomputed run evidence")
+
 result = {
     "schema_version": 2,
     "trainer_complete": True,
@@ -856,6 +1062,9 @@ result = {
     "checkpoint": str(checkpoint),
     "checkpoint_bytes": checkpoint.stat().st_size,
     "checkpoint_sha256": sha(checkpoint),
+    "checkpoint_lineage": str(lineage_path),
+    "checkpoint_lineage_sha256": lineage_sha,
+    "qualification_only": screen["qualification_only"],
     "train_metrics": phase_metrics["train"],
     "eval_metrics": phase_metrics["eval"],
 }
@@ -1017,6 +1226,7 @@ PY
     echo "START index=$CURRENT_INDEX/$TOTAL_ARMS arm=$arm seed=$seed steps=$STEPS tag=$tag"
     write_screen_status running 0 "launching arm"
     env TAG="$tag" REWARD_MANIFEST="$manifest" WARM="$WARM" POOL="$POOL" \
+        BOOTSTRAP_MODE="$BOOTSTRAP_MODE" \
         STEPS="$STEPS" SEED="$seed" LOG="$log" RIG_ALLOW_FLOAT=1 \
         SCREEN_MANIFEST_SHA256="$SCREEN_MANIFEST_SHA" DRY_RUN=0 \
         EXPECTED_PUFFER_PATCH_BUNDLE_SHA256="$SCREEN_PATCH_BUNDLE_SHA" \
@@ -1111,6 +1321,7 @@ for index, (arm, seed) in enumerate(schedule, 1):
         "index": index, "arm": arm, "seed": seed,
         "path": str(result_path), "sha256": sha(result_path),
         "checkpoint_sha256": result["checkpoint_sha256"],
+        "checkpoint_lineage_sha256": result["checkpoint_lineage_sha256"],
     })
 core = {
     "schema_version": 1,

--- a/tools/test_checkpoint_lineage.py
+++ b/tools/test_checkpoint_lineage.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools import checkpoint_lineage
+
+
+def digest(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+class CheckpointLineageTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.checkpoint = self.root / "policy.bin"
+        self.checkpoint.write_bytes(
+            b"exact-v5-policy" + b"\0" * (
+                checkpoint_lineage.EXPECTED_CHECKPOINT_BYTES -
+                len(b"exact-v5-policy")))
+        self.original_checkpoint = self.checkpoint.read_bytes()
+        self.run_manifest = self.root / "RUN_MANIFEST.json"
+        self.run_manifest.write_text(json.dumps({
+            "schema_version": 1,
+            "mode": "native_fresh_v5_qualification",
+            "seed": "42",
+            "observation_abi": "obs-v5",
+            "observation_version": "5",
+            "action_abi": "exact-joint-v1",
+            "initialization": "fresh",
+            "qualification_only": "1",
+            "policy_hidden_size": "512",
+            "policy_num_layers": "3",
+            "policy_expansion_factor": "1",
+            "expected_checkpoint_bytes": str(
+                checkpoint_lineage.EXPECTED_CHECKPOINT_BYTES),
+            "source_sha256": "1" * 64,
+            "compiled_module_sha256": "2" * 64,
+            "puffer_patch_bundle_sha256": "3" * 64,
+            "screen_manifest_sha256": "4" * 64,
+            "warm_lineage_sha256": "",
+            "pool_lineage_bundle_sha256": "",
+        }, sort_keys=True) + "\n", encoding="utf-8")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def expected(self):
+        return {
+            "source_sha256": "1" * 64,
+            "compiled_module_sha256": "2" * 64,
+            "puffer_patch_bundle_sha256": "3" * 64,
+        }
+
+    def create(self):
+        payload = checkpoint_lineage.lineage_from_run_manifest(
+            self.checkpoint, self.run_manifest)
+        sidecar = checkpoint_lineage.sidecar_path(self.checkpoint)
+        checkpoint_lineage.write_lineage(sidecar, payload)
+        return payload, sidecar
+
+    def test_round_trip_binds_checkpoint_runtime_and_producer(self):
+        payload, sidecar = self.create()
+        observed = checkpoint_lineage.validate_lineage(
+            self.checkpoint, sidecar, expected=self.expected(),
+            require_eligible=False)
+        self.assertEqual(observed, payload)
+        self.assertEqual(payload["checkpoint"]["sha256"],
+                         digest(self.checkpoint.read_bytes()))
+        self.assertEqual(payload["producer"]["run_manifest_sha256"],
+                         digest(self.run_manifest.read_bytes()))
+        self.assertFalse(payload["ancestry"]["eligible"])
+        self.assertTrue(payload["ancestry"]["qualification_only"])
+        self.assertEqual(
+            sidecar.read_bytes(), checkpoint_lineage.canonical_bytes(payload))
+
+    def test_qualification_output_is_never_eligible_ancestry(self):
+        _, sidecar = self.create()
+        with self.assertRaisesRegex(
+                checkpoint_lineage.LineageError, "qualification-only"):
+            checkpoint_lineage.validate_lineage(
+                self.checkpoint, sidecar, expected=self.expected(),
+                require_eligible=True)
+
+    def test_eligible_nonqualification_lineage_round_trips(self):
+        manifest = json.loads(self.run_manifest.read_text(encoding="utf-8"))
+        manifest["qualification_only"] = "0"
+        manifest["initialization"] = "lineage-v5"
+        manifest["mode"] = "native_static_pool_reward_ablation"
+        manifest["warm_lineage_sha256"] = "5" * 64
+        manifest["pool_lineage_bundle_sha256"] = "6" * 64
+        self.run_manifest.write_text(
+            json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8")
+        payload = checkpoint_lineage.lineage_from_run_manifest(
+            self.checkpoint, self.run_manifest,
+            allow_eligible_publication=True)
+        sidecar = checkpoint_lineage.sidecar_path(self.checkpoint)
+        checkpoint_lineage.write_lineage(sidecar, payload)
+        observed = checkpoint_lineage.validate_lineage(
+            self.checkpoint, sidecar, expected=self.expected(),
+            require_eligible=True)
+        self.assertTrue(observed["ancestry"]["eligible"])
+        self.assertEqual(observed["ancestry"]["warm_lineage_sha256"],
+                         "5" * 64)
+
+    def test_missing_malformed_and_noncanonical_sidecars_fail_closed(self):
+        missing = self.root / "missing.json"
+        with self.assertRaisesRegex(checkpoint_lineage.LineageError, "missing"):
+            checkpoint_lineage.validate_lineage(
+                self.checkpoint, missing, expected=self.expected())
+
+        malformed = self.root / "malformed.json"
+        malformed.write_text("{not json}\n", encoding="utf-8")
+        with self.assertRaisesRegex(checkpoint_lineage.LineageError, "JSON"):
+            checkpoint_lineage.validate_lineage(
+                self.checkpoint, malformed, expected=self.expected())
+
+        payload, sidecar = self.create()
+        sidecar.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(checkpoint_lineage.LineageError,
+                                    "canonical"):
+            checkpoint_lineage.validate_lineage(
+                self.checkpoint, sidecar, expected=self.expected())
+
+    def test_checkpoint_and_every_runtime_identity_are_hash_bound(self):
+        _, sidecar = self.create()
+        self.checkpoint.write_bytes(b"changed-policy")
+        with self.assertRaisesRegex(checkpoint_lineage.LineageError,
+                                    "checkpoint"):
+            checkpoint_lineage.validate_lineage(
+                self.checkpoint, sidecar, expected=self.expected())
+
+        self.checkpoint.write_bytes(self.original_checkpoint)
+        for key in checkpoint_lineage.SHA256_KEYS:
+            with self.subTest(key=key):
+                expected = self.expected()
+                expected[key] = "wrong" if isinstance(expected[key], str) else 999
+                with self.assertRaisesRegex(checkpoint_lineage.LineageError,
+                                            key):
+                    checkpoint_lineage.validate_lineage(
+                        self.checkpoint, sidecar, expected=expected)
+
+    def test_frozen_compatibility_cannot_be_overridden_by_caller(self):
+        _, sidecar = self.create()
+        for key, value in (
+            ("observation_abi", "obs-v4"),
+            ("observation_version", 4),
+            ("action_abi", "marginal-heads-v1"),
+            ("policy_hidden_size", 999),
+        ):
+            with self.subTest(key=key):
+                with self.assertRaisesRegex(
+                        checkpoint_lineage.LineageError,
+                        "implementation digests"):
+                    checkpoint_lineage.validate_lineage(
+                        self.checkpoint, sidecar,
+                        expected={key: value}, require_eligible=False)
+                with self.assertRaisesRegex(
+                        checkpoint_lineage.LineageError,
+                        "implementation digests"):
+                    checkpoint_lineage._parse_expected([f"{key}={value}"])
+
+    def test_modified_manifest_cannot_relabel_qualification_as_eligible(self):
+        self.create()
+        copied = self.root / "copied-policy.bin"
+        copied.write_bytes(self.checkpoint.read_bytes())
+        manifest = json.loads(self.run_manifest.read_text(encoding="utf-8"))
+        manifest.update({
+            "mode": "native_static_pool_reward_ablation",
+            "qualification_only": "0",
+            "initialization": "lineage-v5",
+            "warm_lineage_sha256": "5" * 64,
+            "pool_lineage_bundle_sha256": "6" * 64,
+        })
+        relabel = self.root / "relabel.json"
+        relabel.write_text(
+            json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+                checkpoint_lineage.LineageError,
+                "accepted screen result materialization"):
+            checkpoint_lineage.lineage_from_run_manifest(copied, relabel)
+
+    def test_current_checkpoint_size_is_frozen_at_create_and_validate(self):
+        manifest = json.loads(self.run_manifest.read_text(encoding="utf-8"))
+        manifest["expected_checkpoint_bytes"] = "13670400"
+        self.run_manifest.write_text(
+            json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(
+                checkpoint_lineage.LineageError,
+                "expected_checkpoint_bytes must be"):
+            checkpoint_lineage.lineage_from_run_manifest(
+                self.checkpoint, self.run_manifest)
+
+        manifest["expected_checkpoint_bytes"] = str(
+            checkpoint_lineage.EXPECTED_CHECKPOINT_BYTES)
+        self.run_manifest.write_text(
+            json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8")
+        payload, sidecar = self.create()
+        self.checkpoint.write_bytes(b"legacy-sized")
+        payload["checkpoint"] = {
+            "bytes": self.checkpoint.stat().st_size,
+            "sha256": digest(self.checkpoint.read_bytes()),
+        }
+        checkpoint_lineage.write_lineage(sidecar, payload, replace=True)
+        with self.assertRaisesRegex(
+                checkpoint_lineage.LineageError, "current ABI requires"):
+            checkpoint_lineage.validate_lineage(
+                self.checkpoint, sidecar, expected=self.expected(),
+                require_eligible=False)
+
+    def test_same_size_legacy_semantics_are_rejected(self):
+        payload, sidecar = self.create()
+        payload["compatibility"]["observation_abi"] = "obs-v4"
+        payload["compatibility"]["observation_version"] = 4
+        payload["compatibility"]["action_abi"] = "marginal-heads-v1"
+        checkpoint_lineage.write_lineage(sidecar, payload, replace=True)
+        with self.assertRaisesRegex(checkpoint_lineage.LineageError,
+                                    "observation_abi"):
+            checkpoint_lineage.validate_lineage(
+                self.checkpoint, sidecar, expected=self.expected())
+
+    def test_producer_manifest_rejects_missing_or_invalid_contract_fields(self):
+        manifest = json.loads(self.run_manifest.read_text(encoding="utf-8"))
+        for key, bad in (
+            ("qualification_only", "maybe"),
+            ("qualification_only", "0"),
+            ("source_sha256", "short"),
+            ("observation_version", "4"),
+            ("initialization", "legacy-v4"),
+        ):
+            with self.subTest(key=key):
+                changed = dict(manifest)
+                changed[key] = bad
+                self.run_manifest.write_text(
+                    json.dumps(changed) + "\n", encoding="utf-8")
+                with self.assertRaises(checkpoint_lineage.LineageError):
+                    checkpoint_lineage.lineage_from_run_manifest(
+                        self.checkpoint, self.run_manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_experiment_contracts.py
+++ b/tools/test_experiment_contracts.py
@@ -44,6 +44,23 @@ class ExperimentContractTests(unittest.TestCase):
         self.assertIn("trailing Puffer overrides are not allowed", result.stderr)
         self.assertNotIn("missing reward manifest", result.stderr)
 
+    def test_reward_launcher_rejects_non_v5_checkpoint_size_before_runtime(self):
+        result = run_script(
+            "tools/run_reward_ablation.sh",
+            env={
+                "TAG": "wrong-size-contract-test",
+                "REWARD_MANIFEST": "missing.json",
+                "BOOTSTRAP_MODE": "fresh-v5-qualification",
+                "EXPECT_BYTES": "13670400",
+            },
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "obs-v5/exact-joint-v1 requires EXPECT_BYTES=16066560",
+            result.stderr,
+        )
+        self.assertNotIn("vendored Python missing", result.stderr)
+
     def test_frozen_eval_rejects_trailing_override_before_checkpoint_io(self):
         with tempfile.TemporaryDirectory() as tmp:
             result = run_script(

--- a/tools/test_experiment_contracts.py
+++ b/tools/test_experiment_contracts.py
@@ -344,7 +344,7 @@ class ExperimentContractTests(unittest.TestCase):
             },
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("missing warm checkpoint", result.stderr)
+        self.assertIn("exact-action-canary forbids WARM", result.stderr)
 
         source = (ROOT / "tools/run_reward_screen.sh").read_text(
             encoding="utf-8"
@@ -352,7 +352,7 @@ class ExperimentContractTests(unittest.TestCase):
         self.assertIn("exact-action-canary", source)
         self.assertIn("arms=(both)", source)
         self.assertIn("seeds=(42)", source)
-        self.assertIn('"qualification_only": screen_profile == "exact-action-canary"', source)
+        self.assertIn('"qualification_only": qualification_only', source)
         self.assertIn("--complete-log", source)
         self.assertLess(
             source.index('terminate_current_arm "$pid" "$process_group"'),
@@ -360,6 +360,49 @@ class ExperimentContractTests(unittest.TestCase):
                 'write_screen_status failed 1 "hard-integrity error budget exhausted"'
             ),
         )
+
+    def test_exact_action_canary_requires_fresh_v5_without_legacy_assets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "screen"
+            base = {
+                "STEPS": "50000000",
+                "SCREEN_PROFILE": "exact-action-canary",
+                "OUT_DIR": str(out),
+            }
+            for key in ("WARM", "POOL"):
+                env = dict(base)
+                env[key] = "legacy-input"
+                result = run_script("tools/run_reward_screen.sh", env=env)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    f"exact-action-canary forbids {key}", result.stderr)
+                self.assertFalse(out.exists())
+
+            result = run_script("tools/run_reward_screen.sh", env=base)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn("WARM is required", result.stderr)
+            self.assertNotIn("POOL is required", result.stderr)
+            self.assertTrue(
+                "vendored Python missing" in result.stderr or
+                "flock is required" in result.stderr,
+                result.stderr,
+            )
+            self.assertTrue(out.exists())
+
+        screen = (ROOT / "tools/run_reward_screen.sh").read_text(
+            encoding="utf-8")
+        arm = (ROOT / "tools/run_reward_ablation.sh").read_text(
+            encoding="utf-8")
+        for contract in (
+            "fresh-v5-qualification", "obs-v5", "exact-joint-v1",
+            '"qualification_only": qualification_only',
+            'NUM_FROZEN_BANKS=0',
+        ):
+            self.assertIn(contract, screen)
+        self.assertIn('BOOTSTRAP_MODE="$BOOTSTRAP_MODE"', screen)
+        self.assertIn('case "$BOOTSTRAP_MODE" in', arm)
+        self.assertIn('--selfplay.enabled 0', arm)
+        self.assertIn('--vec.num-frozen-banks 0', arm)
 
     @unittest.skipUnless(VENDOR_CHECKOUT, "vendored Puffer checkout unavailable")
     def test_puffer_machine_log_uses_explicit_loop_phase_and_fresh_panels(self):
@@ -495,6 +538,16 @@ class ExperimentContractTests(unittest.TestCase):
             "pufferlib/__init__.py",
             "pufferlib/models.py",
             "pufferlib/muon.py",
+        ):
+            self.assertIn(field, screen)
+            self.assertIn(field, arm)
+        self.assertIn('"compiled_semantic_contract": compiled_contract', screen)
+        for field in (
+            "compiled_exact_action_source_sha256",
+            "compiled_environment_source_sha256",
+            "compiled_observation_abi",
+            "compiled_observation_version",
+            "compiled_action_abi",
         ):
             self.assertIn(field, screen)
             self.assertIn(field, arm)

--- a/training/puffer_exact_joint_actions.patch
+++ b/training/puffer_exact_joint_actions.patch
@@ -211,15 +211,19 @@ index 0f64be1..566ca22 100644
 
  #define _PUFFER_STRINGIFY(x) #x
  #define PUFFER_STRINGIFY(x) _PUFFER_STRINGIFY(x)
-@@ -509,6 +510,7 @@ PYBIND11_MODULE(_C, m) {
+@@ -509,6 +510,11 @@ PYBIND11_MODULE(_C, m) {
      m.attr("precision_bytes") = (int)sizeof(precision_t);
      m.attr("env_name") = PUFFER_STRINGIFY(ENV_NAME);
      m.attr("gpu") = 1;
 +    m.attr("exact_action_source_hash") = PUFFER_EXACT_ACTION_SOURCE_HASH;
++    m.attr("environment_source_hash") = PUFFER_ENV_SOURCE_HASH;
++    m.attr("observation_abi") = PUFFER_OBSERVATION_ABI;
++    m.attr("observation_version") = PUFFER_OBSERVATION_VERSION;
++    m.attr("action_abi") = PUFFER_ACTION_ABI;
 
      // Core functions
      m.def("log", &puf_log);
-@@ -606,10 +608,25 @@ PYBIND11_MODULE(_C, m) {
+@@ -606,10 +612,25 @@ PYBIND11_MODULE(_C, m) {
          .def_property_readonly("gpu_obs_ptr",       [](VecEnv& ve) { return (long long)ve.vec->gpu_observations; })
          .def_property_readonly("gpu_rewards_ptr",   [](VecEnv& ve) { return (long long)ve.vec->gpu_rewards; })
          .def_property_readonly("gpu_terminals_ptr", [](VecEnv& ve) { return (long long)ve.vec->gpu_terminals; })
@@ -257,15 +261,19 @@ index 30400be..f946354 100644
 
  namespace py = pybind11;
 
-@@ -164,6 +165,7 @@ PYBIND11_MODULE(_C, m) {
+@@ -164,6 +165,11 @@ PYBIND11_MODULE(_C, m) {
      m.attr("precision_bytes") = 4;
      m.attr("env_name") = PUFFER_STRINGIFY(ENV_NAME);
      m.attr("gpu") = 0;
 +    m.attr("exact_action_source_hash") = PUFFER_EXACT_ACTION_SOURCE_HASH;
++    m.attr("environment_source_hash") = PUFFER_ENV_SOURCE_HASH;
++    m.attr("observation_abi") = PUFFER_OBSERVATION_ABI;
++    m.attr("observation_version") = PUFFER_OBSERVATION_VERSION;
++    m.attr("action_abi") = PUFFER_ACTION_ABI;
 
      m.def("puff_advantage_cpu", &py_puff_advantage_cpu);
      m.def("create_vec", &create_vec, py::arg("args"), py::arg("gpu") = 0);
-@@ -179,6 +181,20 @@ PYBIND11_MODULE(_C, m) {
+@@ -179,6 +185,20 @@ PYBIND11_MODULE(_C, m) {
          .def_property_readonly("obs_ptr", [](VecEnv& ve) { return (long long)ve.vec->observations; })
          .def_property_readonly("rewards_ptr", [](VecEnv& ve) { return (long long)ve.vec->rewards; })
          .def_property_readonly("terminals_ptr", [](VecEnv& ve) { return (long long)ve.vec->terminals; })

--- a/training/test_exact_joint_actions.py
+++ b/training/test_exact_joint_actions.py
@@ -75,6 +75,28 @@ class ExactJointActionPatchTests(unittest.TestCase):
         self.assertIn("Exact sequential support", installer)
         self.assertIn("exact joint-action backend support is incomplete", installer)
 
+    def test_compiled_module_exports_semantic_lineage_not_only_tensor_shape(self):
+        installer = INSTALLER.read_text(encoding="utf-8")
+        for fragment in (
+            "PUFFER_ENV_SOURCE_HASH",
+            "PUFFER_OBSERVATION_VERSION",
+            "PUFFER_ACTION_ABI",
+            '"obs-v5"',
+            '"exact-joint-v1"',
+            'getattr(_C, "environment_source_hash"',
+            'getattr(_C, "observation_abi"',
+            'getattr(_C, "observation_version"',
+            'getattr(_C, "action_abi"',
+        ):
+            self.assertIn(fragment, installer)
+        for fragment in (
+            'm.attr("environment_source_hash") = PUFFER_ENV_SOURCE_HASH;',
+            'm.attr("observation_abi") = PUFFER_OBSERVATION_ABI;',
+            'm.attr("observation_version") = PUFFER_OBSERVATION_VERSION;',
+            'm.attr("action_abi") = PUFFER_ACTION_ABI;',
+        ):
+            self.assertEqual(self.patch.count(fragment), 2)
+
     def test_packed_interface_fails_closed_outside_supported_shape(self):
         for fragment in (
             "get_num_act_sizes() > 3",

--- a/training/test_selfplay_league.py
+++ b/training/test_selfplay_league.py
@@ -34,6 +34,7 @@ import sys
 import tempfile
 import types
 import unittest
+from unittest import mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
@@ -42,6 +43,8 @@ PATCH = os.path.join(ROOT, 'training', 'selfplay_league.patch')
 sys.path.insert(0, os.path.join(ROOT, 'tools'))
 from build_league import (  # noqa: E402
     DEFAULT_EXPECT_BYTES, LeagueError, build_league, parse_seed_args)
+from checkpoint_lineage import (  # noqa: E402
+    lineage_from_run_manifest, sidecar_path, write_lineage)
 
 
 def find_pufferlib():
@@ -169,7 +172,8 @@ class BuildLeagueTest(unittest.TestCase):
 
     def test_layout_matches_selfplay_conventions(self):
         out = os.path.join(self.tmp, 'league')
-        manifest = build_league(out, self.seeds, self.EXPECT)
+        manifest = build_league(
+            out, self.seeds, self.EXPECT, allow_legacy_unlabeled=True)
         pool = os.path.join(out, 'pool')
         # File naming: f'{i:016d}.bin' (selfplay.py:171/:247 convention).
         for i, (name, src) in enumerate(self.seeds):
@@ -198,13 +202,14 @@ class BuildLeagueTest(unittest.TestCase):
         make_seed(bad, self.EXPECT - 1)
         with self.assertRaisesRegex(LeagueError, 'expected'):
             build_league(os.path.join(self.tmp, 'league2'),
-                         self.seeds + [('bad', bad)], self.EXPECT)
+                         self.seeds + [('bad', bad)], self.EXPECT,
+                         allow_legacy_unlabeled=True)
 
     def test_rejects_missing_seed(self):
         with self.assertRaisesRegex(LeagueError, 'does not exist'):
             build_league(os.path.join(self.tmp, 'league3'),
                          [('ghost', os.path.join(self.tmp, 'ghost.bin'))],
-                         self.EXPECT)
+                         self.EXPECT, allow_legacy_unlabeled=True)
 
     def test_rejects_duplicate_name(self):
         with self.assertRaisesRegex(LeagueError, 'duplicate'):
@@ -216,9 +221,86 @@ class BuildLeagueTest(unittest.TestCase):
 
     def test_refuses_nonempty_pool(self):
         out = os.path.join(self.tmp, 'league4')
-        build_league(out, self.seeds, self.EXPECT)
+        build_league(
+            out, self.seeds, self.EXPECT, allow_legacy_unlabeled=True)
         with self.assertRaisesRegex(LeagueError, 'refusing'):
-            build_league(out, self.seeds, self.EXPECT)
+            build_league(
+                out, self.seeds, self.EXPECT, allow_legacy_unlabeled=True)
+
+    def test_copy_failure_leaves_no_partial_pool_and_retry_succeeds(self):
+        out = os.path.join(self.tmp, 'atomic-league')
+        real_copy = shutil.copyfile
+        calls = 0
+
+        def fail_third_copy(source, destination):
+            nonlocal calls
+            calls += 1
+            if calls == 3:
+                raise OSError('synthetic copy failure')
+            return real_copy(source, destination)
+
+        with mock.patch('build_league.shutil.copyfile', side_effect=fail_third_copy):
+            with self.assertRaisesRegex(LeagueError, 'atomically'):
+                build_league(
+                    out, self.seeds, self.EXPECT,
+                    allow_legacy_unlabeled=True)
+        self.assertFalse(os.path.exists(os.path.join(out, 'pool')))
+        self.assertFalse(any(name.startswith('.pool.tmp.')
+                             for name in os.listdir(out)))
+
+        manifest = build_league(
+            out, self.seeds, self.EXPECT, allow_legacy_unlabeled=True)
+        self.assertEqual(len(manifest['seeds']), len(self.seeds))
+
+    def test_current_pool_requires_and_copies_eligible_lineage(self):
+        with self.assertRaisesRegex(LeagueError, 'lineage'):
+            build_league(
+                os.path.join(self.tmp, 'missing-lineage'),
+                self.seeds, self.EXPECT)
+
+        current_seeds = []
+        for name, _ in self.seeds:
+            checkpoint = os.path.join(self.tmp, f'current-{name}.bin')
+            make_seed(checkpoint, DEFAULT_EXPECT_BYTES)
+            current_seeds.append((name, checkpoint))
+
+        for index, (_, checkpoint) in enumerate(current_seeds):
+            manifest_path = os.path.join(self.tmp, f'run-{index}.json')
+            with open(manifest_path, 'w') as handle:
+                json.dump({
+                    'schema_version': 1,
+                    'mode': 'native_static_pool_reward_ablation',
+                    'seed': str(index),
+                    'observation_abi': 'obs-v5',
+                    'observation_version': '5',
+                    'action_abi': 'exact-joint-v1',
+                    'initialization': 'lineage-v5',
+                    'qualification_only': '0',
+                    'policy_hidden_size': '512',
+                    'policy_num_layers': '3',
+                    'policy_expansion_factor': '1',
+                    'expected_checkpoint_bytes': str(DEFAULT_EXPECT_BYTES),
+                    'source_sha256': '1' * 64,
+                    'compiled_module_sha256': '2' * 64,
+                    'puffer_patch_bundle_sha256': '3' * 64,
+                    'screen_manifest_sha256': '4' * 64,
+                    'warm_lineage_sha256': '5' * 64,
+                    'pool_lineage_bundle_sha256': '6' * 64,
+                }, handle, sort_keys=True)
+                handle.write('\n')
+            payload = lineage_from_run_manifest(
+                checkpoint, manifest_path, allow_eligible_publication=True)
+            write_lineage(sidecar_path(checkpoint), payload)
+
+        out = os.path.join(self.tmp, 'current-lineage')
+        manifest = build_league(
+            out, current_seeds, DEFAULT_EXPECT_BYTES)
+        self.assertEqual(manifest['version'], 2)
+        self.assertTrue(manifest['lineage_required'])
+        for seed in manifest['seeds']:
+            self.assertTrue(seed['lineage_file'].endswith('.lineage.json'))
+            self.assertTrue(os.path.isfile(os.path.join(
+                out, 'pool', seed['lineage_file'])))
 
 
 class PatchedSetupTest(unittest.TestCase):
@@ -242,7 +324,8 @@ class PatchedSetupTest(unittest.TestCase):
             make_seed(p, self.EXPECT)
             seeds.append((n, p))
         out = os.path.join(self.tmp, 'league')
-        build_league(out, seeds, self.EXPECT)
+        build_league(
+            out, seeds, self.EXPECT, allow_legacy_unlabeled=True)
         return os.path.join(out, 'pool')
 
     def test_patch_is_applicable_or_already_applied_to_vendor(self):


### PR DESCRIPTION
## Summary
- make exact-action qualification fresh obs-v5 with no legacy warm checkpoint or pool
- bind current checkpoints to canonical source/module/patch and semantic lineage records
- require eligible lineage for warm starts and atomically published league pools
- export and verify the compiled native semantic contract

## Verification
- 231 tools tests (2 skips)
- 30 training tests (1 skip)
- 442 engine + 63 focused Puffer tests, normal and ASan/UBSan
- fresh pinned PufferLib patch application
- bash syntax, ShellCheck, Python compile, diff check

## Deployment
Source-only. The active RTX 2070 baseline and BBTV were not modified. CUDA qualification remains gated on recurrent-state hardening and the immutable live-run boundary.