### PR TITLE
Independently validate exact-action canary artifacts

### DIFF
--- a/tools/analyze_reward_screen.py
+++ b/tools/analyze_reward_screen.py
@@ -601,11 +601,12 @@ def _validate_result(
         "result_file": path.name,
         "result_sha256": _sha256(path),
         "checkpoint_sha256": checkpoint_sha,
-        "checkpoint_lineage_sha256": checkpoint_lineage_sha,
         "reward_sha256": expected_reward_sha,
         "provenance_sha256": provenance_sha,
         "eval": selected,
     }
+    if checkpoint_lineage_sha is not None:
+        summary["checkpoint_lineage_sha256"] = checkpoint_lineage_sha
     return result, summary
 
 

--- a/tools/analyze_reward_screen.py
+++ b/tools/analyze_reward_screen.py
@@ -36,6 +36,8 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
+from live_integrity_guard import HARD_INTEGRITY_KEYS
+
 
 EXPECTED_SCHEDULE = (
     ("r0", 42),
@@ -136,6 +138,7 @@ POSSESSION_GAIN_EFFECT_DEFINITIONS = {
 PAIRED_CANDIDATES = ("possession_only", "gain_only", "neither")
 PAIRED_FINAL_SEEDS = (42, 43, 44)
 CONTROL_FINAL_SCHEDULE = (("both", 42), ("both", 43), ("both", 44))
+EXACT_ACTION_CANARY_SCHEDULE = (("both", 42),)
 
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 
@@ -223,6 +226,18 @@ def _screen_spec(contract: dict[str, Any]) -> dict[str, Any]:
             "factors": {"both": {"control": True}},
             "effect_definitions": {},
         }
+    if profile == "exact-action-canary":
+        return {
+            "profile": profile,
+            "candidate_arm": "both",
+            "schedule": EXACT_ACTION_CANARY_SCHEDULE,
+            "seeds": (42,),
+            "reward_sha256": {
+                "both": POSSESSION_GAIN_REWARD_SHA256["both"],
+            },
+            "factors": {"both": {"qualification": True}},
+            "effect_definitions": {},
+        }
     if profile in ("paired-confirmation", "paired-final"):
         candidate = contract.get("candidate_arm")
         if candidate not in PAIRED_CANDIDATES:
@@ -265,6 +280,181 @@ def _screen_spec(contract: dict[str, Any]) -> dict[str, Any]:
             },
         }
     raise AnalysisError(f"unsupported reward-screen profile: {profile!r}")
+
+
+def _validate_exact_action_canary_contract(contract: dict[str, Any]) -> None:
+    if contract.get("qualification_only") is not True:
+        raise AnalysisError(
+            "exact-action-canary contract must be qualification_only")
+    if contract.get("warm") is not None or contract.get("pool") is not None:
+        raise AnalysisError("exact-action-canary contract must have null warm/pool")
+
+    requested_steps = _need_int(
+        contract.get("requested_steps"), "exact-action-canary requested_steps")
+    if requested_steps != 50_000_000:
+        raise AnalysisError(
+            "exact-action-canary requested_steps must equal 50000000")
+    rollout_quantum = _need_int(
+        contract.get("rollout_quantum"), "exact-action-canary rollout_quantum")
+    if rollout_quantum <= 0:
+        raise AnalysisError("exact-action-canary rollout_quantum must be positive")
+    final_steps = _need_int(
+        contract.get("final_steps"), "exact-action-canary final_steps")
+    expected_final_steps = requested_steps // rollout_quantum * rollout_quantum
+    if final_steps != expected_final_steps or final_steps <= 0:
+        raise AnalysisError(
+            "exact-action-canary final_steps do not match the complete-rollout "
+            f"budget: {final_steps} != {expected_final_steps}")
+
+    bootstrap = _need_mapping(
+        contract.get("bootstrap"), "exact-action-canary bootstrap")
+    expected_bootstrap = {
+        "mode": "fresh-v5-qualification",
+        "observation_abi": "obs-v5",
+        "observation_version": 5,
+        "action_abi": "exact-joint-v1",
+        "initialization": "fresh",
+        "warm_lineage_sha256": "",
+        "pool_lineage_bundle_sha256": "",
+    }
+    for field, expected in expected_bootstrap.items():
+        if bootstrap.get(field) != expected:
+            raise AnalysisError(
+                f"exact-action-canary bootstrap {field} mismatch: "
+                f"{bootstrap.get(field)!r} != {expected!r}")
+
+    settings = _need_mapping(
+        contract.get("settings"), "exact-action-canary settings")
+    for field, expected in (
+        ("num_frozen_banks", 0),
+        ("frozen_bank_pct", 0),
+        ("native_precision_bytes", 4),
+        ("min_train_games", 1),
+        ("min_eval_games", 10_000),
+        ("eval_episodes", 10_000),
+    ):
+        observed = _need_int(
+            settings.get(field), f"exact-action-canary settings.{field}")
+        if observed != expected:
+            raise AnalysisError(
+                f"exact-action-canary settings.{field} mismatch: "
+                f"{observed} != {expected}")
+
+    error_budget = _need_mapping(
+        contract.get("error_budget"), "exact-action-canary error_budget")
+    if _need_int(
+            error_budget.get("contamination_budget"),
+            "exact-action-canary contamination_budget") != 0:
+        raise AnalysisError(
+            "exact-action-canary contamination_budget must be exactly zero")
+    hard_keys = error_budget.get("hard_integrity_keys")
+    if hard_keys != list(HARD_INTEGRITY_KEYS):
+        raise AnalysisError(
+            "exact-action-canary hard_integrity_keys do not match the frozen registry")
+    poll_seconds = _need_int(
+        error_budget.get("detection_poll_seconds"),
+        "exact-action-canary detection_poll_seconds",
+    )
+    if not 1 <= poll_seconds <= 60:
+        raise AnalysisError(
+            "exact-action-canary detection_poll_seconds must be in 1..60")
+    if _need_int(
+            error_budget.get("max_panel_silence_seconds"),
+            "exact-action-canary max_panel_silence_seconds") != 180:
+        raise AnalysisError(
+            "exact-action-canary max_panel_silence_seconds must equal 180")
+
+    implementation = _need_mapping(
+        contract.get("implementation"), "exact-action-canary implementation")
+    implementation_hashes = (
+        "screen_script_sha256",
+        "game_stats_sha256",
+        "live_integrity_guard_sha256",
+        "checkpoint_lineage_sha256",
+        "status_wrapper_sha256",
+        "launcher_sha256",
+        "source_sha256",
+        "compiled_module_sha256",
+        "puffer_patch_bundle_sha256",
+        "vendor_source_sha256",
+    )
+    for field in implementation_hashes:
+        _need_sha256(
+            implementation.get(field),
+            f"exact-action-canary implementation.{field}",
+        )
+    compiled = _need_mapping(
+        implementation.get("compiled_semantic_contract"),
+        "exact-action-canary compiled_semantic_contract",
+    )
+    expected_compiled = {
+        "env_name": "bloodbowl",
+        "gpu": 1,
+        "precision_bytes": 4,
+        "observation_abi": "obs-v5",
+        "observation_version": 5,
+        "action_abi": "exact-joint-v1",
+    }
+    for field, expected in expected_compiled.items():
+        observed = (
+            _need_int(compiled.get(field), f"exact-action-canary compiled {field}")
+            if isinstance(expected, int) else compiled.get(field)
+        )
+        if observed != expected:
+            raise AnalysisError(
+                f"exact-action-canary compiled {field} mismatch: "
+                f"{observed!r} != {expected!r}")
+    _need_sha256(
+        compiled.get("exact_action_source_sha256"),
+        "exact-action-canary compiled exact_action_source_sha256",
+    )
+    environment_source_sha = _need_sha256(
+        compiled.get("environment_source_sha256"),
+        "exact-action-canary compiled environment_source_sha256",
+    )
+    if environment_source_sha != implementation["source_sha256"]:
+        raise AnalysisError(
+            "exact-action-canary compiled environment source does not match "
+            "the installed source identity")
+
+
+def _validate_exact_action_canary_result(
+        result: dict[str, Any], label: str, contract: dict[str, Any]) -> str:
+    if result.get("qualification_only") is not True:
+        raise AnalysisError(f"{label} must be qualification_only")
+    if result.get("acceptance_failures") != []:
+        raise AnalysisError(
+            f"{label} must record an exactly empty acceptance_failures array")
+
+    settings = _need_mapping(contract.get("settings"), "screen settings")
+    for phase, minimum_field in (
+        ("train", "min_train_games"), ("eval", "min_eval_games")):
+        metrics = _need_mapping(
+            result.get(f"{phase}_metrics"), f"{label} {phase}_metrics")
+        observed_n = _finite_number(
+            metrics.get("n"), f"{label} {phase}_metrics.n")
+        minimum_n = _need_int(
+            settings.get(minimum_field),
+            f"screen settings {minimum_field}",
+        )
+        if observed_n < minimum_n:
+            raise AnalysisError(
+                f"{label} {phase}_metrics.n is below the frozen minimum: "
+                f"{observed_n} < {minimum_n}")
+        for key in HARD_INTEGRITY_KEYS:
+            observed = _finite_number(
+                metrics.get(key), f"{label} {phase}_metrics.{key}")
+            if observed != 0.0:
+                raise AnalysisError(
+                    f"{label} {phase}_metrics.{key} must be exactly zero")
+
+    lineage_path = result.get("checkpoint_lineage")
+    if not isinstance(lineage_path, str) or not lineage_path:
+        raise AnalysisError(f"{label} checkpoint_lineage must be a non-empty path")
+    return _need_sha256(
+        result.get("checkpoint_lineage_sha256"),
+        f"{label} checkpoint_lineage_sha256",
+    )
 
 
 def _validate_schedule(
@@ -386,6 +576,10 @@ def _validate_result(
     checkpoint_sha = _need_sha256(
         result.get("checkpoint_sha256"), f"{label} checkpoint_sha256"
     )
+    checkpoint_lineage_sha = None
+    if contract.get("screen_profile") == "exact-action-canary":
+        checkpoint_lineage_sha = _validate_exact_action_canary_result(
+            result, label, contract)
     provenance_sha = {
         field.removesuffix("_sha256"): _need_sha256(
             result.get(field), f"{label} {field}"
@@ -407,6 +601,7 @@ def _validate_result(
         "result_file": path.name,
         "result_sha256": _sha256(path),
         "checkpoint_sha256": checkpoint_sha,
+        "checkpoint_lineage_sha256": checkpoint_lineage_sha,
         "reward_sha256": expected_reward_sha,
         "provenance_sha256": provenance_sha,
         "eval": selected,
@@ -468,6 +663,16 @@ def _validate_completion(
             raise AnalysisError(
                 f"completion checkpoint hash mismatch for {arm}/seed {seed}"
             )
+        if results[key].get("qualification_only") is True:
+            recorded_lineage_sha = _need_sha256(
+                recorded.get("checkpoint_lineage_sha256"),
+                f"completion checkpoint_lineage_sha256 for {arm}/seed {seed}",
+            )
+            if recorded_lineage_sha != results[key].get(
+                    "checkpoint_lineage_sha256"):
+                raise AnalysisError(
+                    "completion checkpoint lineage hash mismatch for "
+                    f"{arm}/seed {seed}")
 
     return {
         "present": True,
@@ -480,7 +685,7 @@ def _validate_completion(
 def _factorial_effects(
     cells: dict[str, float], profile: str,
 ) -> dict[str, float]:
-    if profile == "control-final":
+    if profile in ("control-final", "exact-action-canary"):
         return {}
     if profile == "distance-possession":
         r0, r1, r2, r3 = (cells[arm] for arm in ("r0", "r1", "r2", "r3"))
@@ -546,6 +751,8 @@ def analyze_screen(
         raise AnalysisError("unsupported SCREEN_MANIFEST.json schema")
     contract = _need_mapping(manifest.get("contract"), "screen contract")
     spec = _screen_spec(contract)
+    if spec["profile"] == "exact-action-canary":
+        _validate_exact_action_canary_contract(contract)
     prefix = contract.get("prefix")
     if not isinstance(prefix, str) or not prefix:
         raise AnalysisError("screen contract has no prefix")
@@ -590,23 +797,35 @@ def analyze_screen(
         runs.append(summary)
 
     seeds = tuple(spec.get("seeds", (42, 43)))
-    warnings = [
-        (
-            f"Only n={len(seeds)} seeds are available. Across-seed means and sample SDs "
-            "are descriptive; they are not confidence intervals, hypothesis "
-            "tests, or a strength claim."
-        ),
-        (
-            "These contrasts summarize final-policy self-play evaluation "
-            "metrics. Promotion still requires paired held-out match-strength "
-            "and behavioral checks."
-        ),
-    ]
+    if spec["profile"] == "exact-action-canary":
+        warnings = [
+            (
+                "This is a qualification-only runtime canary. Its checkpoint is "
+                "permanently ineligible as training ancestry, and its metrics are "
+                "not causal reward or policy-strength evidence."
+            ),
+        ]
+    else:
+        warnings = [
+            (
+                f"Only n={len(seeds)} seeds are available. Across-seed means and "
+                "sample SDs are descriptive; they are not confidence intervals, "
+                "hypothesis tests, or a strength claim."
+            ),
+            (
+                "These contrasts summarize final-policy self-play evaluation "
+                "metrics. Promotion still requires paired held-out match-strength "
+                "and behavioral checks."
+            ),
+        ]
     completion_path = directory / "SCREEN_COMPLETE.json"
     if completion_path.exists():
         completion = _validate_completion(
             completion_path, manifest_sha, schedule, result_paths, raw_results
         )
+    elif spec["profile"] == "exact-action-canary":
+        raise AnalysisError(
+            "exact-action-canary requires the atomic SCREEN_COMPLETE.json proof")
     else:
         completion = {"present": False}
         warnings.append(
@@ -655,12 +874,16 @@ def analyze_screen(
     return {
         "schema_version": 1,
         "analysis": (
-            "control_reward_replication"
-            if spec["profile"] == "control-final"
+            "exact_action_canary_qualification"
+            if spec["profile"] == "exact-action-canary"
             else (
-                "paired_reward_confirmation"
-                if spec["profile"] in ("paired-confirmation", "paired-final")
-                else "paired_reward_screen_2x2"
+                "control_reward_replication"
+                if spec["profile"] == "control-final"
+                else (
+                    "paired_reward_confirmation"
+                    if spec["profile"] in ("paired-confirmation", "paired-final")
+                    else "paired_reward_screen_2x2"
+                )
             )
         ),
         "screen": {

--- a/tools/analyze_reward_screen.py
+++ b/tools/analyze_reward_screen.py
@@ -36,7 +36,10 @@ import sys
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
-from live_integrity_guard import HARD_INTEGRITY_KEYS
+if __package__:
+    from .live_integrity_guard import HARD_INTEGRITY_KEYS
+else:
+    from live_integrity_guard import HARD_INTEGRITY_KEYS
 
 
 EXPECTED_SCHEDULE = (
@@ -139,6 +142,16 @@ PAIRED_CANDIDATES = ("possession_only", "gain_only", "neither")
 PAIRED_FINAL_SEEDS = (42, 43, 44)
 CONTROL_FINAL_SCHEDULE = (("both", 42), ("both", 43), ("both", 44))
 EXACT_ACTION_CANARY_SCHEDULE = (("both", 42),)
+EXACT_ACTION_CANARY_REQUESTED_STEPS = 50_000_000
+EXACT_ACTION_CANARY_TOTAL_AGENTS = 2_048
+EXACT_ACTION_CANARY_HORIZON = 64
+EXACT_ACTION_CANARY_ROLLOUT_QUANTUM = (
+    EXACT_ACTION_CANARY_TOTAL_AGENTS * EXACT_ACTION_CANARY_HORIZON)
+EXACT_ACTION_CANARY_FINAL_STEPS = (
+    EXACT_ACTION_CANARY_REQUESTED_STEPS
+    // EXACT_ACTION_CANARY_ROLLOUT_QUANTUM
+    * EXACT_ACTION_CANARY_ROLLOUT_QUANTUM)
+EXACT_ACTION_CANARY_CHECKPOINT_BYTES = 16_066_560
 
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
 
@@ -291,20 +304,22 @@ def _validate_exact_action_canary_contract(contract: dict[str, Any]) -> None:
 
     requested_steps = _need_int(
         contract.get("requested_steps"), "exact-action-canary requested_steps")
-    if requested_steps != 50_000_000:
+    if requested_steps != EXACT_ACTION_CANARY_REQUESTED_STEPS:
         raise AnalysisError(
             "exact-action-canary requested_steps must equal 50000000")
     rollout_quantum = _need_int(
         contract.get("rollout_quantum"), "exact-action-canary rollout_quantum")
-    if rollout_quantum <= 0:
-        raise AnalysisError("exact-action-canary rollout_quantum must be positive")
+    if rollout_quantum != EXACT_ACTION_CANARY_ROLLOUT_QUANTUM:
+        raise AnalysisError(
+            "exact-action-canary rollout_quantum mismatch: "
+            f"{rollout_quantum} != {EXACT_ACTION_CANARY_ROLLOUT_QUANTUM}")
     final_steps = _need_int(
         contract.get("final_steps"), "exact-action-canary final_steps")
-    expected_final_steps = requested_steps // rollout_quantum * rollout_quantum
-    if final_steps != expected_final_steps or final_steps <= 0:
+    if final_steps != EXACT_ACTION_CANARY_FINAL_STEPS:
         raise AnalysisError(
-            "exact-action-canary final_steps do not match the complete-rollout "
-            f"budget: {final_steps} != {expected_final_steps}")
+            "exact-action-canary final_steps do not match the frozen "
+            f"complete-rollout budget: {final_steps} != "
+            f"{EXACT_ACTION_CANARY_FINAL_STEPS}")
 
     bootstrap = _need_mapping(
         contract.get("bootstrap"), "exact-action-canary bootstrap")
@@ -326,9 +341,15 @@ def _validate_exact_action_canary_contract(contract: dict[str, Any]) -> None:
     settings = _need_mapping(
         contract.get("settings"), "exact-action-canary settings")
     for field, expected in (
+        ("total_agents", EXACT_ACTION_CANARY_TOTAL_AGENTS),
+        ("horizon", EXACT_ACTION_CANARY_HORIZON),
+        ("expected_checkpoint_bytes", EXACT_ACTION_CANARY_CHECKPOINT_BYTES),
         ("num_frozen_banks", 0),
         ("frozen_bank_pct", 0),
         ("native_precision_bytes", 4),
+        ("policy_hidden_size", 512),
+        ("policy_num_layers", 3),
+        ("policy_expansion_factor", 1),
         ("min_train_games", 1),
         ("min_eval_games", 10_000),
         ("eval_episodes", 10_000),
@@ -943,35 +964,40 @@ def render_text(report: dict[str, Any]) -> str:
         )
 
     lines.append("")
-    lines.append(
-        "Per-seed paired contrasts"
-        if screen["profile"] in ("paired-confirmation", "paired-final")
-        else (
-            "Per-seed control summaries"
-            if screen["profile"] == "control-final"
-            else "Per-seed 2x2 effects"
-        )
-    )
-    for seed in report["per_seed"]:
-        lines.append(f"  seed {seed}")
-        for metric in report["metrics"]:
-            effects = report["per_seed"][seed]["effects"][metric]
-            lines.append(f"    {metric}: " + " ".join(
-                f"{effect}={_format_number(effects[effect])}"
-                for effect in report["effect_definitions"]
-            ))
-
-    lines.append("")
-    seed_count = len(report["per_seed"])
-    lines.append(f"Across {seed_count} seeds (descriptive means)")
-    for metric in report["metrics"]:
-        summaries = report["across_seeds"]["effects"][metric]
+    if screen["profile"] == "exact-action-canary":
+        lines.append("Qualification verdict")
         lines.append(
-            f"  {metric}: " + " ".join(
-                f"{effect}={_format_number(summaries[effect]['mean'])}"
-                for effect in report["effect_definitions"]
+            "  accepted fixed one-arm runtime canary; no reward contrasts computed")
+    else:
+        lines.append(
+            "Per-seed paired contrasts"
+            if screen["profile"] in ("paired-confirmation", "paired-final")
+            else (
+                "Per-seed control summaries"
+                if screen["profile"] == "control-final"
+                else "Per-seed 2x2 effects"
             )
         )
+        for seed in report["per_seed"]:
+            lines.append(f"  seed {seed}")
+            for metric in report["metrics"]:
+                effects = report["per_seed"][seed]["effects"][metric]
+                lines.append(f"    {metric}: " + " ".join(
+                    f"{effect}={_format_number(effects[effect])}"
+                    for effect in report["effect_definitions"]
+                ))
+
+        lines.append("")
+        seed_count = len(report["per_seed"])
+        lines.append(f"Across {seed_count} seeds (descriptive means)")
+        for metric in report["metrics"]:
+            summaries = report["across_seeds"]["effects"][metric]
+            lines.append(
+                f"  {metric}: " + " ".join(
+                    f"{effect}={_format_number(summaries[effect]['mean'])}"
+                    for effect in report["effect_definitions"]
+                )
+            )
     lines.append("")
     lines.append("Warnings")
     lines.extend(f"  - {warning}" for warning in report["warnings"])

--- a/tools/test_analyze_reward_screen.py
+++ b/tools/test_analyze_reward_screen.py
@@ -9,6 +9,7 @@ import unittest
 from pathlib import Path
 
 import analyze_reward_screen
+from live_integrity_guard import HARD_INTEGRITY_KEYS
 
 
 def write_json(path, value):
@@ -27,6 +28,131 @@ def digest(value):
 
 
 class RewardScreenAnalysisTests(unittest.TestCase):
+    def build_exact_action_canary(self, root):
+        root = Path(root)
+        prefix = "exact-action-canary-test"
+        manifest = {
+            "schema_version": 1,
+            "contract": {
+                "prefix": prefix,
+                "screen_profile": "exact-action-canary",
+                "qualification_only": True,
+                "bootstrap": {
+                    "mode": "fresh-v5-qualification",
+                    "observation_abi": "obs-v5",
+                    "observation_version": 5,
+                    "action_abi": "exact-joint-v1",
+                    "initialization": "fresh",
+                    "warm_lineage_sha256": "",
+                    "pool_lineage_bundle_sha256": "",
+                },
+                "requested_steps": 50_000_000,
+                "final_steps": 49_938_432,
+                "rollout_quantum": 131_072,
+                "schedule": [{"index": 1, "arm": "both", "seed": 42}],
+                "settings": {
+                    "expected_checkpoint_bytes": "16",
+                    "frozen_bank_pct": "0",
+                    "num_frozen_banks": "0",
+                    "native_precision_bytes": "4",
+                    "min_train_games": "1",
+                    "min_eval_games": "10000",
+                    "eval_episodes": "10000",
+                },
+                "warm": None,
+                "pool": None,
+                "rewards": {
+                    "both": {
+                        "reward_sha256": analyze_reward_screen
+                        .POSSESSION_GAIN_REWARD_SHA256["both"]
+                    }
+                },
+                "error_budget": {
+                    "contamination_budget": 0,
+                    "detection_poll_seconds": 30,
+                    "max_panel_silence_seconds": 180,
+                    "hard_integrity_keys": list(
+                        HARD_INTEGRITY_KEYS
+                    ),
+                },
+                "implementation": {
+                    **{
+                        field: digest(field)
+                        for field in (
+                            "screen_script_sha256",
+                            "game_stats_sha256",
+                            "live_integrity_guard_sha256",
+                            "checkpoint_lineage_sha256",
+                            "status_wrapper_sha256",
+                            "launcher_sha256",
+                            "source_sha256",
+                            "compiled_module_sha256",
+                            "puffer_patch_bundle_sha256",
+                            "vendor_source_sha256",
+                        )
+                    },
+                    "compiled_semantic_contract": {
+                        "env_name": "bloodbowl",
+                        "gpu": 1,
+                        "precision_bytes": 4,
+                        "observation_abi": "obs-v5",
+                        "observation_version": 5,
+                        "action_abi": "exact-joint-v1",
+                        "exact_action_source_sha256": digest(
+                            "exact-action-source"),
+                        "environment_source_sha256": digest("source_sha256"),
+                    }
+                },
+            },
+        }
+        manifest_path = root / "SCREEN_MANIFEST.json"
+        write_json(manifest_path, manifest)
+        manifest_sha = sha256(manifest_path)
+        checkpoint_lineage_sha = digest("checkpoint-lineage")
+        zero_metrics = {
+            key: 0.0 for key in HARD_INTEGRITY_KEYS
+        }
+        result_path = root / f"{prefix}-both-s42.result.json"
+        result = {
+            "schema_version": 2,
+            "trainer_complete": True,
+            "acceptance_pass": True,
+            "acceptance_failures": [],
+            "qualification_only": True,
+            "arm": "both",
+            "seed": 42,
+            "tag": f"{prefix}-both-s42",
+            "screen_manifest_sha256": manifest_sha,
+            "reward_sha256": analyze_reward_screen
+            .POSSESSION_GAIN_REWARD_SHA256["both"],
+            "checkpoint_bytes": 16,
+            "checkpoint_sha256": digest("checkpoint-both-42"),
+            "checkpoint_lineage": "/remote/run/0000000049938432.bin.lineage.json",
+            "checkpoint_lineage_sha256": checkpoint_lineage_sha,
+            "log_sha256": digest("log-both-42"),
+            "status_sha256": digest("status-both-42"),
+            "process_sha256": digest("process-both-42"),
+            "run_manifest_sha256": digest("manifest-both-42"),
+            "train_metrics": {"n": 20_000, **zero_metrics},
+            "eval_metrics": {"n": 10_000, "tds": 1.0, **zero_metrics},
+        }
+        write_json(result_path, result)
+        write_json(root / "SCREEN_COMPLETE.json", {
+            "schema_version": 1,
+            "screen_manifest_sha256": manifest_sha,
+            "completed_utc": "2026-07-21T00:00:00+00:00",
+            "results": [{
+                "index": 1,
+                "arm": "both",
+                "seed": 42,
+                "path": f"/remote/screen/{result_path.name}",
+                "sha256": sha256(result_path),
+                "checkpoint_sha256": result["checkpoint_sha256"],
+                "checkpoint_lineage_sha256": checkpoint_lineage_sha,
+            }],
+        })
+        return manifest_sha
+
     def build_screen(self, root, *, completion=True):
         root = Path(root)
         prefix = "screen-test"
@@ -142,6 +268,108 @@ class RewardScreenAnalysisTests(unittest.TestCase):
         self.assertEqual(across["distance_main"]["mean"], 6.5)
         self.assertEqual(across["interaction"]["mean"], 4.0)
         self.assertIn("n=2", " ".join(report["warnings"]))
+
+    def test_exact_action_canary_is_independently_qualified(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.build_exact_action_canary(tmp)
+            report = analyze_reward_screen.analyze_screen(tmp, ("tds",))
+
+        self.assertEqual(report["analysis"], "exact_action_canary_qualification")
+        self.assertEqual(report["screen"]["profile"], "exact-action-canary")
+        self.assertEqual(list(report["per_seed"]), ["42"])
+        self.assertEqual(report["per_seed"]["42"]["effects"]["tds"], {})
+        self.assertIn("qualification-only", " ".join(report["warnings"]))
+
+    def test_exact_action_canary_rejects_nonfresh_or_misaligned_contract(self):
+        mutations = (
+            (
+                "warm",
+                lambda contract: contract.__setitem__(
+                    "warm", {"path": "/remote/forbidden.bin"}),
+                "null warm/pool",
+            ),
+            (
+                "final_steps",
+                lambda contract: contract.__setitem__(
+                    "final_steps", contract["final_steps"] + 1),
+                "complete-rollout budget",
+            ),
+            (
+                "action_abi",
+                lambda contract: contract["bootstrap"].__setitem__(
+                    "action_abi", "marginal-heads"),
+                "bootstrap action_abi mismatch",
+            ),
+        )
+        for label, mutate, message in mutations:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                self.build_exact_action_canary(tmp)
+                manifest_path = Path(tmp) / "SCREEN_MANIFEST.json"
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                mutate(manifest["contract"])
+                write_json(manifest_path, manifest)
+                with self.assertRaisesRegex(
+                        analyze_reward_screen.AnalysisError, message):
+                    analyze_reward_screen.analyze_screen(tmp, ("tds",))
+
+    def test_exact_action_canary_rejects_nonzero_or_missing_hard_metrics(self):
+        mutations = (
+            (
+                "nonzero",
+                lambda result: result["train_metrics"].__setitem__(
+                    "illegal_frac", 1.0),
+                "train_metrics.illegal_frac must be exactly zero",
+            ),
+            (
+                "missing",
+                lambda result: result["eval_metrics"].pop(
+                    "reward_nonfinite_episodes"),
+                "eval_metrics.reward_nonfinite_episodes must be numeric",
+            ),
+        )
+        for label, mutate, message in mutations:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                self.build_exact_action_canary(tmp)
+                result_path = (
+                    Path(tmp) / "exact-action-canary-test-both-s42.result.json")
+                result = json.loads(result_path.read_text(encoding="utf-8"))
+                mutate(result)
+                write_json(result_path, result)
+                with self.assertRaisesRegex(
+                        analyze_reward_screen.AnalysisError, message):
+                    analyze_reward_screen.analyze_screen(tmp, ("tds",))
+
+    def test_exact_action_canary_requires_empty_failures_and_lineage_binding(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.build_exact_action_canary(tmp)
+            result_path = (
+                Path(tmp) / "exact-action-canary-test-both-s42.result.json")
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+            result["acceptance_failures"] = None
+            write_json(result_path, result)
+            with self.assertRaisesRegex(
+                    analyze_reward_screen.AnalysisError,
+                    "exactly empty acceptance_failures"):
+                analyze_reward_screen.analyze_screen(tmp, ("tds",))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.build_exact_action_canary(tmp)
+            (Path(tmp) / "SCREEN_COMPLETE.json").unlink()
+            with self.assertRaisesRegex(
+                    analyze_reward_screen.AnalysisError,
+                    "requires the atomic SCREEN_COMPLETE"):
+                analyze_reward_screen.analyze_screen(tmp, ("tds",))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.build_exact_action_canary(tmp)
+            completion_path = Path(tmp) / "SCREEN_COMPLETE.json"
+            completion = json.loads(completion_path.read_text(encoding="utf-8"))
+            completion["results"][0]["checkpoint_lineage_sha256"] = "0" * 64
+            write_json(completion_path, completion)
+            with self.assertRaisesRegex(
+                    analyze_reward_screen.AnalysisError,
+                    "checkpoint lineage hash mismatch"):
+                analyze_reward_screen.analyze_screen(tmp, ("tds",))
 
     def test_possession_gain_profile_computes_separate_main_effects(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/test_analyze_reward_screen.py
+++ b/tools/test_analyze_reward_screen.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -51,10 +52,15 @@ class RewardScreenAnalysisTests(unittest.TestCase):
                 "rollout_quantum": 131_072,
                 "schedule": [{"index": 1, "arm": "both", "seed": 42}],
                 "settings": {
-                    "expected_checkpoint_bytes": "16",
+                    "total_agents": "2048",
+                    "horizon": "64",
+                    "expected_checkpoint_bytes": "16066560",
                     "frozen_bank_pct": "0",
                     "num_frozen_banks": "0",
                     "native_precision_bytes": "4",
+                    "policy_hidden_size": "512",
+                    "policy_num_layers": "3",
+                    "policy_expansion_factor": "1",
                     "min_train_games": "1",
                     "min_eval_games": "10000",
                     "eval_episodes": "10000",
@@ -125,7 +131,7 @@ class RewardScreenAnalysisTests(unittest.TestCase):
             "screen_manifest_sha256": manifest_sha,
             "reward_sha256": analyze_reward_screen
             .POSSESSION_GAIN_REWARD_SHA256["both"],
-            "checkpoint_bytes": 16,
+            "checkpoint_bytes": 16_066_560,
             "checkpoint_sha256": digest("checkpoint-both-42"),
             "checkpoint_lineage": "/remote/run/0000000049938432.bin.lineage.json",
             "checkpoint_lineage_sha256": checkpoint_lineage_sha,
@@ -152,6 +158,20 @@ class RewardScreenAnalysisTests(unittest.TestCase):
             }],
         })
         return manifest_sha
+
+    def rebind_exact_action_canary(self, root):
+        root = Path(root)
+        manifest_path = root / "SCREEN_MANIFEST.json"
+        manifest_sha = sha256(manifest_path)
+        result_path = root / "exact-action-canary-test-both-s42.result.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["screen_manifest_sha256"] = manifest_sha
+        write_json(result_path, result)
+        completion_path = root / "SCREEN_COMPLETE.json"
+        completion = json.loads(completion_path.read_text(encoding="utf-8"))
+        completion["screen_manifest_sha256"] = manifest_sha
+        completion["results"][0]["sha256"] = sha256(result_path)
+        write_json(completion_path, completion)
 
     def build_screen(self, root, *, completion=True):
         root = Path(root)
@@ -280,6 +300,10 @@ class RewardScreenAnalysisTests(unittest.TestCase):
         self.assertEqual(list(report["per_seed"]), ["42"])
         self.assertEqual(report["per_seed"]["42"]["effects"]["tds"], {})
         self.assertIn("qualification-only", " ".join(report["warnings"]))
+        rendered = analyze_reward_screen.render_text(report)
+        self.assertIn("Qualification verdict", rendered)
+        self.assertNotIn("2x2 effects", rendered)
+        self.assertNotIn("Across 1 seeds", rendered)
 
     def test_exact_action_canary_rejects_nonfresh_or_misaligned_contract(self):
         mutations = (
@@ -312,6 +336,53 @@ class RewardScreenAnalysisTests(unittest.TestCase):
                 with self.assertRaisesRegex(
                         analyze_reward_screen.AnalysisError, message):
                     analyze_reward_screen.analyze_screen(tmp, ("tds",))
+
+    def test_exact_action_canary_rejects_coherent_budget_and_shape_drift(self):
+        mutations = (
+            (
+                "rollout_budget",
+                lambda contract, result: (
+                    contract.__setitem__("rollout_quantum", 30_000_000),
+                    contract.__setitem__("final_steps", 30_000_000),
+                ),
+                "rollout_quantum mismatch",
+            ),
+            (
+                "checkpoint_bytes",
+                lambda contract, result: (
+                    contract["settings"].__setitem__(
+                        "expected_checkpoint_bytes", "8"),
+                    result.__setitem__("checkpoint_bytes", 8),
+                ),
+                "settings.expected_checkpoint_bytes mismatch",
+            ),
+            (
+                "policy_shape",
+                lambda contract, result: (
+                    contract["settings"].__setitem__("policy_hidden_size", "999"),
+                    contract["settings"].__setitem__("policy_num_layers", "1"),
+                    contract["settings"].__setitem__(
+                        "policy_expansion_factor", "99"),
+                ),
+                "settings.policy_hidden_size mismatch",
+            ),
+        )
+        for label, mutate, message in mutations:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                self.build_exact_action_canary(tmp)
+                root = Path(tmp)
+                manifest_path = root / "SCREEN_MANIFEST.json"
+                result_path = (
+                    root / "exact-action-canary-test-both-s42.result.json")
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                result = json.loads(result_path.read_text(encoding="utf-8"))
+                mutate(manifest["contract"], result)
+                write_json(manifest_path, manifest)
+                write_json(result_path, result)
+                self.rebind_exact_action_canary(root)
+                with self.assertRaisesRegex(
+                        analyze_reward_screen.AnalysisError, message):
+                    analyze_reward_screen.analyze_screen(root, ("tds",))
 
     def test_exact_action_canary_rejects_nonzero_or_missing_hard_metrics(self):
         mutations = (
@@ -759,6 +830,19 @@ class RewardScreenAnalysisTests(unittest.TestCase):
         self.assertEqual(payload["metrics"], ["tds"])
         self.assertEqual(payload["across_seeds"]["effects"]["tds"]
                          ["interaction"]["mean"], 4.0)
+
+    def test_module_supports_repository_package_import(self):
+        result = subprocess.run(
+            [sys.executable, "-c", "import tools.analyze_reward_screen"],
+            cwd=Path(__file__).resolve().parent.parent,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={key: value for key, value in os.environ.items()
+                 if key != "PYTHONPATH"},
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/test_analyze_reward_screen.py
+++ b/tools/test_analyze_reward_screen.py
@@ -253,6 +253,7 @@ class RewardScreenAnalysisTests(unittest.TestCase):
 
         self.assertTrue(report["screen"]["completion"]["present"])
         self.assertEqual(len(report["runs"]), 8)
+        self.assertNotIn("checkpoint_lineage_sha256", report["runs"][0])
         self.assertEqual(report["per_seed"]["42"]["effects"]["tds"], {
             "possession_main": 3.5,
             "distance_main": 4.5,


### PR DESCRIPTION
## Summary
- add stopped analyzer support for the exact-action qualification canary
- require the frozen fresh/pool-free fp32 obs-v5/exact-joint-v1 contract
- independently recheck exact-zero train/eval integrity and lineage/completion binding

## Verification
- `PYTHONPATH=tools python3 -m unittest tools.test_analyze_reward_screen`
- `PYTHONPATH=tools python3 -m unittest discover -s tools -p "test_*.py"` (255 tests, 2 skipped)
- `ruff check tools/analyze_reward_screen.py tools/test_analyze_reward_screen.py`
- `python3 -m py_compile tools/analyze_reward_screen.py tools/test_analyze_reward_screen.py`