### PR TITLE
docs: bind qualification to fixed runner

### DIFF
--- a/docs/exact-action-canary-2070-execution-checklist.md
+++ b/docs/exact-action-canary-2070-execution-checklist.md
@@ -9,10 +9,10 @@ qualification.
 
 - Candidate source: `a52fc6e2f4ece5a7ff16bb4791e3aca4dd72f2e3`
 - Candidate Git tree: `57731b2af496a4e382d263bbfe123bc219f6bd51`
-- Control runner: `9274f45480d5bfff7943d3ce80fbc15c96760665`
-- Runner Git tree: `30cf4d146be5e31ce450adec47e693a40c732b82`
+- Control runner: `ffa49adfd71644fe3ffa10106df1fcdc7421b0c7`
+- Runner Git tree: `dd06117b77a4d15b5deb1770f86a465dc04338d0`
 - Runner file SHA-256:
-  `c1d9ad45884754f307e58272a8d43a399ab4320a3906972f001edfc75839b740`
+  `4b8519da01edcff7ee203e8114b3ef4aa8fb673df63cb9ce0b83e34baa6ba646`
 - Stopped analyzer SHA-256:
   `6e8fc25fe954da206a90e0cb0d1a2cff0db268f5c29b16bbad28db3c37445fb6`
 - Stopped complete-log guard SHA-256:
@@ -21,7 +21,7 @@ qualification.
 - Candidate root:
   `/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e`
 - Control root:
-  `/home/rache/bloodbowl-rl-qualification-control-20260722`
+  `/home/rache/bloodbowl-rl-qualification-control-20260722-v2`
 - Qualification root:
   `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification`
 - Canary output:
@@ -76,7 +76,7 @@ materialization:
 3. Candidate `QUALIFICATION.json` exists in the fixed qualification root,
    states `qualification_only=true` and `accepted=true`, and is independently
    accepted twice from fresh candidate-interpreter processes using exact runner
-   commit `9274f45`.
+   commit `ffa49ad`.
 4. The qualification directory is closed and its exact relative file set,
    modes, sizes, and SHA-256 inventory are fixed.
 5. Candidate source, Puffer source, venv package inventory, installed Blood Bowl
@@ -164,7 +164,7 @@ After=default.target
 [Service]
 Type=oneshot
 WorkingDirectory=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e
-ExecStartPre=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin/python /home/rache/bloodbowl-rl-qualification-control-20260722/tools/qualify_recurrent_cuda.py validate /home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification/QUALIFICATION.json
+ExecStartPre=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin/python /home/rache/bloodbowl-rl-qualification-control-20260722-v2/tools/qualify_recurrent_cuda.py validate /home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification/QUALIFICATION.json
 ExecStartPre=/usr/bin/bash -c 'set -euo pipefail; out="$$(/usr/local/bin/nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)"; stripped="$$(/usr/bin/printf "%s" "$${out}" | /usr/bin/tr -d "[:space:]")"; test -z "$${stripped}"'
 ExecStart=/usr/bin/env -u WARM -u POOL PATH=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CUDA_VISIBLE_DEVICES=0 OMP_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16 MKL_NUM_THREADS=16 NUMEXPR_NUM_THREADS=16 STEPS=50000000 SCREEN_PROFILE=exact-action-canary PREFIX=exact-action-canary-50m-s42-v1 OUT_DIR=/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1 POLL_SECONDS=30 PLAN_ONLY=0 ARM_DETACH=0 /usr/bin/bash /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/tools/run_reward_screen.sh
 Restart=no
@@ -227,7 +227,7 @@ reuse partial checkpoints.
 After the unit exits, require inactive `Result=success`, `ExecMainStatus=0`,
 `NRestarts=0`, no compute PID, and exact source/unit/authorization identity.
 Require the screen's own complete validation plus all three fresh independent
-stopped checks below. Run them from exact control commit `9274f45` with the
+stopped checks below. Run them from exact control commit `ffa49ad` with the
 candidate interpreter, writing only under the separately new/empty
 stopped-validation output directory:
 

--- a/docs/qualification-2070-execution-checklist.md
+++ b/docs/qualification-2070-execution-checklist.md
@@ -9,7 +9,7 @@ qualification/canary output as training ancestry.
 
 | Role | Exact identity |
 |---|---|
-| Control runner | `9274f45480d5bfff7943d3ce80fbc15c96760665` |
+| Control runner | `ffa49adfd71644fe3ffa10106df1fcdc7421b0c7` |
 | Predecessor | `afc8008933548438ca93c41341f5f08fdd294386` |
 | Candidate | `a52fc6e2f4ece5a7ff16bb4791e3aca4dd72f2e3` |
 | PufferLib base | `9836f0d2e78889c1aaf189c04d161b6fc61a9386` |
@@ -19,11 +19,18 @@ qualification/canary output as training ancestry.
 | Observation/action ABI | `obs-v5` / `exact-joint-v1` |
 
 The corresponding outer Git tree identities are runner
-`30cf4d146be5e31ce450adec47e693a40c732b82`, predecessor
+`dd06117b77a4d15b5deb1770f86a465dc04338d0`, predecessor
 `f89318a58c9038a888419f9a0720478c1cf1a325`, and candidate
 `57731b2af496a4e382d263bbfe123bc219f6bd51`. The frozen control-runner
 `tools/qualify_recurrent_cuda.py` SHA-256 is
-`c1d9ad45884754f307e58272a8d43a399ab4320a3906972f001edfc75839b740`.
+`4b8519da01edcff7ee203e8114b3ef4aa8fb673df63cb9ce0b83e34baa6ba646`.
+
+The earlier control root at commit `9274f45480d5bfff7943d3ce80fbc15c96760665`
+is retained as immutable rejection evidence. Its first predecessor capture
+proved that the old runner dereferenced the explicitly supplied venv Python
+symlink and therefore launched the managed base interpreter without the venv's
+packages. It is not an executable qualification authority. Only the merged
+runner identity above may create new throughput or qualification evidence.
 
 The predecessor installer SHA-256 is
 `577434b35c785cdb271647434ad974f1cb57f3a6dde3620d8f176d3aaa5be119`.
@@ -62,7 +69,7 @@ Any absence, addition, reordering, or digest mismatch rejects that runtime.
 Target roots are pairwise distinct and outside the protected recovery tree:
 
 ```text
-/home/rache/bloodbowl-rl-qualification-control-20260722
+/home/rache/bloodbowl-rl-qualification-control-20260722-v2
 /home/rache/bloodbowl-rl-qualification-predecessor-afc8008
 /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e
 /home/rache/bloodbowl-rl-qualification-artifacts-20260722
@@ -111,11 +118,18 @@ For each outer source checkout:
    cu128`, then install only the source-local Puffer tree editable with
    `--no-deps --no-build-isolation` so the already pinned setuptools performs
    the editable install.
-5. Require the portable sorted freeze with the one editable line excluded to
-   equal the requirements file byte-for-byte. Also record a full sorted freeze
-   after replacing the one checkout-specific editable path with a common
-   `<PUFFER_ROOT>` sentinel. Predecessor and candidate normalized freezes must
-   be byte-identical.
+5. Preserve the raw sorted freeze first. The cu128 index reports the installed
+   Torch build as `torch==2.10.0+cu128`, while the portable input requirements
+   intentionally pin `torch==2.10.0`; this single deterministic local-version
+   suffix is the only permitted raw difference after excluding the editable
+   line. Create and preserve a separate requirements-normalized freeze by
+   changing exactly that line to `torch==2.10.0`, then require byte equality
+   with the requirements file. Also record a full sorted freeze after replacing
+   the one checkout-specific editable path with a common `<PUFFER_ROOT>`
+   sentinel. Predecessor and candidate raw-portable hashes,
+   requirements-normalized hashes, and full sentinel-normalized hashes must be
+   pairwise identical by representation. Any other difference rejects the
+   runtime.
 6. If wheel libraries lack development links, create only these exact local
    links inside the venv after verifying their targets exist:
 

--- a/docs/qualification-2070-execution-checklist.md
+++ b/docs/qualification-2070-execution-checklist.md
@@ -29,8 +29,12 @@ The earlier control root at commit `9274f45480d5bfff7943d3ce80fbc15c96760665`
 is retained as immutable rejection evidence. Its first predecessor capture
 proved that the old runner dereferenced the explicitly supplied venv Python
 symlink and therefore launched the managed base interpreter without the venv's
-packages. It is not an executable qualification authority. Only the merged
-runner identity above may create new throughput or qualification evidence.
+packages. The rejected empty output is preserved only at
+`<artifacts>/predecessor-throughput-attempt1-rejected-python-resolve`; the
+authorized `<artifacts>/predecessor-throughput` target must remain absent before
+the corrected capture. The old runner is not an executable qualification
+authority. Only the merged runner identity above may create new throughput or
+qualification evidence.
 
 The predecessor installer SHA-256 is
 `577434b35c785cdb271647434ad974f1cb57f3a6dde3620d8f176d3aaa5be119`.


### PR DESCRIPTION
## Summary
- bind the recurrent-CUDA qualification and exact-action canary checklists to merged runner `ffa49ad`
- preserve the rejected pre-fix control root as non-authoritative evidence
- document the exact cu128 Torch freeze normalization already observed during isolated runtime construction

## Verification
- `git diff --check`
- exact old/new identity reference audit with `rg`

No trainer, service, runtime, or experiment output is modified by this documentation-only change.