### PR TITLE
Harden recurrent evaluation state boundaries

### DIFF
--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -175,6 +175,15 @@ under the same run ID or let a later arm advance. A fresh runtime receives only
 the staged provenance/CUDA/deterministic checks and a disposable 50M-step canary
 before any long paired screen.
 
+The staged CUDA checks must include recurrent boundaries: exact-zero primary
+and every frozen-bank state after graph warmup; deterministic graph-on/off first
+outputs; fresh train→eval games; primary/frozen first-post-terminal equivalence
+to zero state; Torch/native boundary parity; finite exact zero-update PPO ratios;
+and a target-GPU throughput comparison. Training requires `reset_state=True`
+with evaluation mode off. A row-sized captured reset gate is acceptable; a
+layers × rows × hidden no-op launch is not. Any mismatch consumes the entire
+error budget and blocks the canary.
+
 A final training Steps line is not completion. The audited evaluator may continue
 until the completed-game gate is satisfied. Do not kill it merely because the
 dashboard is no longer advancing training steps. Acceptance requires the explicit

--- a/.claude/skills/puffer-env-dev/SKILL.md
+++ b/.claude/skills/puffer-env-dev/SKILL.md
@@ -390,6 +390,21 @@ surface, match() mechanics): `reference/vecenv-internals.md`.
   **bc_v4** (not valid for obs-v5 warm-start; val exact 0.508; lives on the
   training boxes — local `training/` only holds ≤ bc_v3b).
 
+### Recurrent evaluation state
+
+The current installed Puffer stack applies
+`training/puffer_recurrent_eval_state.patch` after exact joint actions. CUDA
+graph warmup must restore primary and every frozen-bank recurrent buffer to
+exact zero. Training is valid only with `reset_state=True` and evaluation mode
+off because PPO does not retain each segment's initial recurrent state.
+Evaluation starts from fresh games, preserves state across nonterminal rollout
+calls, and clears a terminal row before forwarding the next game's observation.
+Keep the captured device-gated reset launch proportional to active rows, not
+layers × rows × hidden size. Source tests are not CUDA acceptance: before a run,
+measure graph-on/off deterministic parity and throughput, primary/frozen
+post-terminal parity, construction checksums, and zero-update ratios on the
+target GPU.
+
 ## Historical BC-regularized PPO patch (rejected for new runs)
 
 The AlphaStar-style human anchor was tested after D27. When `[train] bc_coef > 0`,

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -141,6 +141,14 @@ checkpoints, and remember that stopped instances can be reclaimed.
   Launch it with both `WARM` and `POOL` absent (use `env -u WARM -u POOL` when
   the shell may inherit them). It uses zero frozen banks, and its output is
   permanently marked qualification-only; do not continue from it.
+- The recurrent runtime is part of the frozen implementation identity. Before
+  the exact-action canary, a fresh isolated build must prove zero primary and
+  frozen state after CUDA graph warmup, graph-on/off deterministic output
+  parity, fresh train→eval game boundaries, primary/frozen post-terminal parity,
+  Torch/native parity, finite exact zero-update ratios, and target-GPU
+  throughput without material regression. Training requires
+  `reset_state=True`; direct training while evaluation mode is active fails.
+  Do not infer these guarantees from patch markers or CPU tests.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -518,6 +518,17 @@ changes a reward, active queue, production default, or promotion verdict.
   policy tuple outside exact support; reward-screen live and final gates provide
   independent enforcement rather than waiting for a multi-billion-step arm to
   finish.
+- Apply `training/puffer_recurrent_eval_state.patch` after the exact-action
+  patch. CUDA graph warmup must leave primary and every frozen recurrent buffer
+  at exact zero. PPO training requires `reset_state=True` and evaluation mode
+  off; persistent-state training is unsupported because recomputation does not
+  capture trajectory initial state. Evaluation starts from fresh games, carries
+  state across rollout-call boundaries, and zeros each terminal row before the
+  next game's observation. The graph-captured reset launch must be row-sized,
+  not hidden-state-sized. Before a repaired run, require graph-on/off output
+  parity, primary/frozen post-terminal parity, exact-zero construction checks,
+  zero-update ratio parity, and a measured no-regression throughput smoke on the
+  target GPU.
 - BBP v4 is the first replay-pair lineage with exact conditional masks and
   canonical inactive-head sentinels (`arg=32`, `square=390`). Do not train a
   current BC/action experiment from v1-v3 pairs or mix those lineages merely

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,16 @@ newer evidence wins.
   `--legacy-unlabeled` is historical reconstruction only. Launch the disposable
   exact-action canary with `WARM` and `POOL` unset: it is fresh, pool-free, and
   permanently ineligible as ancestry.
+- **Recurrent evaluation has an explicit boundary contract.** The installed
+  patch stack applies `puffer_recurrent_eval_state.patch` after exact actions.
+  Graph warmup restores primary and every frozen-bank state to exact zero;
+  train→eval starts fresh games and clears state once; nonterminal evaluation
+  state persists across rollout calls; terminal rows clear before the next
+  game's observation. Training is allowed only with `reset_state=True` and
+  evaluation mode off. Do not ship a hidden-state-sized no-op reset launch:
+  keep the captured gate row-sized, then measure graph-on/off parity, target-GPU
+  throughput, primary/frozen post-terminal parity, and zero-update ratios before
+  any canary.
 - **`puffer/bloodbowl/` is the SOURCE OF TRUTH; `vendor/PufferLib/ocean/bloodbowl/` is an installed snapshot** written by `tools/install_puffer_env.sh` — the build compiles the snapshot, NOT your edit. The snapshot can lag (the Mac checkout's may still say 1612). Drift guard: `tools/install_puffer_env.sh --check` (exit 1 = re-install). Run it before any build on a training box.
 - After ANY env code change, ON THE TARGET: `bash tools/install_puffer_env.sh`,
   `bash tools/install_puffer_env.sh --check`, then

--- a/docs/plans/recurrent-evaluation-state-hardening.md
+++ b/docs/plans/recurrent-evaluation-state-hardening.md
@@ -1,0 +1,115 @@
+# Recurrent evaluation-state hardening
+
+Status: source implementation locally verified, 2026-07-21; target-GPU gates
+remain deployment-bound. Work is isolated from the active RTX 2070 recovery
+queue and BBTV. This plan does not authorize deployment.
+
+Base: merged `origin/main` at
+`d1e200b4980f6b0dbb56200b2dfe471ecf80862b`.
+
+## Confirmed defects
+
+The pinned Puffer runtime mutates MinGRU state during CUDA-graph warmup and
+restores weights, optimizer momentum, and RNG state but not primary or frozen
+recurrent buffers. PufferLib PR 579 independently reproduces nonzero state
+after construction and supplies the minimal all-bank cleanup.
+
+Evaluation has a second boundary defect. Blood Bowl emits a terminal together
+with the next game's initial observation, but persistent native evaluation
+forwards that observation through the preceding game's recurrent state. Torch
+instead clears state at every horizon-one call and discards the delayed reward
+and terminal produced by the final action, so native and Torch evaluate
+different policies.
+
+Finally, training currently accepts `reset_state=False` even though PPO does
+not preserve each sampled segment's initial recurrent state. Recomputed
+probabilities therefore cannot represent the behavior trajectory in that mode.
+
+## Bounded contract
+
+1. After graph warmup, primary and every frozen-bank recurrent buffer is zero.
+2. Entering evaluation mode after training starts fresh environments and
+   clears all recurrent state once, preventing a partial training game from
+   entering the evaluation panel. Thereafter state persists across arbitrary
+   rollout-call boundaries, but a terminal clears the corresponding row before
+   the next game's observation is evaluated.
+3. The native terminal-row operation is part of every captured rollout graph
+   and is controlled by a device-resident evaluation-mode flag; it cannot be
+   omitted because capture happened during training mode.
+4. Torch carries pending reward/terminal data across rollout calls and applies
+   the same pre-forward terminal-row reset.
+5. Public and worker training entry points reject `reset_state=False` before
+   creating environments, files, or GPU state; both backends also reject a
+   direct training call while evaluation mode is active. `eval()` and `match()`
+   continue to use persistent state through explicit evaluation mode.
+6. Default training behavior at mid-horizon terminals remains unchanged. A
+   rollout-only reset there would diverge from PPO recomputation, which has no
+   terminal mask or captured initial state. That larger repair is separate.
+
+## Test-first slices
+
+1. Add source-contract tests for the upstream post-warmup all-bank zero and
+   its ordering before final synchronization.
+2. Add executable Torch helper tests covering pending outcome persistence,
+   training-boundary clearing, selective terminal-row reset, MinGRU/LSTM tuple
+   symmetry, and shape rejection.
+3. Add native source-contract tests for a device-resident mode flag, an
+   unconditionally captured terminal-row kernel, global terminal indexing,
+   bank-local state indexing, and placement before `policy_forward`.
+4. Add public-loop tests proving train, evaluation phase, standalone eval, and
+   match select the correct mode and persistent training is rejected.
+5. Apply one recurrent patch after the exact-action patch in the installer;
+   include it in patch-bundle identities and fail closed if any marker is
+   missing.
+6. Apply both patches to a fresh pinned Puffer checkout and run Torch behavior,
+   tools/training, native, and sanitizer suites.
+
+## Deployment-boundary acceptance
+
+These checks are mandatory after the immutable baseline boundary, in a fresh
+isolated 2070 checkout:
+
+- imported source/module/patch identities match the frozen screen;
+- primary and all frozen state checksums are exactly zero immediately after
+  CUDA construction with graph capture enabled;
+- graph-enabled and graph-disabled first deterministic logits/values match;
+- primary and each frozen bank's first post-terminal output matches a freshly
+  zeroed policy from the same observation;
+- identical match results and first-game traces are independent of preceding
+  match history;
+- Torch/native deterministic outputs agree at ordinary and post-terminal
+  boundaries;
+- graph-enabled throughput has no material regression against the exact-action
+  runtime on the same host and configuration;
+- zero-update rollout/recompute ratios remain finite and equal within the
+  existing exact-action tolerance;
+- every hard integrity counter, including `illegal_frac`, remains exactly zero.
+
+No canary or long run starts if any check fails.
+
+## Local verification
+
+- recurrent patch applies exactly after the current exact-action patch on a
+  fresh pinned Puffer tree and the installer is idempotent;
+- executable Torch boundary tests pass, including pending outcome persistence,
+  selective terminal clearing, training-boundary clearing, and shape failure;
+- 232 tools tests (2 dependency skips) and 38 training tests (1 dependency
+  skip) pass;
+- 442 engine tests and every focused Puffer test pass under optimized and
+  ASan/UBSan builds;
+- bash syntax, Python compilation of the applied Puffer sources, and
+  `git diff --check` pass.
+
+Correctness review removed a hidden-state-sized captured reset grid that would
+have launched roughly 403 million no-op threads per current Blood Bowl training
+rollout. The final kernel launches one thread per active row and writes layers ×
+hidden only for terminal evaluation rows. Review also added direct-backend
+training rejection while evaluation mode is active and fresh environment reset
+at a nonzero-step train→eval transition.
+
+## Explicitly out of scope
+
+- terminal-aware PPO state capture/recomputation inside training horizons;
+- reward coefficients, rules, observation/action semantics, BC anchors, pool
+  generation, BBTV, or the active pre-repair experiment;
+- any attempt to reuse qualification-only output as training ancestry.

--- a/tools/install_puffer_env.sh
+++ b/tools/install_puffer_env.sh
@@ -39,14 +39,15 @@ snapshot_hash() {
         | xargs -0 $SHA256 | $SHA256 | awk '{print $1}')
 }
 
-# Hash every source that defines exact-action transport or sampling. The
-# installer writes this digest into a generated header; both native and CPU
-# extension modules expose the compiled value. --check then compares current
-# sources, generated header, and imported module instead of trusting mtimes.
+# Hash every source that defines exact-action transport, sampling, or recurrent
+# evaluation semantics. The installer writes this digest into a generated
+# header; both native and CPU extension modules expose the compiled value.
+# --check then compares current sources, generated header, and imported module.
 exact_backend_hash() {
     (
         cd "$PUFFER"
         for rel in \
+            pufferlib/pufferl.py \
             pufferlib/torch_pufferl.py \
             src/bindings.cu \
             src/bindings_cpu.cpp \
@@ -99,6 +100,18 @@ if [ "$MODE" = "check" ]; then
             "$PUFFER/pufferlib/torch_pufferl.py" \
             "$PUFFER/src/vecenv.h" "$PUFFER/src/pufferlib.cu"; then
             echo "drift check: exact-action backend marker missing: $exact_marker" >&2
+            echo "  fix: run tools/install_puffer_env.sh $PUFFER" >&2
+            exit 1
+        fi
+    done
+    for recurrent_contract in \
+        'src/pufferlib.cu:reset_recurrent_state_on_terminal' \
+        'src/bindings.cu:set_evaluation_mode' \
+        'pufferlib/torch_pufferl.py:pending_terminals'; do
+        recurrent_file="${recurrent_contract%%:*}"
+        recurrent_marker="${recurrent_contract#*:}"
+        if ! grep -Fq "$recurrent_marker" "$PUFFER/$recurrent_file"; then
+            echo "drift check: recurrent evaluation marker missing: $recurrent_marker" >&2
             echo "  fix: run tools/install_puffer_env.sh $PUFFER" >&2
             exit 1
         fi
@@ -324,6 +337,25 @@ if ! grep -q 'sample_joint_logits' "$TORCH_PUFFERL_PY" || \
    ! grep -q 'joint_action_offsets' "$PUFFER/src/vecenv.h" || \
    ! grep -q 'Exact sequential support' "$PUFFER/src/pufferlib.cu"; then
     echo "error: exact joint-action backend support is incomplete" >&2
+    exit 1
+fi
+
+# Recurrent evaluation contract. Apply only after exact-action support because
+# both patches extend the same native and Torch rollout paths.
+RECURRENT_PATCH="$ROOT/training/puffer_recurrent_eval_state.patch"
+if [ -f "$RECURRENT_PATCH" ] && \
+   ! grep -q 'reset_recurrent_state_rows' "$TORCH_PUFFERL_PY"; then
+    if git -C "$PUFFER" apply "$RECURRENT_PATCH"; then
+        echo "applied:   recurrent evaluation-state boundaries -> Puffer native/Torch backends"
+    else
+        echo "error: recurrent evaluation-state patch did not apply" >&2
+        exit 1
+    fi
+fi
+if ! grep -q 'reset_recurrent_state_on_terminal' "$PUFFER/src/pufferlib.cu" || \
+   ! grep -q 'set_evaluation_mode' "$PUFFER/src/bindings.cu" || \
+   ! grep -q 'pending_terminals' "$TORCH_PUFFERL_PY"; then
+    echo "error: recurrent evaluation-state support is incomplete" >&2
     exit 1
 fi
 

--- a/tools/run_reward_ablation.sh
+++ b/tools/run_reward_ablation.sh
@@ -425,6 +425,7 @@ PATCH_HASH="$({
   sha256sum "$ROOT/training/pufferl_metrics_keyerror.patch"
   sha256sum "$ROOT/training/torch_pufferl_trusted_load.patch"
   sha256sum "$ROOT/training/puffer_exact_joint_actions.patch"
+  sha256sum "$ROOT/training/puffer_recurrent_eval_state.patch"
 } | sha256sum | awk '{print $1}')"
 if [ -n "$EXPECTED_PUFFER_PATCH_BUNDLE_SHA256" ] && \
    [ "$PATCH_HASH" != "$EXPECTED_PUFFER_PATCH_BUNDLE_SHA256" ]; then

--- a/tools/run_reward_screen.sh
+++ b/tools/run_reward_screen.sh
@@ -511,6 +511,7 @@ patches = [
     root / "training/pufferl_metrics_keyerror.patch",
     root / "training/torch_pufferl_trusted_load.patch",
     root / "training/puffer_exact_joint_actions.patch",
+    root / "training/puffer_recurrent_eval_state.patch",
 ]
 vendor_sources = [
     "pufferlib/__init__.py", "pufferlib/pufferl.py",

--- a/training/puffer_recurrent_eval_state.patch
+++ b/training/puffer_recurrent_eval_state.patch
@@ -1,0 +1,300 @@
+diff --git a/pufferlib/torch_pufferl.py b/pufferlib/torch_pufferl.py
+index 4cf6184..9442a16 100644
+--- a/pufferlib/torch_pufferl.py
++++ b/pufferlib/torch_pufferl.py
+@@ -189,6 +189,27 @@ def _cpu_tensor(ptr, shape, dtype):
+     arr = (ctype * n).from_address(ptr)
+     return torch.frombuffer(arr, dtype=dtype).reshape(shape)
+
++def reset_recurrent_state_rows(state, terminals):
++    if not state:
++        return ()
++    terminals = torch.as_tensor(terminals).reshape(-1).bool()
++    result = []
++    for tensor in state:
++        if tensor.ndim != 3 or tensor.shape[1] != terminals.numel():
++            raise RuntimeError(
++                'recurrent state batch does not match terminal rows')
++        mask = terminals.to(device=tensor.device).view(1, -1, 1)
++        result.append(torch.where(mask, torch.zeros_like(tensor), tensor))
++    return tuple(result)
++
++def prepare_recurrent_rollout(state, rewards, terminals,
++        reset_state, evaluation_mode):
++    if reset_state and not evaluation_mode:
++        state = tuple(torch.zeros_like(s) for s in state) if state else ()
++        rewards = torch.zeros_like(rewards)
++        terminals = torch.zeros_like(terminals)
++    return state, rewards, terminals
++
+ class PuffeRL:
+     def __init__(self, args, vec, policy, verbose=True):
+         config = args['train']
+@@ -258,6 +279,10 @@ class PuffeRL:
+             if self.mask_size > 0 else None)
+         self.ratio = torch.ones(total_agents, horizon, device=device)
+         self.state = policy.initial_state(total_agents, device=device)
++        self.reset_state = bool(args['reset_state'])
++        self.evaluation_mode = False
++        self.pending_rewards = torch.zeros(total_agents, device=device)
++        self.pending_terminals = torch.zeros(total_agents, device=device)
+
+         self.batch_size = total_agents * horizon
+         self.minibatch_segments = config['minibatch_size'] // horizon
+@@ -301,16 +326,27 @@ class PuffeRL:
+     def num_params(self):
+         return self.model_size
+
++    def set_evaluation_mode(self, enabled):
++        enabled = bool(enabled)
++        if enabled == self.evaluation_mode:
++            return
++        if enabled and self.global_step > 0:
++            self._vec.reset()
++        self.state = tuple(torch.zeros_like(s) for s in self.state)
++        self.pending_rewards.zero_()
++        self.pending_terminals.zero_()
++        self.evaluation_mode = enabled
++
+     def rollouts(self):
+         prof = self.profile
+         config = self.config
+         device = self.device
+         horizon = config['horizon']
+
+-        self.state = tuple(torch.zeros_like(s) for s in self.state) if self.state else ()
++        self.state, r, d = prepare_recurrent_rollout(
++            self.state, self.pending_rewards, self.pending_terminals,
++            self.reset_state, self.evaluation_mode)
+         o = self.vec_obs
+-        r = torch.zeros(self.total_agents, device=device)
+-        d = torch.zeros(self.total_agents, device=device)
+
+         P = Profile
+         prof.mark(0)
+@@ -319,6 +355,8 @@ class PuffeRL:
+
+             prof.mark(1)
+             with torch.no_grad():
++                if self.evaluation_mode:
++                    self.state = reset_recurrent_state_rows(self.state, d)
+                 logits, value, state = self.policy.forward_eval(o_device, self.state)
+                 if self.vec_joint_actions is not None:
+                     counts_cpu = self.vec_joint_counts.clone()
+@@ -369,12 +407,18 @@ class PuffeRL:
+             prof.elapsed(P.EVAL_GPU, 1, 2)
+             prof.elapsed(P.EVAL_ENV, 2, 3)
+
++        self.pending_rewards = torch.as_tensor(r, device=device).clone()
++        self.pending_terminals = torch.as_tensor(d, device=device).clone()
++
+         prof.mark(1)
+         prof.elapsed(P.ROLLOUT, 0, 1)
+         self.global_step += self.total_agents * horizon
+         self.env_logs = self._vec.log()
+
+     def train(self):
++        if not self.reset_state or self.evaluation_mode:
++            raise RuntimeError(
++                'training requires reset_state=True and evaluation_mode=False')
+         prof = self.profile
+         losses = defaultdict(float)
+         config = self.config
+diff --git a/pufferlib/pufferl.py b/pufferlib/pufferl.py
+index 929c300..a23109c 100644
+--- a/pufferlib/pufferl.py
++++ b/pufferlib/pufferl.py
+@@ -204,6 +204,10 @@ def validate_config(args):
+     assert minibatch_size <= horizon * total_agents, \
+         f'minibatch_size {minibatch_size} > total_agents {total_agents} * horizon {horizon}'
+
++def require_training_state_reset(args):
++    if not args['reset_state']:
++        raise ValueError('training requires reset_state=True')
++
+ def _resolve_backend(args):
+     compiled_env = getattr(_C, 'env_name', None)
+     assert compiled_env is None or compiled_env == args['env_name'], \
+@@ -214,6 +218,7 @@ def _resolve_backend(args):
+     return _C
+
+ def _train_worker(args):
++    require_training_state_reset(args)
+     backend = _resolve_backend(args)
+     pufferl = backend.create_pufferl(args)
+     args.pop('nccl_id', None)
+@@ -225,6 +230,7 @@ def _train_worker(args):
+
+ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
+     '''Single-GPU training worker. Process target for both DDP ranks and sweep trials.'''
++    require_training_state_reset(args)
+     backend = _resolve_backend(args)
+     rank = args['rank']
+     run_id = str(int(1000*time.time()))
+@@ -289,6 +295,7 @@ def _train(env_name, args, sweep_obj=None, result_queue=None, verbose=False):
+     last_phase_eval = False
+     last_phase_epoch = -1
+     for epoch in range(train_epochs + eval_epochs):
++        backend.set_evaluation_mode(pufferl, epoch >= train_epochs)
+         backend.rollouts(pufferl)
+
+         if epoch < train_epochs:
+@@ -445,6 +452,7 @@ def _train(env_name, args=None, gpus=None, **kwargs):
+
+ def train(env_name, args=None, gpus=None, **kwargs):
+     args = args or load_config(env_name)
++    require_training_state_reset(args)
+     validate_config(args)
+
+     subprocess = gpus is not None
+@@ -555,6 +563,8 @@ def eval(env_name, args=None, load_path=None):
+         backend.load_weights(pufferl, load_path)
+         print(f'Loaded weights from {load_path}')
+
++    backend.set_evaluation_mode(pufferl, True)
++
+     while True:
+         backend.render(pufferl, 0)
+         backend.rollouts(pufferl)
+@@ -629,6 +639,7 @@ def match(env_name, policy_a_path, policy_b_path, num_games=4096, args=None, ver
+
+     backend.load_weights(pufferl, policy_a_path)
+     backend.load_frozen_bank(pufferl, 0, policy_b_path)
++    backend.set_evaluation_mode(pufferl, True)
+
+     logs = {}
+     while True:
+diff --git a/src/pufferlib.cu b/src/pufferlib.cu
+index 583d9a1..3b163a3 100644
+--- a/src/pufferlib.cu
++++ b/src/pufferlib.cu
+@@ -406,6 +406,8 @@ typedef struct {
+     long last_log_step;
+     int train_warmup;
+     bool rollout_captured;
++    bool evaluation_mode;
++    int* evaluation_mode_puf;
+     bool train_captured;
+     ulong seed;
+     curandStatePhilox4_32_10_t** rng_states;  // per-buffer persistent RNG states [num_buffers]
+@@ -420,6 +422,21 @@ typedef struct {
+     // Bank 0 = primary (learner). NULL = no layout set (primary owns full chunk).
+     int* bank_layout;
+ } PuffeRL;
++
++__global__ void reset_recurrent_state_on_terminal(
++        precision_t* state, const float* terminals,
++        const int* evaluation_mode, int state_stride, int active_rows,
++        int hidden_size, int num_layers) {
++    int row = blockIdx.x * blockDim.x + threadIdx.x;
++    if (row >= active_rows || *evaluation_mode == 0 ||
++            terminals[row] == 0.0f) return;
++    for (int layer = 0; layer < num_layers; layer++) {
++        for (int column = 0; column < hidden_size; column++) {
++            state[(layer * state_stride + row) * hidden_size + column] =
++                from_float(0.0f);
++        }
++    }
++}
+
+ Dict* log_environments_impl(PuffeRL& pufferl) {
+     // Capacity raised from 32 to 64 to accommodate chess's per-bank
+@@ -749,6 +766,11 @@ extern "C" void net_callback_wrapper(void* ctx, int buf, int t) {
+             mask_stride_b = mask_stride;
+         }
+
++        reset_recurrent_state_on_terminal<<<
++            grid_size(bank_size), BLOCK_SIZE, 0, stream>>>(
++                s_bank->data, env.terminals.data + sub_start,
++                pufferl->evaluation_mode_puf, s_bank->shape[1], bank_size,
++                s_bank->shape[2], s_bank->shape[0]);
+         PrecisionTensor dec_puf = policy_forward(p_bank, *w_bank, *a_bank, obs_b, *s_bank, stream);
+
+         PrecisionTensor p_logstd = {};
+@@ -2101,6 +2123,9 @@ std::unique_ptr<PuffeRL> create_pufferl_impl(HypersT& hypers,
+     pufferl->train_activations = policy_reg_train(&pufferl->policy, pufferl->weights, acts, grads, B_TT);
+     pufferl->buffer_activations = (PolicyActivations*)calloc(num_buffers, sizeof(PolicyActivations));
+     pufferl->buffer_states = (PrecisionTensor*)calloc(num_buffers, sizeof(PrecisionTensor));
++    pufferl->evaluation_mode = false;
++    cudaMalloc(&pufferl->evaluation_mode_puf, sizeof(int));
++    cudaMemset(pufferl->evaluation_mode_puf, 0, sizeof(int));
+     for (int i = 0; i < num_buffers; i++) {
+         pufferl->buffer_activations[i] = policy_reg_rollout(
+             &pufferl->policy, pufferl->weights, acts, inf_batch);
+@@ -2278,6 +2303,13 @@ std::unique_ptr<PuffeRL> create_pufferl_impl(HypersT& hypers,
+             rng_init<<<grid_size(agents_per_buf), BLOCK_SIZE>>>(
+                 pufferl->rng_states[i], pufferl->seed + i, agents_per_buf);
+         }
++        for (int bank = 0; bank < 1 + pufferl->num_frozen_banks; bank++) {
++            PrecisionTensor* bs = (bank == 0) ? pufferl->buffer_states
++                : pufferl->frozen_banks[bank - 1].buffer_states;
++            for (int b = 0; b < num_buffers; b++) {
++                puf_zero(&bs[b], pufferl->default_stream);
++            }
++        }
+         cudaDeviceSynchronize();
+
+         pufferl->epoch = 0;
+@@ -2360,6 +2392,7 @@ void close_impl(PuffeRL& pufferl) {
+     }
+     free(pufferl.frozen_banks);
+     free(pufferl.bank_layout);
++    cudaFree(pufferl.evaluation_mode_puf);
+
+     if (pufferl.nccl_comm != nullptr) {
+         ncclCommDestroy(pufferl.nccl_comm);
+diff --git a/src/bindings.cu b/src/bindings.cu
+index 26d7741..cf9f8de 100644
+--- a/src/bindings.cu
++++ b/src/bindings.cu
+@@ -141,6 +141,6 @@ void rollouts(pybind11::object pufferl_obj) {
+     // state symmetrically — otherwise frozen banks accumulate indefinitely while
+     // primary resets, giving primary an unfair in-distribution advantage).
+-    if (pufferl.hypers.reset_state) {
++    if (pufferl.hypers.reset_state && !pufferl.evaluation_mode) {
+         for (int i = 0; i < pufferl.hypers.num_buffers; i++) {
+             puf_zero(&pufferl.buffer_states[i], pufferl.default_stream);
+         }
+@@ -163,8 +163,34 @@ void rollouts(pybind11::object pufferl_obj) {
+     pufferl.global_step += pufferl.hypers.horizon * pufferl.hypers.total_agents;
+ }
+
++void set_evaluation_mode(pybind11::object pufferl_obj, bool enabled) {
++    PuffeRL& pufferl = pufferl_obj.cast<PuffeRL&>();
++    if (enabled == pufferl.evaluation_mode) return;
++    if (enabled && pufferl.global_step > 0) {
++        static_vec_reset(pufferl.vec);
++    }
++    for (int i = 0; i < pufferl.hypers.num_buffers; i++) {
++        puf_zero(&pufferl.buffer_states[i], pufferl.default_stream);
++    }
++    for (int b = 0; b < pufferl.num_frozen_banks; b++) {
++        for (int i = 0; i < pufferl.hypers.num_buffers; i++) {
++            puf_zero(&pufferl.frozen_banks[b].buffer_states[i],
++                pufferl.default_stream);
++        }
++    }
++    int device_enabled = enabled ? 1 : 0;
++    cudaMemcpyAsync(pufferl.evaluation_mode_puf, &device_enabled, sizeof(int),
++        cudaMemcpyHostToDevice, pufferl.default_stream);
++    cudaStreamSynchronize(pufferl.default_stream);
++    pufferl.evaluation_mode = enabled;
++}
++
+ pybind11::dict train(pybind11::object pufferl_obj) {
+     PuffeRL& pufferl = pufferl_obj.cast<PuffeRL&>();
++    if (!pufferl.hypers.reset_state || pufferl.evaluation_mode) {
++        throw std::runtime_error(
++            "training requires reset_state=True and evaluation_mode=False");
++    }
+     {
+         pybind11::gil_scoped_release no_gil;
+         train_impl(pufferl);
+@@ -521,6 +547,7 @@ PYBIND11_MODULE(_C, m) {
+     m.def("eval_log", &puf_eval_log);
+     m.def("render", &render);
+     m.def("rollouts", &rollouts);
++    m.def("set_evaluation_mode", &set_evaluation_mode);
+     m.def("train", &train);
+     m.def("close", &puf_close);
+     m.def("save_weights", &save_weights);

--- a/training/test_recurrent_eval_state.py
+++ b/training/test_recurrent_eval_state.py
@@ -1,0 +1,179 @@
+"""Contracts for recurrent state at graph, rollout, and game boundaries."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+try:
+    import torch
+except ImportError:  # pragma: no cover - minimal CI image
+    torch = None
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PATCH = ROOT / "training" / "puffer_recurrent_eval_state.patch"
+INSTALLER = ROOT / "tools" / "install_puffer_env.sh"
+SCREEN = ROOT / "tools" / "run_reward_screen.sh"
+ARM = ROOT / "tools" / "run_reward_ablation.sh"
+
+
+class RecurrentEvaluationPatchTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.patch = PATCH.read_text(encoding="utf-8")
+
+    def test_graph_warmup_restores_primary_and_every_frozen_state(self):
+        for fragment in (
+            "for (int bank = 0; bank < 1 + pufferl->num_frozen_banks; bank++)",
+            "pufferl->frozen_banks[bank - 1].buffer_states",
+            "for (int b = 0; b < num_buffers; b++)",
+            "puf_zero(&bs[b], pufferl->default_stream);",
+        ):
+            self.assertIn(fragment, self.patch)
+        zero_at = self.patch.index("for (int bank = 0; bank < 1 + pufferl->num_frozen_banks")
+        sync_at = self.patch.index("cudaDeviceSynchronize();", zero_at)
+        epoch_at = self.patch.index("pufferl->epoch = 0;", zero_at)
+        self.assertLess(zero_at, sync_at)
+        self.assertLess(sync_at, epoch_at)
+
+    def test_native_terminal_reset_is_captured_and_bank_local(self):
+        for fragment in (
+            "evaluation_mode_puf",
+            "reset_recurrent_state_on_terminal<<<",
+            "grid_size(bank_size)",
+            "env.terminals.data + sub_start",
+            "s_bank->shape[0]",
+            "bank_size",
+            "s_bank->shape[2]",
+        ):
+            self.assertIn(fragment, self.patch)
+        callback = self.patch.split(
+            'extern "C" void net_callback_wrapper', 1)[1]
+        callback = callback.split("// Write policy action", 1)[0]
+        self.assertLess(
+            callback.index("reset_recurrent_state_on_terminal<<<"),
+            callback.index("policy_forward("),
+        )
+        self.assertNotIn("grid_size(state_n)", callback)
+        self.assertNotIn(
+            "if (pufferl->evaluation_mode) {\n+            reset_recurrent",
+            callback,
+            "a host branch evaluated during capture would omit the eval kernel",
+        )
+
+    def test_mode_transition_clears_primary_and_frozen_state_once(self):
+        for fragment in (
+            "void set_evaluation_mode(",
+            "if (enabled == pufferl.evaluation_mode) return;",
+            "if (enabled && pufferl.global_step > 0)",
+            "static_vec_reset(pufferl.vec);",
+            "if enabled and self.global_step > 0:",
+            "self._vec.reset()",
+            "puf_zero(&pufferl.buffer_states[i]",
+            "puf_zero(&pufferl.frozen_banks[b].buffer_states[i]",
+            "cudaMemcpyAsync(pufferl.evaluation_mode_puf",
+            'm.def("set_evaluation_mode", &set_evaluation_mode);',
+        ):
+            self.assertIn(fragment, self.patch)
+
+    def test_torch_carries_pending_outcomes_and_selects_eval_reset(self):
+        for fragment in (
+            "self.pending_rewards",
+            "self.pending_terminals",
+            "prepare_recurrent_rollout",
+            "self.state, self.pending_rewards, self.pending_terminals",
+            "self.state = reset_recurrent_state_rows(self.state, d)",
+            "self.pending_rewards = torch.as_tensor(r, device=device).clone()",
+            "self.pending_terminals = torch.as_tensor(d, device=device).clone()",
+        ):
+            self.assertIn(fragment, self.patch)
+
+    @unittest.skipUnless(torch is not None, "requires torch")
+    def test_torch_terminal_row_helper_executes_selectively(self):
+        start = self.patch.index("+def reset_recurrent_state_rows(")
+        lines = []
+        for line in self.patch[start:].splitlines():
+            if not line.startswith("+"):
+                break
+            lines.append(line[1:])
+        namespace = {"torch": torch}
+        exec("\n".join(lines), namespace)
+        reset = namespace["reset_recurrent_state_rows"]
+
+        hidden = torch.arange(12, dtype=torch.float32).reshape(2, 3, 2) + 1
+        cell = hidden + 100
+        result = reset((hidden, cell), torch.tensor([0.0, 1.0, 0.0]))
+        self.assertEqual(len(result), 2)
+        for before, after in zip((hidden, cell), result):
+            self.assertTrue(torch.equal(after[:, 0], before[:, 0]))
+            self.assertTrue(torch.equal(after[:, 1], torch.zeros_like(after[:, 1])))
+            self.assertTrue(torch.equal(after[:, 2], before[:, 2]))
+        self.assertTrue(torch.equal(hidden[:, 1], torch.tensor([[3., 4.], [9., 10.]])))
+        self.assertEqual(reset((), torch.tensor([1.0])), ())
+        with self.assertRaisesRegex(RuntimeError, "recurrent state batch"):
+            reset((hidden,), torch.tensor([0.0, 1.0]))
+
+    @unittest.skipUnless(torch is not None, "requires torch")
+    def test_torch_rollout_boundary_helpers_preserve_or_clear_exactly(self):
+        start = self.patch.index("+def reset_recurrent_state_rows(")
+        lines = []
+        for line in self.patch[start:].splitlines():
+            if not line.startswith("+"):
+                break
+            lines.append(line[1:])
+        namespace = {"torch": torch}
+        exec("\n".join(lines), namespace)
+        reset = namespace["reset_recurrent_state_rows"]
+        prepare = namespace["prepare_recurrent_rollout"]
+
+        state = (torch.arange(12, dtype=torch.float32).reshape(2, 3, 2) + 1,)
+        rewards = torch.tensor([1.0, 2.0, 3.0])
+        terminals = torch.tensor([0.0, 1.0, 0.0])
+
+        carried_state, carried_rewards, carried_terminals = prepare(
+            state, rewards, terminals, reset_state=True, evaluation_mode=True)
+        self.assertTrue(torch.equal(carried_state[0], state[0]))
+        self.assertTrue(torch.equal(carried_rewards, rewards))
+        self.assertTrue(torch.equal(carried_terminals, terminals))
+        post_terminal = reset(carried_state, carried_terminals)
+        self.assertTrue(torch.equal(post_terminal[0][:, 0], state[0][:, 0]))
+        self.assertTrue(torch.equal(
+            post_terminal[0][:, 1], torch.zeros_like(state[0][:, 1])))
+        self.assertTrue(torch.equal(post_terminal[0][:, 2], state[0][:, 2]))
+
+        cleared_state, cleared_rewards, cleared_terminals = prepare(
+            state, rewards, terminals, reset_state=True, evaluation_mode=False)
+        self.assertTrue(torch.equal(cleared_state[0], torch.zeros_like(state[0])))
+        self.assertTrue(torch.equal(cleared_rewards, torch.zeros_like(rewards)))
+        self.assertTrue(torch.equal(cleared_terminals, torch.zeros_like(terminals)))
+        self.assertTrue(torch.equal(state[0][:, 1], torch.tensor([[3., 4.], [9., 10.]])))
+
+    def test_training_rejects_persistent_state_and_all_eval_paths_select_mode(self):
+        for fragment in (
+            "training requires reset_state=True",
+            "evaluation_mode=False",
+            "backend.set_evaluation_mode(pufferl, epoch >= train_epochs)",
+            "backend.set_evaluation_mode(pufferl, True)",
+        ):
+            self.assertIn(fragment, self.patch)
+        self.assertGreaterEqual(
+            self.patch.count("training requires reset_state=True"), 2)
+
+    def test_installer_and_experiment_identity_require_recurrent_patch(self):
+        installer = INSTALLER.read_text(encoding="utf-8")
+        screen = SCREEN.read_text(encoding="utf-8")
+        arm = ARM.read_text(encoding="utf-8")
+        for source in (installer, screen, arm):
+            self.assertIn("puffer_recurrent_eval_state.patch", source)
+        self.assertIn("pufferlib/pufferl.py", installer)
+        for marker in (
+            "reset_recurrent_state_on_terminal",
+            "set_evaluation_mode",
+            "pending_terminals",
+        ):
+            self.assertIn(marker, installer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Makes recurrent evaluation state trustworthy across CUDA graph warmup, rollout calls, game terminals, policy banks, and train-to-eval transitions.

## Changes

- restore primary and every frozen-bank recurrent buffer after graph warmup
- persist evaluation state across rollout calls and clear terminal rows before the next game observation
- begin post-training evaluation from fresh games
- align Torch pending terminal/reward handling with native evaluation
- reject unsupported persistent/evaluation-mode PPO training
- keep the captured terminal gate row-sized to avoid training throughput waste
- freeze the recurrent patch into installer, source/module identity, experiment manifests, and project guidelines

## Verification

- fresh pinned Puffer install: exact patch then recurrent patch, exact application and idempotency
- 232 tools tests (2 skips)
- 38 training tests (1 skip)
- 442 engine tests plus all focused Puffer tests
- full ASan/UBSan suite
- Python compilation, bash syntax, substantive shellcheck, and diff checks
- independent correctness review: no remaining P0-P2 finding

## Deployment boundary

No live service or run was changed. Native CUDA construction, graph-on/off deterministic parity, primary/frozen post-terminal parity, zero-update ratios, and target-GPU throughput remain mandatory after the active seed-44 baseline reaches its immutable boundary. No canary starts if any check is nonzero, nonfinite, or mismatched.