### PR TITLE
Add strict recovery log integrity audit

### DIFF
--- a/tools/audit_recovery_complete_logs.py
+++ b/tools/audit_recovery_complete_logs.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Strict, read-only integrity audit for completed pre-exact-action recovery logs.
+
+This lineage predates exact joint-action execution, so ``illegal_frac`` is a
+historical diagnostic rather than an acceptance field. Every reward-corruption,
+non-finite, component-ledger, engine-error, and demo-fallback counter that was
+valid in the recovery lineage must nevertheless be present, finite, and exactly
+zero in every populated machine-readable panel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+import sys
+from typing import Any, Iterable
+
+
+PREFIX = b"PUFFER_ENV_JSON "
+HARD_INTEGRITY_KEYS = (
+    "reward_clip_frac",
+    "reward_clip_frac_nonzero",
+    "reward_clip_excess",
+    "reward_clip_signed_delta",
+    "reward_clipped_samples_per_episode",
+    "reward_clip_terminal_samples_per_episode",
+    "reward_clip_nonterminal_samples_per_episode",
+    "reward_nonfinite_frac",
+    "reward_nonfinite_samples_per_episode",
+    "reward_clip_episodes",
+    "reward_nonfinite_episodes",
+    "reward_component_mismatch_samples_per_episode",
+    "reward_component_nonfinite_samples_per_episode",
+    "error_episodes",
+    "demo_fallbacks",
+)
+HISTORICAL_DIAGNOSTIC_KEYS = ("illegal_frac",)
+
+
+class AuditError(ValueError):
+    """A recovery log is incomplete, malformed, or violates its zero budget."""
+
+
+def _number(value: Any, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise AuditError(f"{label} must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise AuditError(f"{label} must be finite")
+    return result
+
+
+def _integer(value: Any, label: str, *, minimum: int = 0) -> int:
+    number = _number(value, label)
+    result = int(number)
+    if number != result or result < minimum:
+        raise AuditError(f"{label} must be an integer >= {minimum}")
+    return result
+
+
+def _binary(value: Any, label: str) -> int:
+    result = _integer(value, label)
+    if result not in (0, 1):
+        raise AuditError(f"{label} must be 0 or 1")
+    return result
+
+
+def _reject_json_constant(path: Path, line_number: int, token: str) -> None:
+    raise AuditError(
+        f"{path}:{line_number}: invalid JSON constant in PUFFER_ENV_JSON: {token}"
+    )
+
+
+def _reject_duplicate_keys(
+    path: Path, line_number: int, pairs: list[tuple[str, Any]]
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise AuditError(
+                f"{path}:{line_number}: duplicate JSON key in "
+                f"PUFFER_ENV_JSON: {key}"
+            )
+        result[key] = value
+    return result
+
+
+def _file_identity(path: Path) -> tuple[int, int, int, int]:
+    stat = path.stat()
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+
+
+def scan_log(path: str | Path, *, min_eval_games: int) -> dict[str, Any]:
+    path = Path(path).resolve()
+    if not path.is_file():
+        raise AuditError(f"recovery log is missing: {path}")
+    if isinstance(min_eval_games, bool) or not isinstance(min_eval_games, int) \
+            or min_eval_games <= 0:
+        raise AuditError("min_eval_games must be a positive integer")
+    identity_before = _file_identity(path)
+
+    digest = hashlib.sha256()
+    machine_panels = 0
+    empty_panels = 0
+    train_panels = 0
+    eval_panels = 0
+    final_reprints = 0
+    maximum_eval_games = 0
+    previous_steps: int | None = None
+    maximum_steps = 0
+    diagnostics = {
+        key: {"min": None, "max": None, "nonzero_panels": 0}
+        for key in HISTORICAL_DIAGNOSTIC_KEYS
+    }
+
+    with path.open("rb") as source:
+        for line_number, raw_line in enumerate(source, 1):
+            digest.update(raw_line)
+            if not raw_line.startswith(PREFIX):
+                continue
+            machine_panels += 1
+            try:
+                text = raw_line[len(PREFIX):].decode("utf-8")
+                panel = json.loads(
+                    text,
+                    parse_constant=lambda token: _reject_json_constant(
+                        path, line_number, token
+                    ),
+                    object_pairs_hook=lambda pairs: _reject_duplicate_keys(
+                        path, line_number, pairs
+                    ),
+                )
+            except AuditError:
+                raise
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise AuditError(
+                    f"{path}:{line_number}: invalid PUFFER_ENV_JSON: {exc}"
+                ) from exc
+            if not isinstance(panel, dict):
+                raise AuditError(
+                    f"{path}:{line_number}: PUFFER_ENV_JSON is not an object"
+                )
+
+            schema = _integer(
+                panel.get("_puffer_schema"),
+                f"{path}:{line_number} schema",
+            )
+            if schema < 2:
+                raise AuditError(f"{path}:{line_number}: telemetry schema {schema} < 2")
+            steps = _integer(
+                panel.get("_puffer_agent_steps"),
+                f"{path}:{line_number} agent steps",
+            )
+            if previous_steps is not None and steps < previous_steps:
+                raise AuditError(
+                    f"{path}:{line_number}: agent steps regressed "
+                    f"from {previous_steps:g} to {steps:g}"
+                )
+            previous_steps = steps
+            maximum_steps = max(maximum_steps, steps)
+            phase_eval = _binary(
+                panel.get("_puffer_phase_eval"),
+                f"{path}:{line_number} phase marker",
+            )
+            cumulative = _binary(
+                panel.get("_puffer_env_cumulative"),
+                f"{path}:{line_number} cumulative marker",
+            )
+            final_reprint = _binary(
+                panel.get("_puffer_final_reprint"),
+                f"{path}:{line_number} final-reprint marker",
+            )
+            eval_completed = _integer(
+                panel.get("_puffer_eval_episodes_completed"),
+                f"{path}:{line_number} completed eval games",
+            )
+            monitored_present = any(
+                key in panel
+                for key in (*HARD_INTEGRITY_KEYS, *HISTORICAL_DIAGNOSTIC_KEYS)
+            )
+            if "n" not in panel:
+                if monitored_present or final_reprint or eval_completed:
+                    raise AuditError(
+                        f"{path}:{line_number}: telemetry payload lacks panel n"
+                    )
+                empty_panels += 1
+                continue
+            n = _integer(panel["n"], f"{path}:{line_number} panel n")
+
+            has_payload = bool(
+                n > 0 or monitored_present or final_reprint or eval_completed
+            )
+            if not has_payload:
+                empty_panels += 1
+                continue
+
+            missing = [key for key in HARD_INTEGRITY_KEYS if key not in panel]
+            if missing:
+                raise AuditError(
+                    f"{path}:{line_number}: missing hard-integrity fields: {missing}"
+                )
+            for key in HARD_INTEGRITY_KEYS:
+                value = _number(panel[key], f"{path}:{line_number} {key}")
+                if value != 0.0:
+                    raise AuditError(
+                        f"{path}:{line_number}: hard-integrity field {key}={value!r}"
+                    )
+
+            for key in HISTORICAL_DIAGNOSTIC_KEYS:
+                if key not in panel:
+                    raise AuditError(
+                        f"{path}:{line_number}: missing historical diagnostic {key}"
+                    )
+                value = _number(panel[key], f"{path}:{line_number} {key}")
+                summary = diagnostics[key]
+                summary["min"] = value if summary["min"] is None else min(
+                    summary["min"], value
+                )
+                summary["max"] = value if summary["max"] is None else max(
+                    summary["max"], value
+                )
+                summary["nonzero_panels"] += int(value != 0.0)
+
+            if final_reprint:
+                if not phase_eval or not cumulative or n == 0:
+                    raise AuditError(
+                        f"{path}:{line_number}: final reprint must be a populated "
+                        "cumulative eval panel"
+                    )
+                final_reprints += 1
+            elif n > 0 and phase_eval:
+                eval_panels += 1
+            elif n > 0:
+                train_panels += 1
+            if phase_eval:
+                maximum_eval_games = max(maximum_eval_games, eval_completed)
+
+    identity_after = _file_identity(path)
+    if identity_after != identity_before:
+        raise AuditError(f"log changed during audit: {path}")
+
+    if machine_panels == 0:
+        raise AuditError(f"no PUFFER_ENV_JSON panels found: {path}")
+    if train_panels == 0:
+        raise AuditError(f"completed log has no independent train panel: {path}")
+    if eval_panels == 0:
+        raise AuditError(f"completed log has no independent eval panel: {path}")
+    if final_reprints != 1:
+        raise AuditError(
+            f"completed log must have exactly one final reprint; "
+            f"found {final_reprints}: {path}"
+        )
+    if maximum_eval_games < min_eval_games:
+        raise AuditError(
+            f"completed log evaluated only {maximum_eval_games} games; "
+            f"requires {min_eval_games}: {path}"
+        )
+
+    return {
+        "accepted": True,
+        "path": str(path),
+        "bytes": identity_before[2],
+        "sha256": digest.hexdigest(),
+        "machine_panels": machine_panels,
+        "empty_panels": empty_panels,
+        "train_panels": train_panels,
+        "eval_panels": eval_panels,
+        "final_reprints": final_reprints,
+        "maximum_agent_steps": maximum_steps,
+        "maximum_eval_games": maximum_eval_games,
+        "historical_diagnostics": diagnostics,
+    }
+
+
+def audit_logs(
+    paths: Iterable[str | Path], *, expected_count: int, min_eval_games: int
+) -> dict[str, Any]:
+    paths = [Path(path).resolve() for path in paths]
+    if isinstance(expected_count, bool) or not isinstance(expected_count, int) \
+            or expected_count <= 0:
+        raise AuditError("expected_count must be a positive integer")
+    if len(paths) != expected_count:
+        raise AuditError(f"expected {expected_count} logs, received {len(paths)}")
+    if len(set(paths)) != len(paths):
+        raise AuditError("duplicate log path in recovery audit")
+    reports = [scan_log(path, min_eval_games=min_eval_games) for path in paths]
+    return {
+        "schema_version": 1,
+        "accepted": True,
+        "lineage": "pre-exact-action-recovery",
+        "hard_integrity_keys": list(HARD_INTEGRITY_KEYS),
+        "historical_diagnostics": {
+            "illegal_frac": (
+                "reported but not gated for the frozen marginal-action lineage"
+            )
+        },
+        "expected_log_count": expected_count,
+        "minimum_eval_games": min_eval_games,
+        "logs": reports,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("logs", nargs="+", type=Path)
+    parser.add_argument("--expected-count", type=int, default=3)
+    parser.add_argument("--min-eval-games", type=int, default=10000)
+    args = parser.parse_args(argv)
+    try:
+        report = audit_logs(
+            args.logs,
+            expected_count=args.expected_count,
+            min_eval_games=args.min_eval_games,
+        )
+    except (OSError, AuditError) as exc:
+        print(f"recovery complete-log audit failed: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, sort_keys=True, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/audit_recovery_complete_logs.py
+++ b/tools/audit_recovery_complete_logs.py
@@ -20,6 +20,7 @@ from typing import Any, Iterable
 
 
 PREFIX = b"PUFFER_ENV_JSON "
+MARKER = b"PUFFER_ENV_JSON"
 HARD_INTEGRITY_KEYS = (
     "reward_clip_frac",
     "reward_clip_frac_nonzero",
@@ -108,6 +109,9 @@ def scan_log(path: str | Path, *, min_eval_games: int) -> dict[str, Any]:
     train_panels = 0
     eval_panels = 0
     final_reprints = 0
+    final_reprint_line: int | None = None
+    final_eval_games: int | None = None
+    last_machine_panel_line: int | None = None
     maximum_eval_games = 0
     previous_steps: int | None = None
     maximum_steps = 0
@@ -120,8 +124,14 @@ def scan_log(path: str | Path, *, min_eval_games: int) -> dict[str, Any]:
         for line_number, raw_line in enumerate(source, 1):
             digest.update(raw_line)
             if not raw_line.startswith(PREFIX):
+                if MARKER in raw_line:
+                    raise AuditError(
+                        f"{path}:{line_number}: displaced or malformed "
+                        "PUFFER_ENV_JSON marker"
+                    )
                 continue
             machine_panels += 1
+            last_machine_panel_line = line_number
             try:
                 text = raw_line[len(PREFIX):].decode("utf-8")
                 panel = json.loads(
@@ -231,6 +241,8 @@ def scan_log(path: str | Path, *, min_eval_games: int) -> dict[str, Any]:
                         "cumulative eval panel"
                     )
                 final_reprints += 1
+                final_reprint_line = line_number
+                final_eval_games = eval_completed
             elif n > 0 and phase_eval:
                 eval_panels += 1
             elif n > 0:
@@ -253,9 +265,14 @@ def scan_log(path: str | Path, *, min_eval_games: int) -> dict[str, Any]:
             f"completed log must have exactly one final reprint; "
             f"found {final_reprints}: {path}"
         )
-    if maximum_eval_games < min_eval_games:
+    if final_reprint_line != last_machine_panel_line:
         raise AuditError(
-            f"completed log evaluated only {maximum_eval_games} games; "
+            f"completed log final reprint is not its last machine panel: {path}"
+        )
+    assert final_eval_games is not None
+    if final_eval_games < min_eval_games:
+        raise AuditError(
+            f"completed log final reprint evaluated only {final_eval_games} games; "
             f"requires {min_eval_games}: {path}"
         )
 
@@ -269,8 +286,10 @@ def scan_log(path: str | Path, *, min_eval_games: int) -> dict[str, Any]:
         "train_panels": train_panels,
         "eval_panels": eval_panels,
         "final_reprints": final_reprints,
+        "final_reprint_line": final_reprint_line,
         "maximum_agent_steps": maximum_steps,
         "maximum_eval_games": maximum_eval_games,
+        "final_eval_games": final_eval_games,
         "historical_diagnostics": diagnostics,
     }
 
@@ -286,7 +305,14 @@ def audit_logs(
         raise AuditError(f"expected {expected_count} logs, received {len(paths)}")
     if len(set(paths)) != len(paths):
         raise AuditError("duplicate log path in recovery audit")
+    identities = [_file_identity(path) for path in paths]
+    inode_identities = [(identity[0], identity[1]) for identity in identities]
+    if len(set(inode_identities)) != len(inode_identities):
+        raise AuditError("duplicate log inode in recovery audit")
     reports = [scan_log(path, min_eval_games=min_eval_games) for path in paths]
+    digests = [report["sha256"] for report in reports]
+    if len(set(digests)) != len(digests):
+        raise AuditError("duplicate log content in recovery audit")
     return {
         "schema_version": 1,
         "accepted": True,
@@ -307,7 +333,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("logs", nargs="+", type=Path)
     parser.add_argument("--expected-count", type=int, default=3)
-    parser.add_argument("--min-eval-games", type=int, default=10000)
+    parser.add_argument("--min-eval-games", type=int, required=True)
     args = parser.parse_args(argv)
     try:
         report = audit_logs(

--- a/tools/test_audit_recovery_complete_logs.py
+++ b/tools/test_audit_recovery_complete_logs.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools/audit_recovery_complete_logs.py"
+SPEC = importlib.util.spec_from_file_location("audit_recovery_complete_logs", MODULE_PATH)
+audit = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(audit)
+
+
+def complete_panels():
+    base = {
+        "_puffer_schema": 2,
+        "_puffer_agent_steps": 100.0,
+        "_puffer_phase_eval": 0,
+        "_puffer_env_cumulative": 0,
+        "_puffer_final_reprint": 0,
+        "_puffer_eval_episodes_completed": 0,
+        "n": 5,
+        "illegal_frac": 0.2,
+        **{key: 0.0 for key in audit.HARD_INTEGRITY_KEYS},
+    }
+    train = dict(base)
+    evaluation = dict(base)
+    evaluation.update({
+        "_puffer_agent_steps": 200.0,
+        "_puffer_phase_eval": 1,
+        "_puffer_env_cumulative": 1,
+        "_puffer_eval_episodes_completed": 10000,
+        "n": 10000,
+    })
+    final = dict(evaluation)
+    final["_puffer_final_reprint"] = 1
+    return [train, evaluation, final]
+
+
+def write_log(path, panels):
+    lines = [
+        "PufferLib 4.0\nPUFFER_ENV_JSON "
+        + json.dumps(panel, sort_keys=True, allow_nan=True)
+        + "\n"
+        for panel in panels
+    ]
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+class RecoveryCompleteLogAuditTests(unittest.TestCase):
+    def test_accepts_exact_zero_recovery_panels_but_reports_historical_illegal(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "seed42.log"
+            write_log(path, complete_panels())
+            report = audit.scan_log(path, min_eval_games=10000)
+        self.assertTrue(report["accepted"])
+        self.assertEqual(report["machine_panels"], 3)
+        self.assertEqual(report["train_panels"], 1)
+        self.assertEqual(report["eval_panels"], 1)
+        self.assertEqual(report["final_reprints"], 1)
+        self.assertEqual(report["historical_diagnostics"]["illegal_frac"]["max"], 0.2)
+
+    def test_allows_only_a_truly_empty_startup_panel_without_n(self):
+        empty = {
+            "_puffer_schema": 2,
+            "_puffer_agent_steps": 0,
+            "_puffer_phase_eval": 0,
+            "_puffer_env_cumulative": 0,
+            "_puffer_final_reprint": 0,
+            "_puffer_eval_episodes_completed": 0,
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "seed42.log"
+            write_log(path, [empty, *complete_panels()])
+            report = audit.scan_log(path, min_eval_games=10000)
+            self.assertEqual(report["machine_panels"], 4)
+            self.assertEqual(report["empty_panels"], 1)
+
+            partial = dict(empty)
+            partial["reward_clip_frac"] = 0.0
+            write_log(path, [partial, *complete_panels()])
+            with self.assertRaisesRegex(audit.AuditError, "lacks panel n"):
+                audit.scan_log(path, min_eval_games=10000)
+
+    def test_rejects_each_nonzero_hard_integrity_field(self):
+        for key in audit.HARD_INTEGRITY_KEYS:
+            with self.subTest(key=key), tempfile.TemporaryDirectory() as temporary:
+                panels = complete_panels()
+                panels[0][key] = 0.125
+                path = Path(temporary) / "bad.log"
+                write_log(path, panels)
+                with self.assertRaisesRegex(audit.AuditError, key):
+                    audit.scan_log(path, min_eval_games=10000)
+
+    def test_rejects_missing_nonfinite_and_malformed_hard_telemetry(self):
+        cases = []
+        missing = complete_panels()
+        del missing[0][audit.HARD_INTEGRITY_KEYS[0]]
+        cases.append(("missing", missing, "missing hard-integrity"))
+        nonfinite = complete_panels()
+        nonfinite[0][audit.HARD_INTEGRITY_KEYS[0]] = float("nan")
+        cases.append(("nonfinite", nonfinite, "invalid JSON constant"))
+        for label, panels, message in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                path = Path(temporary) / "bad.log"
+                write_log(path, panels)
+                with self.assertRaisesRegex(audit.AuditError, message):
+                    audit.scan_log(path, min_eval_games=10000)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "bad.log"
+            path.write_text("PUFFER_ENV_JSON {bad json}\n", encoding="utf-8")
+            with self.assertRaisesRegex(audit.AuditError, "invalid PUFFER_ENV_JSON"):
+                audit.scan_log(path, min_eval_games=10000)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "bad.log"
+            payload = json.dumps(complete_panels()[0], sort_keys=True)
+            payload = payload.replace(
+                '"reward_clip_frac": 0.0',
+                '"reward_clip_frac": 1.0, "reward_clip_frac": 0.0',
+                1,
+            )
+            path.write_text("PUFFER_ENV_JSON " + payload + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(audit.AuditError, "duplicate JSON key"):
+                audit.scan_log(path, min_eval_games=10000)
+
+    def test_rejects_incomplete_or_invalid_phase_contracts(self):
+        cases = []
+        no_eval = complete_panels()[:1]
+        cases.append(("no_eval", no_eval, "no independent eval panel"))
+        no_final = complete_panels()[:2]
+        cases.append(("no_final", no_final, "exactly one final reprint"))
+        duplicate_final = complete_panels()
+        duplicate_final.append(dict(duplicate_final[-1]))
+        cases.append(("duplicate_final", duplicate_final, "found 2"))
+        invalid_final = complete_panels()
+        invalid_final[-1]["_puffer_phase_eval"] = 0
+        cases.append(
+            ("invalid_final", invalid_final, "populated cumulative eval panel")
+        )
+        fractional_n = complete_panels()
+        fractional_n[0]["n"] = 1.5
+        cases.append(("fractional_n", fractional_n, "panel n must be an integer"))
+        fractional_steps = complete_panels()
+        fractional_steps[0]["_puffer_agent_steps"] = 1.5
+        cases.append(
+            ("fractional_steps", fractional_steps, "agent steps must be an integer")
+        )
+        too_few = complete_panels()
+        too_few[-2]["_puffer_eval_episodes_completed"] = 9999
+        too_few[-1]["_puffer_eval_episodes_completed"] = 9999
+        cases.append(("too_few", too_few, "evaluated only 9999"))
+        old_schema = complete_panels()
+        old_schema[0]["_puffer_schema"] = 1
+        cases.append(("old_schema", old_schema, "schema 1"))
+        reversed_steps = complete_panels()
+        reversed_steps[1]["_puffer_agent_steps"] = 50
+        reversed_steps[2]["_puffer_agent_steps"] = 50
+        cases.append(("steps", reversed_steps, "steps regressed"))
+        for label, panels, message in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                path = Path(temporary) / "bad.log"
+                write_log(path, panels)
+                with self.assertRaisesRegex(audit.AuditError, message):
+                    audit.scan_log(path, min_eval_games=10000)
+
+    def test_rejects_a_log_that_changes_during_the_scan(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "seed42.log"
+            write_log(path, complete_panels())
+            with mock.patch.object(
+                audit,
+                "_file_identity",
+                side_effect=[(1, 2, 100, 3), (1, 2, 101, 4)],
+            ):
+                with self.assertRaisesRegex(audit.AuditError, "changed during audit"):
+                    audit.scan_log(path, min_eval_games=10000)
+
+    def test_audit_requires_exact_unique_log_count(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "seed42.log"
+            write_log(path, complete_panels())
+            with self.assertRaisesRegex(audit.AuditError, "expected 3 logs"):
+                audit.audit_logs([path], expected_count=3, min_eval_games=10000)
+            with self.assertRaisesRegex(audit.AuditError, "duplicate log path"):
+                audit.audit_logs([path, path], expected_count=2, min_eval_games=10000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_audit_recovery_complete_logs.py
+++ b/tools/test_audit_recovery_complete_logs.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+import contextlib
 import importlib.util
+import io
 import json
 from pathlib import Path
 import tempfile
@@ -63,6 +65,7 @@ class RecoveryCompleteLogAuditTests(unittest.TestCase):
         self.assertEqual(report["train_panels"], 1)
         self.assertEqual(report["eval_panels"], 1)
         self.assertEqual(report["final_reprints"], 1)
+        self.assertEqual(report["final_eval_games"], 10000)
         self.assertEqual(report["historical_diagnostics"]["illegal_frac"]["max"], 0.2)
 
     def test_allows_only_a_truly_empty_startup_panel_without_n(self):
@@ -130,6 +133,15 @@ class RecoveryCompleteLogAuditTests(unittest.TestCase):
             with self.assertRaisesRegex(audit.AuditError, "duplicate JSON key"):
                 audit.scan_log(path, min_eval_games=10000)
 
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "bad.log"
+            write_log(path, complete_panels())
+            path.write_bytes(
+                b"progress PUFFER_ENV_JSON {}\n" + path.read_bytes()
+            )
+            with self.assertRaisesRegex(audit.AuditError, "displaced or malformed"):
+                audit.scan_log(path, min_eval_games=10000)
+
     def test_rejects_incomplete_or_invalid_phase_contracts(self):
         cases = []
         no_eval = complete_panels()[:1]
@@ -144,6 +156,13 @@ class RecoveryCompleteLogAuditTests(unittest.TestCase):
         cases.append(
             ("invalid_final", invalid_final, "populated cumulative eval panel")
         )
+        stale_final = complete_panels()
+        stale_final[-1]["_puffer_eval_episodes_completed"] = 9999
+        cases.append(("stale_final", stale_final, "final reprint evaluated only 9999"))
+        final_not_last = complete_panels()
+        final_not_last.append(dict(final_not_last[0]))
+        final_not_last[-1]["_puffer_agent_steps"] = 300
+        cases.append(("final_not_last", final_not_last, "not its last machine panel"))
         fractional_n = complete_panels()
         fractional_n[0]["n"] = 1.5
         cases.append(("fractional_n", fractional_n, "panel n must be an integer"))
@@ -190,6 +209,26 @@ class RecoveryCompleteLogAuditTests(unittest.TestCase):
                 audit.audit_logs([path], expected_count=3, min_eval_games=10000)
             with self.assertRaisesRegex(audit.AuditError, "duplicate log path"):
                 audit.audit_logs([path, path], expected_count=2, min_eval_games=10000)
+
+            hardlink = Path(temporary) / "seed43.log"
+            hardlink.hardlink_to(path)
+            with self.assertRaisesRegex(audit.AuditError, "duplicate log inode"):
+                audit.audit_logs(
+                    [path, hardlink], expected_count=2, min_eval_games=10000
+                )
+
+            copied = Path(temporary) / "seed44.log"
+            copied.write_bytes(path.read_bytes())
+            with self.assertRaisesRegex(audit.AuditError, "duplicate log content"):
+                audit.audit_logs(
+                    [path, copied], expected_count=2, min_eval_games=10000
+                )
+
+    def test_cli_requires_an_explicit_eval_floor(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                audit.main([])
+        self.assertEqual(raised.exception.code, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Add a streaming, read-only auditor for the three stopped pre-exact-action recovery logs.
- Require strict schema and phase structure, monotonic integral steps, at least the explicitly supplied evaluation floor, exactly one populated cumulative final eval reprint, and exact zero across all 15 recovery-valid integrity counters.
- Bind the game floor to the final reprint itself and require that reprint to be the last machine panel.
- Reject malformed or displaced machine markers, non-standard JSON constants, duplicate keys, partial telemetry, duplicate paths/inodes/content, incorrect log count, and logs whose file identity changes during the scan.
- Report historical `illegal_frac` without gating it because that field belongs to the frozen marginal-action lineage.

## Why

The frozen recovery validator does not cover the component-ledger mismatch counters. This gives the post-stop boundary an independent, lineage-specific error-budget check before artifacts can authorize the isolated CUDA qualification.

The tool is not deployed into the active recovery checkout and performs no writes.

## Review fixes

Independent Codex and Fable reviews both identified final-reprint authority, duplicate-log evidence, and implicit CLI-floor gaps. Commit `f93f59b` closes those findings with regressions. D215 establishes that the fresh recovery request and inclusive acceptance floor are exactly 10,000 games; the old frozen 10,001 floor is superseded and is not reused here.

## Validation

- `PYTHONPATH=tools python3 -m unittest tools/test_audit_recovery_complete_logs.py tools/test_game_stats.py` (19 tests)
- `python3 -m py_compile tools/audit_recovery_complete_logs.py tools/test_audit_recovery_complete_logs.py`
- `ruff check tools/audit_recovery_complete_logs.py tools/test_audit_recovery_complete_logs.py`
- `git diff --check`