### PR TITLE
Bind qualification checklists to 16K minibatch runner

### DIFF
--- a/docs/exact-action-canary-2070-execution-checklist.md
+++ b/docs/exact-action-canary-2070-execution-checklist.md
@@ -9,19 +9,19 @@ qualification.
 
 - Candidate source: `a52fc6e2f4ece5a7ff16bb4791e3aca4dd72f2e3`
 - Candidate Git tree: `57731b2af496a4e382d263bbfe123bc219f6bd51`
-- Control runner: `ffa49adfd71644fe3ffa10106df1fcdc7421b0c7`
-- Runner Git tree: `dd06117b77a4d15b5deb1770f86a465dc04338d0`
+- Control runner: `2261cd4c707733679b9482d2ab52eca3088afd54`
+- Runner Git tree: `939b882ba74f51e8e7b31d6bd1d6e8d2c6f1af7d`
 - Runner file SHA-256:
-  `4b8519da01edcff7ee203e8114b3ef4aa8fb673df63cb9ce0b83e34baa6ba646`
+  `65dd97f2abffdd243655caa0d5bbf34e5e2eab164e8a567b9eaae305c178e7a8`
 - Stopped analyzer SHA-256:
-  `6e8fc25fe954da206a90e0cb0d1a2cff0db268f5c29b16bbad28db3c37445fb6`
+  `3ea835d5f7c893571e3a885c4d5ad8a7cd61e16fdd372e968b5d11b955b5d3fd`
 - Stopped complete-log guard SHA-256:
   `e9c957ae37671bc6bfd6d09c7ef2d956736a5ead7242395f2357006bfc571ff1`
 - PufferLib base: `9836f0d2e78889c1aaf189c04d161b6fc61a9386`
 - Candidate root:
   `/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e`
 - Control root:
-  `/home/rache/bloodbowl-rl-qualification-control-20260722-v2`
+  `/home/rache/bloodbowl-rl-qualification-control-20260722-v3`
 - Qualification root:
   `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification`
 - Canary output:
@@ -31,6 +31,7 @@ qualification.
 - Unit name: `bloodbowl-exact-action-canary-50m-s42-v1.service`
 - Requested agent steps: exactly `50000000`
 - Rollout quantum: exactly `131072` (`2048 * 64`)
+- Minibatch size: exactly `16384`
 - Executed/final agent steps: exactly `49938432` (381 complete rollouts)
 - Learner/environment/self-play seed: exactly `42`
 - Reward profile: frozen R0 `both`
@@ -56,7 +57,7 @@ Candidate launch-source SHA-256 identities are:
 The independent stopped analyzer is executed only from the exact control
 runner, not from candidate `a52fc6e`. Re-hash
 `tools/analyze_reward_screen.py` in that control root and require exact SHA-256
-`6e8fc25fe954da206a90e0cb0d1a2cff0db268f5c29b16bbad28db3c37445fb6`.
+`3ea835d5f7c893571e3a885c4d5ad8a7cd61e16fdd372e968b5d11b955b5d3fd`.
 Re-hash `tools/live_integrity_guard.py` in the same control root and require
 exact SHA-256
 `e9c957ae37671bc6bfd6d09c7ef2d956736a5ead7242395f2357006bfc571ff1`.
@@ -76,7 +77,7 @@ materialization:
 3. Candidate `QUALIFICATION.json` exists in the fixed qualification root,
    states `qualification_only=true` and `accepted=true`, and is independently
    accepted twice from fresh candidate-interpreter processes using exact runner
-   commit `ffa49ad`.
+   commit `2261cd4`.
 4. The qualification directory is closed and its exact relative file set,
    modes, sizes, and SHA-256 inventory are fixed.
 5. Candidate source, Puffer source, venv package inventory, installed Blood Bowl
@@ -117,6 +118,7 @@ contract:
 - no warm path, pool path, pool identity, or frozen bank;
 - exact candidate module/backend/environment and complete patch bundle;
 - exact fp32 policy shape 512 x 3 with expansion factor 1;
+- exact 2,048 x 64 rollout contract and minibatch size 16,384;
 - the exact immutable candidate manifest's original ordered 11-key live
   registry including `illegal_frac`, contamination budget zero, poll interval
   30 seconds, and maximum silence 180 seconds; the later stopped control
@@ -164,7 +166,7 @@ After=default.target
 [Service]
 Type=oneshot
 WorkingDirectory=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e
-ExecStartPre=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin/python /home/rache/bloodbowl-rl-qualification-control-20260722-v2/tools/qualify_recurrent_cuda.py validate /home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification/QUALIFICATION.json
+ExecStartPre=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin/python /home/rache/bloodbowl-rl-qualification-control-20260722-v3/tools/qualify_recurrent_cuda.py validate /home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification/QUALIFICATION.json
 ExecStartPre=/usr/bin/bash -c 'set -euo pipefail; out="$$(/usr/local/bin/nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)"; stripped="$$(/usr/bin/printf "%s" "$${out}" | /usr/bin/tr -d "[:space:]")"; test -z "$${stripped}"'
 ExecStart=/usr/bin/env -u WARM -u POOL PATH=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CUDA_VISIBLE_DEVICES=0 OMP_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16 MKL_NUM_THREADS=16 NUMEXPR_NUM_THREADS=16 STEPS=50000000 SCREEN_PROFILE=exact-action-canary PREFIX=exact-action-canary-50m-s42-v1 OUT_DIR=/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1 POLL_SECONDS=30 PLAN_ONLY=0 ARM_DETACH=0 /usr/bin/bash /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/tools/run_reward_screen.sh
 Restart=no
@@ -227,7 +229,7 @@ reuse partial checkpoints.
 After the unit exits, require inactive `Result=success`, `ExecMainStatus=0`,
 `NRestarts=0`, no compute PID, and exact source/unit/authorization identity.
 Require the screen's own complete validation plus all three fresh independent
-stopped checks below. Run them from exact control commit `ffa49ad` with the
+stopped checks below. Run them from exact control commit `2261cd4` with the
 candidate interpreter, writing only under the separately new/empty
 stopped-validation output directory:
 
@@ -239,8 +241,9 @@ stopped-validation output directory:
    --expected-screen-sha <Gate-2-manifest-sha>` and atomically preserve stdout,
    stderr, and exit status. Require analysis
    `exact_action_canary_qualification`, exact one-arm seed-42 schedule, the
-   fixed 2,048 x 64 rollout contract, final step 49,938,432, checkpoint bytes
-   16,066,560, policy shape 512 x 3 x 1, fresh null warm/pool/banks, exact
+   fixed 2,048 x 64 rollout contract and 16,384 minibatch, final step
+   49,938,432, checkpoint bytes 16,066,560, policy shape 512 x 3 x 1, fresh
+   null warm/pool/banks, exact
    fp32 obs-v5/exact-joint provenance, an exactly empty failure list, both
    train/eval game floors, all 16 control hard fields at zero despite the
    immutable manifest's narrower 11-key live registry, lineage digest binding,

--- a/docs/qualification-2070-execution-checklist.md
+++ b/docs/qualification-2070-execution-checklist.md
@@ -9,7 +9,7 @@ qualification/canary output as training ancestry.
 
 | Role | Exact identity |
 |---|---|
-| Control runner | `ffa49adfd71644fe3ffa10106df1fcdc7421b0c7` |
+| Control runner | `2261cd4c707733679b9482d2ab52eca3088afd54` |
 | Predecessor | `afc8008933548438ca93c41341f5f08fdd294386` |
 | Candidate | `a52fc6e2f4ece5a7ff16bb4791e3aca4dd72f2e3` |
 | PufferLib base | `9836f0d2e78889c1aaf189c04d161b6fc61a9386` |
@@ -19,21 +19,27 @@ qualification/canary output as training ancestry.
 | Observation/action ABI | `obs-v5` / `exact-joint-v1` |
 
 The corresponding outer Git tree identities are runner
-`dd06117b77a4d15b5deb1770f86a465dc04338d0`, predecessor
+`939b882ba74f51e8e7b31d6bd1d6e8d2c6f1af7d`, predecessor
 `f89318a58c9038a888419f9a0720478c1cf1a325`, and candidate
 `57731b2af496a4e382d263bbfe123bc219f6bd51`. The frozen control-runner
 `tools/qualify_recurrent_cuda.py` SHA-256 is
-`4b8519da01edcff7ee203e8114b3ef4aa8fb673df63cb9ce0b83e34baa6ba646`.
+`65dd97f2abffdd243655caa0d5bbf34e5e2eab164e8a567b9eaae305c178e7a8`.
 
-The earlier control root at commit `9274f45480d5bfff7943d3ce80fbc15c96760665`
-is retained as immutable rejection evidence. Its first predecessor capture
-proved that the old runner dereferenced the explicitly supplied venv Python
-symlink and therefore launched the managed base interpreter without the venv's
-packages. The rejected empty output is preserved only at
-`<artifacts>/predecessor-throughput-attempt1-rejected-python-resolve`; the
-authorized `<artifacts>/predecessor-throughput` target must remain absent before
-the corrected capture. The old runner is not an executable qualification
-authority. Only the merged runner identity above may create new throughput or
+The earlier control roots are retained as immutable rejection evidence. The
+first root, at commit `9274f45480d5bfff7943d3ce80fbc15c96760665`, proved
+that the old runner dereferenced the explicitly supplied venv Python symlink
+and therefore launched the managed base interpreter without the venv's
+packages. Its rejected empty output is preserved only at
+`<artifacts>/predecessor-throughput-attempt1-rejected-python-resolve`. The
+second root, at commit `ffa49adfd71644fe3ffa10106df1fcdc7421b0c7`, fixed
+that interpreter defect but attempted the complete 131,072-transition rollout
+as one learner minibatch, rather than matching the canary's fixed 16,384
+minibatch, and failed before any transition with a CUDA allocation error. Its
+rejected output is preserved only at
+`<artifacts>/predecessor-throughput-attempt2-rejected-cuda-oom`. The authorized
+`<artifacts>/predecessor-throughput` target must remain absent before the
+corrected capture. Neither old runner is an executable qualification authority.
+Only the merged runner identity above may create new throughput or
 qualification evidence.
 
 The predecessor installer SHA-256 is
@@ -73,7 +79,7 @@ Any absence, addition, reordering, or digest mismatch rejects that runtime.
 Target roots are pairwise distinct and outside the protected recovery tree:
 
 ```text
-/home/rache/bloodbowl-rl-qualification-control-20260722-v2
+/home/rache/bloodbowl-rl-qualification-control-20260722-v3
 /home/rache/bloodbowl-rl-qualification-predecessor-afc8008
 /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e
 /home/rache/bloodbowl-rl-qualification-artifacts-20260722
@@ -210,6 +216,7 @@ capture-throughput
 --throughput-horizon 64
 --throughput-hidden 512
 --throughput-layers 3
+--throughput-minibatch-size 16384
 --throughput-warmup-rollouts 2
 --throughput-timed-rollouts 8
 ```
@@ -217,8 +224,11 @@ capture-throughput
 Require `THROUGHPUT_BASELINE.json`, its confined cell record, exact runner
 identity, expected predecessor identity, literal zero for the exact ordered
 16-key control hard-integrity registry, and positive internally consistent
-timing. Preserve the complete output and hashes before constructing the
-candidate runtime.
+timing. The runner itself rejects any operator-supplied throughput minibatch
+other than 16,384. Require the emitted configuration to bind that exact value,
+and preserve its configuration hash for equality with the candidate throughput
+cell. Preserve the complete output and hashes before constructing the candidate
+runtime.
 
 ## Candidate qualification
 
@@ -253,11 +263,15 @@ run
 --throughput-horizon 64
 --throughput-hidden 512
 --throughput-layers 3
+--throughput-minibatch-size 16384
 --throughput-warmup-rollouts 2
 --throughput-timed-rollouts 8
 ```
 
-The runner itself rejects any regression-budget value other than 0.10. Every
+The runner itself rejects any regression-budget value other than 0.10 and any
+operator-supplied throughput minibatch other than 16,384. The predecessor and
+candidate throughput configurations and configuration hashes must be exactly
+equal. Every
 transition-executing cell—graph off/on, terminal automatic/control, ratio, and
 throughput—must bind the exact ordered 16-key control registry at literal zero;
 construction is the sole exemption because it performs no transition and emits


### PR DESCRIPTION
## Summary
- bind both 2070 execution checklists to merged runner 2261cd4 and fresh v3 control root
- preserve both rejected predecessor attempts as immutable evidence
- make the 16,384 throughput minibatch explicit in predecessor, candidate, canary-manifest, and stopped-analysis gates

## Verification
- `git diff --check`
- exact runner tree and SHA-256 recomputed from merged main
- stopped analyzer and live guard SHA-256 recomputed from merged main
- stale executable v2 identities searched; only the intentionally historical rejected v2 commit remains
- runner/analyzer test suites were green on the exact merged code in PR #62; this PR changes documentation only

## Safety boundary
This does not launch or mutate training. It preserves the literal-zero integrity budget and keeps qualification/canary output ancestry- and reward-evidence-ineligible.