### PR TITLE
fix: match qualification minibatch to canary

### DIFF
--- a/tools/analyze_reward_screen.py
+++ b/tools/analyze_reward_screen.py
@@ -145,6 +145,7 @@ EXACT_ACTION_CANARY_SCHEDULE = (("both", 42),)
 EXACT_ACTION_CANARY_REQUESTED_STEPS = 50_000_000
 EXACT_ACTION_CANARY_TOTAL_AGENTS = 2_048
 EXACT_ACTION_CANARY_HORIZON = 64
+EXACT_ACTION_CANARY_MINIBATCH_SIZE = 16_384
 EXACT_ACTION_CANARY_ROLLOUT_QUANTUM = (
     EXACT_ACTION_CANARY_TOTAL_AGENTS * EXACT_ACTION_CANARY_HORIZON)
 EXACT_ACTION_CANARY_FINAL_STEPS = (
@@ -359,6 +360,7 @@ def _validate_exact_action_canary_contract(contract: dict[str, Any]) -> None:
     for field, expected in (
         ("total_agents", EXACT_ACTION_CANARY_TOTAL_AGENTS),
         ("horizon", EXACT_ACTION_CANARY_HORIZON),
+        ("minibatch_size", EXACT_ACTION_CANARY_MINIBATCH_SIZE),
         ("expected_checkpoint_bytes", EXACT_ACTION_CANARY_CHECKPOINT_BYTES),
         ("num_frozen_banks", 0),
         ("frozen_bank_pct", 0),

--- a/tools/qualify_recurrent_cuda.py
+++ b/tools/qualify_recurrent_cuda.py
@@ -811,15 +811,9 @@ def qualification_args(
     rollout_quantum = total_agents * horizon
     if minibatch_size is None:
         minibatch_size = rollout_quantum
-    if (
-        minibatch_size <= 0
-        or minibatch_size % horizon
-        or minibatch_size > rollout_quantum
-    ):
-        raise QualificationError(
-            "minibatch_size must be positive, horizon-divisible, and no larger "
-            "than the rollout quantum"
-        )
+    minibatch_size = validate_throughput_minibatch(
+        total_agents, horizon, minibatch_size
+    )
     return {
         "env_name": "bloodbowl",
         "reset_state": True,
@@ -867,6 +861,25 @@ def qualification_args(
             "prio_beta0": 1.0,
         },
     }
+
+
+def validate_throughput_minibatch(
+    total_agents: int, horizon: int, minibatch_size: int
+) -> int:
+    rollout_quantum = total_agents * horizon
+    if (
+        total_agents <= 0
+        or horizon <= 0
+        or minibatch_size <= 0
+        or minibatch_size % horizon
+        or minibatch_size > rollout_quantum
+        or rollout_quantum % minibatch_size
+    ):
+        raise QualificationError(
+            "minibatch_size must be positive, horizon-divisible, no larger than "
+            "the rollout quantum, and divide it exactly"
+        )
+    return minibatch_size
 
 
 def _load_backend(puffer_root: Path, *, require_qualification: bool = True):
@@ -2314,6 +2327,11 @@ def main(argv: list[str] | None = None) -> int:
         raise QualificationError("ratio call limit must be positive")
     if args.throughput_warmup_rollouts < 0 or args.throughput_timed_rollouts <= 0:
         raise QualificationError("throughput rollout counts are invalid")
+    validate_throughput_minibatch(
+        args.throughput_agents,
+        args.throughput_horizon,
+        args.throughput_minibatch_size,
+    )
     if args.command == "cell":
         return run_cell(args)
     if args.command == "capture-throughput":

--- a/tools/qualify_recurrent_cuda.py
+++ b/tools/qualify_recurrent_cuda.py
@@ -2327,6 +2327,15 @@ def main(argv: list[str] | None = None) -> int:
         raise QualificationError("ratio call limit must be positive")
     if args.throughput_warmup_rollouts < 0 or args.throughput_timed_rollouts <= 0:
         raise QualificationError("throughput rollout counts are invalid")
+    if (
+        args.command in {"run", "capture-throughput"}
+        and args.throughput_minibatch_size
+        != DEFAULT_THROUGHPUT_MINIBATCH_SIZE
+    ):
+        raise QualificationError(
+            "operator throughput minibatch is frozen at the exact-action "
+            f"canary value {DEFAULT_THROUGHPUT_MINIBATCH_SIZE}"
+        )
     validate_throughput_minibatch(
         args.throughput_agents,
         args.throughput_horizon,

--- a/tools/qualify_recurrent_cuda.py
+++ b/tools/qualify_recurrent_cuda.py
@@ -84,6 +84,9 @@ GRAPH_ATOL_BY_PRECISION = {4: 1.0e-6}
 RATIO_ATOL_BY_PRECISION = {4: 2.0e-5}
 DEFAULT_RATIO_CALL_LIMIT = 64
 DEFAULT_MAX_REGRESSION_FRACTION = 0.10
+# Match the frozen exact-action canary rather than allocating train activations
+# for its entire 2,048 x 64 rollout quantum at once.
+DEFAULT_THROUGHPUT_MINIBATCH_SIZE = 16384
 BACKEND_SOURCE_FILES = (
     "pufferlib/pufferl.py",
     "pufferlib/torch_pufferl.py",
@@ -797,12 +800,26 @@ def qualification_args(
     frozen_bank_pct: float,
     learning_rate: float,
     replay_ratio: int = 1,
+    minibatch_size: int | None = None,
 ) -> dict[str, Any]:
-    if total_agents <= 0 or total_agents % num_buffers:
+    if num_buffers <= 0 or total_agents <= 0 or total_agents % num_buffers:
         raise QualificationError("total_agents must be positive and buffer-divisible")
     if total_agents % 2:
         raise QualificationError("Blood Bowl qualification requires paired agents")
-    minibatch_size = total_agents * horizon
+    if horizon <= 0:
+        raise QualificationError("qualification horizon must be positive")
+    rollout_quantum = total_agents * horizon
+    if minibatch_size is None:
+        minibatch_size = rollout_quantum
+    if (
+        minibatch_size <= 0
+        or minibatch_size % horizon
+        or minibatch_size > rollout_quantum
+    ):
+        raise QualificationError(
+            "minibatch_size must be positive, horizon-divisible, and no larger "
+            "than the rollout quantum"
+        )
     return {
         "env_name": "bloodbowl",
         "reset_state": True,
@@ -1063,6 +1080,7 @@ def _cell_config(kind: str, cudagraphs: int, args: argparse.Namespace) -> dict[s
             frozen_banks=1,
             frozen_bank_pct=0.1,
             learning_rate=0.0,
+            minibatch_size=args.throughput_minibatch_size,
         )
     raise QualificationError(f"unknown qualification cell: {kind}")
 
@@ -1303,6 +1321,7 @@ def _run_worker(
         "--throughput-horizon", str(args.throughput_horizon),
         "--throughput-hidden", str(args.throughput_hidden),
         "--throughput-layers", str(args.throughput_layers),
+        "--throughput-minibatch-size", str(args.throughput_minibatch_size),
         "--throughput-warmup-rollouts", str(args.throughput_warmup_rollouts),
         "--throughput-timed-rollouts", str(args.throughput_timed_rollouts),
     ]
@@ -2222,6 +2241,11 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--throughput-horizon", type=int, default=64)
     parser.add_argument("--throughput-hidden", type=int, default=512)
     parser.add_argument("--throughput-layers", type=int, default=1)
+    parser.add_argument(
+        "--throughput-minibatch-size",
+        type=int,
+        default=DEFAULT_THROUGHPUT_MINIBATCH_SIZE,
+    )
     parser.add_argument("--throughput-warmup-rollouts", type=int, default=2)
     parser.add_argument("--throughput-timed-rollouts", type=int, default=8)
 

--- a/tools/test_analyze_reward_screen.py
+++ b/tools/test_analyze_reward_screen.py
@@ -54,6 +54,7 @@ class RewardScreenAnalysisTests(unittest.TestCase):
                 "settings": {
                     "total_agents": "2048",
                     "horizon": "64",
+                    "minibatch_size": "16384",
                     "expected_checkpoint_bytes": "16066560",
                     "frozen_bank_pct": "0",
                     "num_frozen_banks": "0",
@@ -378,6 +379,13 @@ class RewardScreenAnalysisTests(unittest.TestCase):
                     result.__setitem__("checkpoint_bytes", 8),
                 ),
                 "settings.expected_checkpoint_bytes mismatch",
+            ),
+            (
+                "minibatch_size",
+                lambda contract, result: contract["settings"].__setitem__(
+                    "minibatch_size", "8192"
+                ),
+                "settings.minibatch_size mismatch",
             ),
             (
                 "policy_shape",

--- a/training/test_recurrent_cuda_qualification.py
+++ b/training/test_recurrent_cuda_qualification.py
@@ -551,6 +551,7 @@ class QualificationValidatorTests(unittest.TestCase):
                 throughput_horizon=64,
                 throughput_hidden=512,
                 throughput_layers=3,
+                throughput_minibatch_size=16384,
                 throughput_warmup_rollouts=2,
                 throughput_timed_rollouts=8,
                 cell_timeout_seconds=1800,
@@ -570,6 +571,47 @@ class QualificationValidatorTests(unittest.TestCase):
             command = run.call_args.args[0]
             self.assertEqual(command[0], str(venv_python.absolute()))
             self.assertNotEqual(command[0], str(base_python.resolve()))
+            minibatch_flag = command.index("--throughput-minibatch-size")
+            self.assertEqual(command[minibatch_flag + 1], "16384")
+
+    def test_throughput_minibatch_matches_exact_canary_contract(self):
+        args = mock.Mock(
+            seed=271828,
+            throughput_agents=2048,
+            throughput_buffers=2,
+            throughput_threads=16,
+            throughput_horizon=64,
+            throughput_hidden=512,
+            throughput_layers=3,
+            throughput_minibatch_size=16384,
+        )
+        config = self.q._cell_config("throughput", 0, args)
+        rollout_quantum = (
+            config["vec"]["total_agents"] * config["train"]["horizon"]
+        )
+        self.assertEqual(rollout_quantum, 131072)
+        self.assertEqual(config["train"]["minibatch_size"], 16384)
+
+    def test_qualification_minibatch_must_fit_rollout_contract(self):
+        base = {
+            "cudagraphs": 0,
+            "seed": 271828,
+            "total_agents": 2048,
+            "num_buffers": 2,
+            "num_threads": 16,
+            "horizon": 64,
+            "max_decisions": 64,
+            "hidden_size": 512,
+            "num_layers": 3,
+            "frozen_banks": 1,
+            "frozen_bank_pct": 0.1,
+            "learning_rate": 0.0,
+        }
+        for invalid in (0, 16383, 131136):
+            with self.subTest(minibatch_size=invalid), self.assertRaises(
+                self.q.QualificationError
+            ):
+                self.q.qualification_args(**base, minibatch_size=invalid)
 
     def test_run_failure_record_never_writes_to_rejected_output(self):
         with tempfile.TemporaryDirectory() as temporary:

--- a/training/test_recurrent_cuda_qualification.py
+++ b/training/test_recurrent_cuda_qualification.py
@@ -629,6 +629,24 @@ class QualificationValidatorTests(unittest.TestCase):
             self.q.main(argv)
         run_cell.assert_not_called()
 
+    def test_operator_commands_freeze_canary_throughput_minibatch(self):
+        args = mock.Mock(
+            command="capture-throughput",
+            ratio_call_limit=64,
+            throughput_warmup_rollouts=2,
+            throughput_timed_rollouts=8,
+            throughput_agents=2048,
+            throughput_horizon=64,
+            throughput_minibatch_size=8192,
+        )
+        with mock.patch.object(
+            self.q, "parse_args", return_value=args
+        ), mock.patch.object(self.q, "capture_throughput") as capture, self.assertRaises(
+            self.q.QualificationError
+        ):
+            self.q.main([])
+        capture.assert_not_called()
+
     def test_qualification_minibatch_must_fit_rollout_contract(self):
         base = {
             "cudagraphs": 0,

--- a/training/test_recurrent_cuda_qualification.py
+++ b/training/test_recurrent_cuda_qualification.py
@@ -196,6 +196,15 @@ class QualificationValidatorTests(unittest.TestCase):
         with self.assertRaises(self.q.QualificationError):
             self.q.validate_throughput(
                 candidate, baseline, max_regression_fraction=0.10)
+        candidate = dict(
+            baseline,
+            config_sha256="b" * 64,
+            steps=2000,
+            steps_per_second=2000.0,
+        )
+        with self.assertRaises(self.q.QualificationError):
+            self.q.validate_throughput(
+                candidate, baseline, max_regression_fraction=0.10)
 
     def test_hard_integrity_rejects_redundant_nonzero_reward_counters(self):
         self.assertEqual(self.q.HARD_INTEGRITY_KEYS, (
@@ -592,6 +601,34 @@ class QualificationValidatorTests(unittest.TestCase):
         self.assertEqual(rollout_quantum, 131072)
         self.assertEqual(config["train"]["minibatch_size"], 16384)
 
+    def test_throughput_minibatch_parser_default_is_frozen(self):
+        args = self.q.parse_args([
+            "cell",
+            "--puffer-root", "/tmp/puffer",
+            "--kind", "throughput",
+            "--cudagraphs", "0",
+            "--output-json", "/tmp/throughput.json",
+        ])
+        self.assertEqual(self.q.DEFAULT_THROUGHPUT_MINIBATCH_SIZE, 16384)
+        self.assertEqual(args.throughput_minibatch_size, 16384)
+
+    def test_invalid_throughput_minibatch_fails_before_worker_dispatch(self):
+        argv = [
+            "cell",
+            "--puffer-root", "/tmp/puffer",
+            "--kind", "throughput",
+            "--cudagraphs", "0",
+            "--output-json", "/tmp/throughput.json",
+            "--throughput-agents", "2048",
+            "--throughput-horizon", "64",
+            "--throughput-minibatch-size", "6144",
+        ]
+        with mock.patch.object(self.q, "run_cell") as run_cell, self.assertRaises(
+            self.q.QualificationError
+        ):
+            self.q.main(argv)
+        run_cell.assert_not_called()
+
     def test_qualification_minibatch_must_fit_rollout_contract(self):
         base = {
             "cudagraphs": 0,
@@ -607,7 +644,7 @@ class QualificationValidatorTests(unittest.TestCase):
             "frozen_bank_pct": 0.1,
             "learning_rate": 0.0,
         }
-        for invalid in (0, 16383, 131136):
+        for invalid in (0, 6144, 16383, 24576, 131136):
             with self.subTest(minibatch_size=invalid), self.assertRaises(
                 self.q.QualificationError
             ):
@@ -623,6 +660,9 @@ class QualificationValidatorTests(unittest.TestCase):
             args.ratio_call_limit = 1
             args.throughput_warmup_rollouts = 0
             args.throughput_timed_rollouts = 1
+            args.throughput_agents = 2048
+            args.throughput_horizon = 64
+            args.throughput_minibatch_size = 16384
             args.max_regression_fraction = self.q.DEFAULT_MAX_REGRESSION_FRACTION
             with mock.patch.object(self.q, "parse_args", return_value=args), \
                     mock.patch.object(

--- a/training/test_recurrent_cuda_qualification.py
+++ b/training/test_recurrent_cuda_qualification.py
@@ -630,22 +630,26 @@ class QualificationValidatorTests(unittest.TestCase):
         run_cell.assert_not_called()
 
     def test_operator_commands_freeze_canary_throughput_minibatch(self):
-        args = mock.Mock(
-            command="capture-throughput",
-            ratio_call_limit=64,
-            throughput_warmup_rollouts=2,
-            throughput_timed_rollouts=8,
-            throughput_agents=2048,
-            throughput_horizon=64,
-            throughput_minibatch_size=8192,
-        )
-        with mock.patch.object(
-            self.q, "parse_args", return_value=args
-        ), mock.patch.object(self.q, "capture_throughput") as capture, self.assertRaises(
-            self.q.QualificationError
+        for command, dispatch_name in (
+            ("capture-throughput", "capture_throughput"),
+            ("run", "run_qualification"),
         ):
-            self.q.main([])
-        capture.assert_not_called()
+            args = mock.Mock(
+                command=command,
+                ratio_call_limit=64,
+                throughput_warmup_rollouts=2,
+                throughput_timed_rollouts=8,
+                throughput_agents=2048,
+                throughput_horizon=64,
+                throughput_minibatch_size=8192,
+            )
+            with self.subTest(command=command), mock.patch.object(
+                self.q, "parse_args", return_value=args
+            ), mock.patch.object(self.q, dispatch_name) as dispatch, self.assertRaises(
+                self.q.QualificationError
+            ):
+                self.q.main([])
+            dispatch.assert_not_called()
 
     def test_qualification_minibatch_must_fit_rollout_contract(self):
         base = {


### PR DESCRIPTION
## Summary
- give the throughput cell an explicit 16,384-sample minibatch matching the frozen exact-action canary
- preserve the 2,048 x 64 rollout workload while avoiding an unrelated full-rollout training-activation allocation
- validate minibatch positivity, horizon divisibility, and rollout-quantum bounds
- forward the exact value into every isolated worker

## Evidence
The first corrected predecessor capture reached `create_pufferl` but failed before transitions with CUDA OOM. Its config used a 131,072 minibatch because the runner implicitly equated minibatch size with the full 2,048 x 64 rollout. The exact candidate canary is fixed at 16,384. The rejected output and unit evidence remain preserved; BBTV is restored and the authorized output path remains absent.

## Verification
- new regression failed on the old code: `131072 != 16384`
- 27 qualification tests pass
- `python3 -m py_compile ...`
- Ruff passes
- `git diff --check`

No candidate, predecessor, service, or experiment artifact is modified by this PR.