### PR TITLE
Warm CUDA graphs before qualification capture

### DIFF
--- a/.claude/skills/puffer-env-dev/SKILL.md
+++ b/.claude/skills/puffer-env-dev/SKILL.md
@@ -400,7 +400,11 @@ off because PPO does not retain each segment's initial recurrent state.
 Evaluation starts from fresh games, preserves state across nonterminal rollout
 calls, and clears a terminal row before forwarding the next game's observation.
 Keep the captured device-gated reset launch proportional to active rows, not
-layers × rows × hidden size. Source tests are not CUDA acceptance: before a run,
+layers × rows × hidden size. Graph-enabled qualification cells must use
+`cudagraphs=10`, matching the frozen Puffer/canary warmup boundary. Reject `0`
+because it captures the first execution before CUDA lazy initialization, and
+reserve `-1` for the explicit graph-off parity cell. Source tests are not CUDA
+acceptance: before a run,
 measure graph-on/off deterministic parity and throughput, primary/frozen
 post-terminal parity, construction checksums, and zero-update ratios on the
 target GPU.

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -146,7 +146,10 @@ checkpoints, and remember that stopped instances can be reclaimed.
   frozen state after CUDA graph warmup, graph-on/off deterministic active-row output
   parity, fresh train→eval game boundaries, primary/frozen post-terminal parity,
   Torch/native parity, finite exact zero-update ratios, and target-GPU
-  throughput without material regression. Training requires
+  throughput without material regression. Every graph-enabled qualification
+  cell uses `cudagraphs=10`, matching the frozen Puffer/canary warmup boundary;
+  `0` is rejected because it captures the first execution, and `-1` is reserved
+  for the explicit graph-off parity cell. Training requires
   `reset_state=True`; direct training while evaluation mode is active fails.
   Do not infer these guarantees from patch markers or CPU tests. Use the
   post-boundary fp32 `tools/qualify_recurrent_cuda.py` gate with a predeclared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,7 +533,10 @@ changes a reward, active queue, production default, or promotion verdict.
   off; persistent-state training is unsupported because recomputation does not
   capture trajectory initial state. Evaluation starts from fresh games, carries
   state across rollout-call boundaries, and zeros each terminal row before the
-  next game's observation. The graph-captured reset launch must be row-sized,
+  next game's observation. Graph-enabled qualification cells must use
+  `cudagraphs=10`, matching the frozen Puffer/canary warmup boundary; `0` means
+  capture on the first execution and is invalid, while `-1` is reserved for the
+  explicit graph-off parity cell. The graph-captured reset launch must be row-sized,
   not hidden-state-sized. Before a repaired run, require graph-on/off output
   parity, primary/frozen post-terminal parity, exact-zero construction checks,
   zero-update ratio parity, and a measured no-regression throughput smoke on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,7 +269,11 @@ newer evidence wins.
   Graph warmup restores primary and every frozen-bank state to exact zero;
   train→eval starts fresh games and clears state once; nonterminal evaluation
   state persists across rollout calls; terminal rows clear before the next
-  game's observation. Training is allowed only with `reset_state=True` and
+  game's observation. Graph-enabled qualification cells use `cudagraphs=10`,
+  exactly matching the frozen Puffer/canary warmup boundary. Reject `0` because
+  it captures the first execution before CUDA lazy initialization; reserve `-1`
+  for the explicit graph-off parity cell. Training is allowed only with
+  `reset_state=True` and
   evaluation mode off. Do not ship a hidden-state-sized no-op reset launch:
   keep the captured gate row-sized, then measure graph-on/off parity, target-GPU
   throughput, primary/frozen post-terminal parity, and zero-update ratios before

--- a/docs/plans/recurrent-cuda-qualification.md
+++ b/docs/plans/recurrent-cuda-qualification.md
@@ -133,7 +133,12 @@ turn that limitation into a fail-closed coverage gate.
 Measure a frozen number of warmup and timed rollouts in fresh graph-enabled
 subprocesses using the target production shape. Compare decisions per second to
 an immutable report from the immediately preceding exact-action backend on the
-same idle host and configuration. The predecessor is accepted only through the
+same idle host and configuration. The production graph boundary is exact:
+every graph-enabled cell uses `cudagraphs=10`, matching the frozen
+Puffer/canary default, while only the explicit graph-off parity cell may use
+`-1`. Zero is not a boolean false value; it captures the first execution before
+CUDA library lazy initialization and is rejected before backend load. The
+predecessor is accepted only through the
 exact hashed `preceding_exact_action_throughput_baseline` wrapper and its confined,
 hashed cell record. Its clean source root and commit plus
 module/backend/environment hashes must be predeclared

--- a/tools/qualify_recurrent_cuda.py
+++ b/tools/qualify_recurrent_cuda.py
@@ -84,6 +84,9 @@ GRAPH_ATOL_BY_PRECISION = {4: 1.0e-6}
 RATIO_ATOL_BY_PRECISION = {4: 2.0e-5}
 DEFAULT_RATIO_CALL_LIMIT = 64
 DEFAULT_MAX_REGRESSION_FRACTION = 0.10
+# Puffer's cudagraph setting is a warmup-epoch count, not a boolean. Match the
+# frozen canary/default so CUDA libraries initialize before capture begins.
+DEFAULT_CUDAGRAPH_WARMUP_EPOCHS = 10
 # Match the frozen exact-action canary rather than allocating train activations
 # for its entire 2,048 x 64 rollout quantum at once.
 DEFAULT_THROUGHPUT_MINIBATCH_SIZE = 16384
@@ -632,6 +635,9 @@ def validate_baseline_artifact(path: Path) -> dict[str, Any]:
             or cell.get("preceding_runtime") is not True
             or cell.get("runner_sha256") != current_runner_hash):
         raise QualificationError("throughput predecessor cell role is invalid")
+    validate_cell_cudagraph_record(
+        cell, expected=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS
+    )
     identity = cell.get("identity")
     if not isinstance(identity, Mapping):
         raise QualificationError("throughput predecessor identity is missing")
@@ -882,6 +888,47 @@ def validate_throughput_minibatch(
     return minibatch_size
 
 
+def validate_cell_cudagraphs(kind: str, cudagraphs: int) -> int:
+    if cudagraphs == -1:
+        if kind == "rollout":
+            return cudagraphs
+        raise QualificationError(
+            "cudagraphs=-1 is reserved for the explicit graph-off rollout cell"
+        )
+    if cudagraphs != DEFAULT_CUDAGRAPH_WARMUP_EPOCHS:
+        raise QualificationError(
+            "graph-enabled qualification cells require the exact-action "
+            f"canary warmup boundary {DEFAULT_CUDAGRAPH_WARMUP_EPOCHS}"
+        )
+    return cudagraphs
+
+
+def validate_cell_cudagraph_record(
+    record: Mapping[str, Any], *, expected: int
+) -> dict[str, Any]:
+    config = record.get("config")
+    if not isinstance(config, Mapping):
+        raise QualificationError("qualification cell config is missing")
+    config = dict(config)
+    observed = config.get("cudagraphs")
+    if (
+        not isinstance(observed, int)
+        or isinstance(observed, bool)
+        or observed != expected
+    ):
+        raise QualificationError(
+            "qualification cell cudagraph warmup differs from its frozen role"
+        )
+    if record.get("config_sha256") != canonical_hash(config):
+        raise QualificationError("qualification cell config digest mismatch")
+    throughput = record.get("throughput")
+    if isinstance(throughput, Mapping) and throughput.get(
+        "config_sha256"
+    ) != record.get("config_sha256"):
+        raise QualificationError("qualification throughput config digest mismatch")
+    return config
+
+
 def _load_backend(puffer_root: Path, *, require_qualification: bool = True):
     root = Path(puffer_root).resolve()
     sys.path.insert(0, str(root))
@@ -1049,6 +1096,7 @@ def _load_frozen_from_primary(_C, pufferl, directory: Path, banks: int) -> None:
 
 
 def _cell_config(kind: str, cudagraphs: int, args: argparse.Namespace) -> dict[str, Any]:
+    cudagraphs = validate_cell_cudagraphs(kind, cudagraphs)
     if kind in {"construction", "rollout", "terminal_auto", "terminal_control"}:
         return qualification_args(
             cudagraphs=cudagraphs,
@@ -1066,7 +1114,7 @@ def _cell_config(kind: str, cudagraphs: int, args: argparse.Namespace) -> dict[s
         )
     if kind == "ratio":
         return qualification_args(
-            cudagraphs=0,
+            cudagraphs=cudagraphs,
             seed=args.seed,
             total_agents=8,
             num_buffers=2,
@@ -1081,7 +1129,7 @@ def _cell_config(kind: str, cudagraphs: int, args: argparse.Namespace) -> dict[s
         )
     if kind == "throughput":
         return qualification_args(
-            cudagraphs=0,
+            cudagraphs=cudagraphs,
             seed=args.seed,
             total_agents=args.throughput_agents,
             num_buffers=args.throughput_buffers,
@@ -1353,6 +1401,7 @@ def _run_worker(
     record = _read_json(json_path)
     if record.get("accepted") is not True or record.get("qualification_only") is not True:
         raise QualificationError(f"qualification cell {name} is not accepted/isolated")
+    validate_cell_cudagraph_record(record, expected=cudagraphs)
     if kind in TRANSITION_CELL_KINDS:
         validate_transition_cell_integrity(record, kind)
     record["record_path"] = str(json_path)
@@ -1695,7 +1744,8 @@ def run_qualification(args: argparse.Namespace) -> int:
     records: list[dict[str, Any]] = []
 
     construction = _run_worker(
-        args, kind="construction", name="construction", cudagraphs=0, output=output
+        args, kind="construction", name="construction",
+        cudagraphs=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS, output=output
     )
     records.append(construction)
     construction_identity = construction.get("identity")
@@ -1713,7 +1763,8 @@ def run_qualification(args: argparse.Namespace) -> int:
         args, kind="rollout", name="graph-off", cudagraphs=-1, output=output
     )
     graph_on = _run_worker(
-        args, kind="rollout", name="graph-on", cudagraphs=0, output=output
+        args, kind="rollout", name="graph-on",
+        cudagraphs=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS, output=output
     )
     records.extend((graph_off, graph_on))
     identity = _require_same_identity(records)
@@ -1743,13 +1794,14 @@ def run_qualification(args: argparse.Namespace) -> int:
     }
 
     terminal_auto = _run_worker(
-        args, kind="terminal_auto", name="terminal-auto", cudagraphs=0, output=output
+        args, kind="terminal_auto", name="terminal-auto",
+        cudagraphs=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS, output=output
     )
     terminal_control = _run_worker(
         args,
         kind="terminal_control",
         name="terminal-control",
-        cudagraphs=0,
+        cudagraphs=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS,
         output=output,
     )
     records.extend((terminal_auto, terminal_control))
@@ -1778,7 +1830,8 @@ def run_qualification(args: argparse.Namespace) -> int:
     }
 
     ratio = _run_worker(
-        args, kind="ratio", name="ratio", cudagraphs=0, output=output
+        args, kind="ratio", name="ratio",
+        cudagraphs=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS, output=output
     )
     records.append(ratio)
     _require_same_identity(records)
@@ -1823,7 +1876,8 @@ def run_qualification(args: argparse.Namespace) -> int:
     }
 
     throughput = _run_worker(
-        args, kind="throughput", name="throughput", cudagraphs=0, output=output
+        args, kind="throughput", name="throughput",
+        cudagraphs=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS, output=output
     )
     records.append(throughput)
     _require_same_identity(records)
@@ -1965,6 +2019,12 @@ def validate_qualification(path: Path) -> dict[str, Any]:
         if (record.get("kind") != entry.get("kind")
                 or expected_kinds.get(name) != record.get("kind")):
             raise QualificationError(f"qualification cell kind drifted: {name}")
+        expected_cudagraphs = (
+            -1 if name == "graph-off" else DEFAULT_CUDAGRAPH_WARMUP_EPOCHS
+        )
+        validate_cell_cudagraph_record(
+            record, expected=expected_cudagraphs
+        )
         if record["kind"] in TRANSITION_CELL_KINDS:
             validate_transition_cell_integrity(record, record["kind"])
         artifact = entry.get("artifact")
@@ -2205,7 +2265,8 @@ def capture_throughput(args: argparse.Namespace) -> int:
     )
     output.mkdir(parents=True, exist_ok=True)
     record = _run_worker(
-        args, kind="throughput", name="throughput-baseline", cudagraphs=0,
+        args, kind="throughput", name="throughput-baseline",
+        cudagraphs=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS,
         output=output, preceding_runtime=True,
     )
     expected_predecessor = {
@@ -2342,6 +2403,7 @@ def main(argv: list[str] | None = None) -> int:
         args.throughput_minibatch_size,
     )
     if args.command == "cell":
+        validate_cell_cudagraphs(args.kind, args.cudagraphs)
         return run_cell(args)
     if args.command == "capture-throughput":
         return capture_throughput(args)

--- a/training/test_recurrent_cuda_qualification.py
+++ b/training/test_recurrent_cuda_qualification.py
@@ -372,9 +372,11 @@ class QualificationValidatorTests(unittest.TestCase):
             "compiled_env": "bloodbowl", "qualification_surface": False,
         }
         integrity = {key: 0.0 for key in self.q.HARD_INTEGRITY_KEYS}
+        config = {"cudagraphs": self.q.DEFAULT_CUDAGRAPH_WARMUP_EPOCHS}
+        config_digest = self.q.canonical_hash(config)
         throughput = {
             "host": "rtx2070", "gpu": "RTX 2070", "precision_bytes": 4,
-            "config_sha256": "c" * 64, "steps_per_second": 1000.0,
+            "config_sha256": config_digest, "steps_per_second": 1000.0,
             "hard_integrity_zero": True, "hard_integrity": integrity,
             "steps": 1000, "elapsed_seconds": 1.0,
             "median_rollout_seconds": 0.1, "p95_rollout_seconds": 0.2,
@@ -404,7 +406,7 @@ class QualificationValidatorTests(unittest.TestCase):
                 "kind": "throughput", "preceding_runtime": True,
                 "runner_sha256": self.q.sha256(RUNNER),
                 "identity": identity, "throughput": throughput,
-                "config_sha256": "c" * 64,
+                "config": config, "config_sha256": config_digest,
                 "predecessor_source": source,
                 "runner_source": runner_source,
             }
@@ -566,7 +568,13 @@ class QualificationValidatorTests(unittest.TestCase):
                 cell_timeout_seconds=1800,
             )
             completed = mock.Mock(returncode=0, stdout="", stderr="")
-            record = {"accepted": True, "qualification_only": True}
+            config = {"cudagraphs": 10}
+            record = {
+                "accepted": True,
+                "qualification_only": True,
+                "config": config,
+                "config_sha256": self.q.canonical_hash(config),
+            }
             with mock.patch.object(
                 self.q.subprocess, "run", return_value=completed
             ) as run, mock.patch.object(self.q, "_read_json", return_value=record):
@@ -574,14 +582,94 @@ class QualificationValidatorTests(unittest.TestCase):
                     args,
                     kind="construction",
                     name="construction",
-                    cudagraphs=0,
+                    cudagraphs=10,
                     output=output,
                 )
             command = run.call_args.args[0]
             self.assertEqual(command[0], str(venv_python.absolute()))
             self.assertNotEqual(command[0], str(base_python.resolve()))
+            cudagraph_flag = command.index("--cudagraphs")
+            self.assertEqual(command[cudagraph_flag + 1], "10")
             minibatch_flag = command.index("--throughput-minibatch-size")
             self.assertEqual(command[minibatch_flag + 1], "16384")
+
+    def test_graph_capture_requires_production_warmup_boundary(self):
+        args = mock.Mock(
+            seed=271828,
+            throughput_agents=2048,
+            throughput_buffers=2,
+            throughput_threads=16,
+            throughput_horizon=64,
+            throughput_hidden=512,
+            throughput_layers=3,
+            throughput_minibatch_size=16384,
+        )
+        self.assertEqual(self.q.DEFAULT_CUDAGRAPH_WARMUP_EPOCHS, 10)
+        for kind in (
+            "construction", "rollout", "terminal_auto", "terminal_control",
+            "ratio", "throughput",
+        ):
+            with self.subTest(kind=kind):
+                self.assertEqual(
+                    self.q.validate_cell_cudagraphs(kind, 10), 10
+                )
+                self.assertEqual(
+                    self.q._cell_config(kind, 10, args)["cudagraphs"], 10
+                )
+                with self.assertRaises(self.q.QualificationError):
+                    self.q.validate_cell_cudagraphs(kind, 0)
+        self.assertEqual(self.q.validate_cell_cudagraphs("rollout", -1), -1)
+        for kind in (
+            "construction", "terminal_auto", "terminal_control", "ratio",
+            "throughput",
+        ):
+            with self.subTest(graph_off_kind=kind), self.assertRaises(
+                self.q.QualificationError
+            ):
+                self.q.validate_cell_cudagraphs(kind, -1)
+        runner = RUNNER.read_text(encoding="utf-8")
+        self.assertNotIn("cudagraphs=0", runner)
+        self.assertEqual(
+            runner.count("cudagraphs=DEFAULT_CUDAGRAPH_WARMUP_EPOCHS"), 7
+        )
+
+    def test_cell_rejects_zero_warmup_before_runtime_dispatch(self):
+        argv = [
+            "cell",
+            "--puffer-root", "/tmp/puffer",
+            "--kind", "throughput",
+            "--cudagraphs", "0",
+            "--output-json", "/tmp/throughput.json",
+        ]
+        with mock.patch.object(self.q, "run_cell") as run_cell, self.assertRaises(
+            self.q.QualificationError
+        ):
+            self.q.main(argv)
+        run_cell.assert_not_called()
+
+    def test_cudagraph_record_rejects_coherent_zero_warmup_mutation(self):
+        record = {"config": {"cudagraphs": 10}}
+        record["config_sha256"] = self.q.canonical_hash(record["config"])
+        self.q.validate_cell_cudagraph_record(record, expected=10)
+
+        record["config"]["cudagraphs"] = 0
+        record["config_sha256"] = self.q.canonical_hash(record["config"])
+        with self.assertRaises(self.q.QualificationError):
+            self.q.validate_cell_cudagraph_record(record, expected=10)
+
+        record["config"]["cudagraphs"] = 10.0
+        record["config_sha256"] = self.q.canonical_hash(record["config"])
+        with self.assertRaises(self.q.QualificationError):
+            self.q.validate_cell_cudagraph_record(record, expected=10)
+
+        record["config"]["cudagraphs"] = 10
+        with self.assertRaises(self.q.QualificationError):
+            self.q.validate_cell_cudagraph_record(record, expected=10)
+
+        record["config_sha256"] = self.q.canonical_hash(record["config"])
+        record["throughput"] = {"config_sha256": "a" * 64}
+        with self.assertRaises(self.q.QualificationError):
+            self.q.validate_cell_cudagraph_record(record, expected=10)
 
     def test_throughput_minibatch_matches_exact_canary_contract(self):
         args = mock.Mock(
@@ -594,19 +682,20 @@ class QualificationValidatorTests(unittest.TestCase):
             throughput_layers=3,
             throughput_minibatch_size=16384,
         )
-        config = self.q._cell_config("throughput", 0, args)
+        config = self.q._cell_config("throughput", 10, args)
         rollout_quantum = (
             config["vec"]["total_agents"] * config["train"]["horizon"]
         )
         self.assertEqual(rollout_quantum, 131072)
         self.assertEqual(config["train"]["minibatch_size"], 16384)
+        self.assertEqual(config["cudagraphs"], 10)
 
     def test_throughput_minibatch_parser_default_is_frozen(self):
         args = self.q.parse_args([
             "cell",
             "--puffer-root", "/tmp/puffer",
             "--kind", "throughput",
-            "--cudagraphs", "0",
+            "--cudagraphs", "10",
             "--output-json", "/tmp/throughput.json",
         ])
         self.assertEqual(self.q.DEFAULT_THROUGHPUT_MINIBATCH_SIZE, 16384)
@@ -653,7 +742,7 @@ class QualificationValidatorTests(unittest.TestCase):
 
     def test_qualification_minibatch_must_fit_rollout_contract(self):
         base = {
-            "cudagraphs": 0,
+            "cudagraphs": 10,
             "seed": 271828,
             "total_agents": 2048,
             "num_buffers": 2,
@@ -861,6 +950,7 @@ class QualificationPatchContractTests(unittest.TestCase):
         self.assertIn("--candidate-source-root", plan)
         self.assertIn("Independently pass `--predecessor-source-root`", plan)
         self.assertIn("Do not modify or reuse the recovery Puffer tree", plan)
+        self.assertIn("`cudagraphs=10`", plan)
         self.assertNotIn("On the still-installed predecessor", plan)
         for path in (AGENTS, CLAUDE, PUFFER_SKILL, TRAINING_SKILL):
             with self.subTest(path=path):
@@ -869,6 +959,7 @@ class QualificationPatchContractTests(unittest.TestCase):
                 self.assertIn(candidate, text)
                 self.assertIn("different isolated source", text)
                 self.assertIn("recovery Puffer tree", text)
+                self.assertIn("`cudagraphs=10`", text)
 
         runner = RUNNER.read_text(encoding="utf-8")
         self.assertEqual(q.PREDECESSOR_SOURCE_COMMIT, predecessor)


### PR DESCRIPTION
## Summary
- match every graph-enabled qualification cell to the frozen Puffer/canary `cudagraphs=10` warmup boundary
- preserve `-1` only for the explicit graph-off parity cell and reject zero before backend load
- stop ratio/throughput config builders from overwriting the requested graph schedule
- independently validate persisted graph schedule plus canonical config/throughput hashes
- document the invariant in the plan, AGENTS.md, CLAUDE.md, and both relevant repository skills

## Fail-first evidence
Against merged main, the new tests produced three independent failures: missing frozen graph-warmup constant, zero accepted before runtime dispatch, and throughput config silently recording zero instead of ten. A further coherent-hash mutation test failed before its validator was implemented.

## Verification
- 33 recurrent-CUDA qualification tests pass
- 19 stopped reward-screen analyzer tests pass
- Ruff, Python byte compilation, and `git diff --check` pass
- independent CUDA/source review: no P0-P3 findings

## Runtime evidence
The predecessor attempt with `cudagraphs=0` rejected at `cudaStreamEndCapture` before evidence. Source tracing shows first-use cuBLAS/workspace allocation occurs inside that capture. The failed attempt is preserved; BBTV is restored; candidate qualification was not run; the authorized baseline path remains absent.

## Safety boundary
This PR does not alter Puffer binaries, rewards, actions, observations, or exact-zero gates. It changes only the clean control runner and its contracts. A new merged runner identity and fresh isolated control root are required before retry.