### PR TITLE
Close exact-action canary lock authority

### DIFF
--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -184,6 +184,12 @@ with evaluation mode off. A row-sized captured reset gate is acceptable; a
 layers × rows × hidden no-op launch is not. Any mismatch consumes the entire
 error budget and blocks the canary.
 
+For canary plan-only closure, account for the launcher's persistent ownership
+inode. The output must contain exactly `SCREEN_MANIFEST.json` and a regular
+zero-byte `.screen.lock`; require the empty-file SHA-256, prove the lock is
+released with nonblocking `flock`, and bind both files' modes, sizes, and
+digests. Do not delete the lock or tolerate any third entry.
+
 A final training Steps line is not completion. The audited evaluator may continue
 until the completed-game gate is satisfied. Do not kill it merely because the
 dashboard is no longer advancing training steps. Acceptance requires the explicit

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -141,6 +141,13 @@ checkpoints, and remember that stopped instances can be reclaimed.
   Launch it with both `WARM` and `POOL` absent (use `env -u WARM -u POOL` when
   the shell may inherit them). It uses zero frozen banks, and its output is
   permanently marked qualification-only; do not continue from it.
+- The frozen screen launcher creates `$OUT_DIR/.screen.lock` before manifest
+  freezing and retains the inode as its one-screen ownership surface. A canary
+  plan-only output must contain exactly two regular files:
+  `SCREEN_MANIFEST.json` and a zero-byte `.screen.lock`. Hash both and their
+  modes/sizes, and require a successful nonblocking `flock` after the plan
+  process exits. Never remove the lock to force one-file closure; missing,
+  nonempty, held, or additional output rejects that canary identity.
 - The recurrent runtime is part of the frozen implementation identity. Before
   the exact-action canary, a fresh isolated build must prove zero primary and
   frozen state after CUDA graph warmup, graph-on/off deterministic active-row output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Contract tests inspect the exact immutable launcher blob that will
+          # execute the qualification canary, not only today's control copy.
+          fetch-depth: 0
       - name: Install deps
         run: |
           pip install pyyaml numpy
@@ -46,11 +50,12 @@ jobs:
             tools/install_puffer_env.sh \
             tools/run_reward_ablation.sh \
             tools/run_reward_screen.sh
-      - name: BC corpus filtering and bounded streaming
+      - name: BC corpus filtering, bounded streaming, and qualification contracts
         run: |
           PYTHONPATH=training python3 -m unittest \
             training.test_bc_pretrain_filter \
-            training.test_bc_pretrain_streaming
+            training.test_bc_pretrain_streaming \
+            training.test_recurrent_cuda_qualification
       - name: Build + unit tests
         run: make test
       - name: ASan/UBSan tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,14 @@ For any causal comparison:
   invalid evidence. Do not dirty or relabel the exact candidate to widen its
   manifest; freeze both registries and use the stricter 16-key control verdict
   for qualification and final canary acceptance.
+- `run_reward_screen.sh` creates `$OUT_DIR/.screen.lock` before freezing a
+  screen manifest and intentionally leaves that ownership inode in place. A
+  canary plan-only output is therefore closed only when it contains exactly two
+  regular files: `SCREEN_MANIFEST.json` and a zero-byte `.screen.lock`. Require
+  the empty-file digest, prove the lock is released with nonblocking `flock`,
+  and hash its mode/size with the manifest. Never delete the lock to make a
+  one-file checklist pass; a missing, nonempty, held, or extra entry rejects the
+  canary identity.
 - On an episode-ending step, preserve explicit objective reward (TD) and result
   utility, but do not let incidental action/board shaping co-stack with the
   terminal result. Keep deliberately episode-terminal terms separately visible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,12 @@ newer evidence wins.
   the canary only from the exact immutable `a52fc6e2` checkout. The merged
   control launcher rejects that profile before creating output because its
   widened registry is intentionally not the frozen candidate manifest.
+  The frozen screen launcher intentionally creates and retains
+  `$OUT_DIR/.screen.lock` before plan freezing. Plan-only closure is exactly two
+  regular files: `SCREEN_MANIFEST.json` plus a zero-byte, empty-digest,
+  nonblocking-`flock`-verified released `.screen.lock`, with both modes, sizes,
+  and hashes bound. Do not delete the lock to satisfy a stale one-file
+  checklist; any missing, held, nonempty, or extra entry rejects the canary.
 - **`puffer/bloodbowl/` is the SOURCE OF TRUTH; `vendor/PufferLib/ocean/bloodbowl/` is an installed snapshot** written by `tools/install_puffer_env.sh` — the build compiles the snapshot, NOT your edit. The snapshot can lag (the Mac checkout's may still say 1612). Drift guard: `tools/install_puffer_env.sh --check` (exit 1 = re-install). Run it before any build on a training box.
 - After ANY env code change, ON THE TARGET: `bash tools/install_puffer_env.sh`,
   `bash tools/install_puffer_env.sh --check`, then

--- a/docs/exact-action-canary-2070-execution-checklist.md
+++ b/docs/exact-action-canary-2070-execution-checklist.md
@@ -25,10 +25,10 @@ qualification.
 - Qualification root:
   `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification`
 - Canary output:
-  `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1`
+  `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v2`
 - Stopped-validation output:
-  `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1-validation`
-- Unit name: `bloodbowl-exact-action-canary-50m-s42-v1.service`
+  `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v2-validation`
+- Unit name: `bloodbowl-exact-action-canary-50m-s42-v2.service`
 - Requested agent steps: exactly `50000000`
 - Rollout quantum: exactly `131072` (`2048 * 64`)
 - Minibatch size: exactly `16384`
@@ -43,6 +43,35 @@ qualification.
 - Qualification and canary ancestry eligibility: permanently false
 - Hard-integrity contamination budget: literal zero
 - Live detection interval: at most 30 seconds plus one dashboard emission
+
+The superseded v1 plan-only attempt is immutable rejection evidence, not launch
+authority. The frozen launcher exited zero and wrote its valid manifest, but it
+also intentionally created the persistent zero-byte `.screen.lock` used by the
+one-screen ownership contract. The earlier checklist allowed only the manifest,
+so v1 was rejected before training. Its final preserved location is
+`/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1-plan-rejected-unaccounted-lock`.
+The exact rejection-only evidence is:
+
+| Artifact | Absolute path | SHA-256 |
+|---|---|---|
+| Manifest | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1-plan-rejected-unaccounted-lock/SCREEN_MANIFEST.json` | `15271d946e404ddcd26e9fc075d44b9dbeaa268b6e5e9ffecf536abfd212a331` |
+| Zero-byte lock | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1-plan-rejected-unaccounted-lock/.screen.lock` | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` |
+| Mode/size inventory | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1-plan-rejected-files.tsv` | `6d69a4deb85698279f100079ee6bb3b785af9b36d97cefeb7cc4f11389ce35f7` |
+| Closed content inventory | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1-plan-rejected-inventory.sha256` | `2756134a67dfc8010c13d16eb30533b82671580e6e5eb049f430f813ef7482e4` |
+| Rejection record | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1-plan-rejection.txt` | `68d92db88481fb9aaa06b0e31e80429f5da9904b20ef39e6ed15dcad3f551618` |
+
+The mode/size inventory is the two headerless, bytewise-sorted TSV rows
+`mode<TAB>bytes<TAB>relative-path`, where mode is exactly three octal permission
+digits from GNU `find -printf '%m'` with no prefix. The closed content inventory
+is the two bytewise-sorted `sha256<TWO-SPACES>relative-path` rows. Recompute both
+from the preserved output while excluding the external evidence files
+themselves. The rejected, never-installed unit identity was
+`bloodbowl-exact-action-canary-50m-s42-v1.service`; Gate 1 must prove both that
+unit and its unit file absent.
+No trainer, log, checkpoint, run directory, completion artifact, or GPU compute
+process was created. Do not delete, relabel, launch, or reuse the v1 output or
+unit identity. Only the fresh v2 paths above may proceed under this corrected
+authority.
 
 Candidate launch-source SHA-256 identities are:
 
@@ -86,7 +115,13 @@ materialization:
    still match the accepted qualification.
 6. No recovery trainer, qualification cell, evaluator, or other GPU compute
    process remains. BBTV follower state and public HTTP health are recorded.
-7. The canary output path and unit name do not exist.
+7. The canary output path and unit name do not exist. The exact superseded v1
+   unit identity named above is also absent from the user systemd manager and
+   its unit-file directory, and the original pre-rejection v1 output path
+   `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1`
+   is absent rather than copied alongside its renamed rejection directory.
+8. Recompute the five rejection-only evidence hashes and both canonical
+   inventories above from their exact paths; every value must still match.
 
 Any mismatch stops deployment. Do not delete or overwrite an existing output
 to make the precondition true.
@@ -104,15 +139,37 @@ and pool environment:
   OMP_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16 MKL_NUM_THREADS=16 NUMEXPR_NUM_THREADS=16 \
   STEPS=50000000 \
   SCREEN_PROFILE=exact-action-canary \
-  PREFIX=exact-action-canary-50m-s42-v1 \
-  OUT_DIR=/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1 \
+  PREFIX=exact-action-canary-50m-s42-v2 \
+  OUT_DIR=/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v2 \
   POLL_SECONDS=30 PLAN_ONLY=1 ARM_DETACH=0 \
   /usr/bin/bash /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/tools/run_reward_screen.sh
 ```
 
-Require exit zero and a new `SCREEN_MANIFEST.json`, but no trainer, log, run
-directory, result, or completion artifact. Independently validate the manifest
-contract:
+Require exit zero and exactly two regular files directly under the new output:
+`SCREEN_MANIFEST.json` plus `.screen.lock`, with no directory or other entry.
+Complete and accept this regular-file/type inventory before opening the lock;
+never run the probe against a symlink, FIFO, device, directory, or an
+uninventoried path.
+The lock must have zero bytes, the empty-file SHA-256, and a successful
+post-process, non-creating proof that no process retains it:
+
+```text
+( exec 9</home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v2/.screen.lock; flock -n 9 )
+```
+
+The empty-file SHA-256 must be exactly
+`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
+Open the already inventoried absolute path read-only as shown; a pathname-form `flock`
+probe is forbidden because it could create a missing lock and conceal a failed
+inventory. The subshell is mandatory: it closes FD 9 and releases the proof's
+lock before the command returns. Name the first capture the pre-proof inventory.
+Recompute the exact two-file names, regular-file types, modes, sizes, and
+digests as the post-proof inventory and require it to be byte-identical to the
+pre-proof inventory. This
+file is an intentional ownership-control artifact created before manifest
+freezing; deleting it would weaken the launcher's one-screen contract and is
+forbidden. Require no trainer, log, run directory, result, checkpoint, or
+completion artifact. Independently validate the manifest contract:
 
 - one arm `both`, one seed `42`, exact 50M steps;
 - fresh-v5 qualification, `qualification_only=true`;
@@ -127,8 +184,10 @@ contract:
   verdict separately requires all 16 emitted counters;
 - `arm_detach=0` and exact external output path.
 
-Hash the manifest and every plan-only stdout/stderr/command artifact. A
-plan-only rejection, unexpected file, or manifest mismatch blocks the canary.
+Hash the manifest, the zero-byte released lock, the exact two-file mode/size
+inventory, and every plan-only stdout/stderr/command artifact. A plan-only
+rejection, missing/held/nonempty lock, unexpected file or directory, or
+manifest mismatch blocks the canary.
 
 ## Gate 3: hash-bound authorization record
 
@@ -143,7 +202,8 @@ bind, by absolute path plus SHA-256 where applicable:
   environment, patch, CUDA-library, driver, compiler, CPU, and GPU identities;
 - exact stopped-analyzer path/hash and the separate new/empty stopped-validation
   output directory;
-- canary `SCREEN_MANIFEST.json` and output path;
+- canary `SCREEN_MANIFEST.json`, zero-byte released `.screen.lock`, exact
+  two-file plan-only inventory, and output path;
 - exact unit bytes and unit SHA-256;
 - exact canary command and environment;
 - `Restart=no`, `KillMode=control-group`, `ARM_DETACH=0`, and the two-hour
@@ -170,7 +230,7 @@ Type=oneshot
 WorkingDirectory=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e
 ExecStartPre=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin/python /home/rache/bloodbowl-rl-qualification-control-20260722-v4/tools/qualify_recurrent_cuda.py validate /home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification/QUALIFICATION.json
 ExecStartPre=/usr/bin/bash -c 'set -euo pipefail; out="$$(/usr/local/bin/nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)"; stripped="$$(/usr/bin/printf "%s" "$${out}" | /usr/bin/tr -d "[:space:]")"; test -z "$${stripped}"'
-ExecStart=/usr/bin/env -u WARM -u POOL PATH=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CUDA_VISIBLE_DEVICES=0 OMP_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16 MKL_NUM_THREADS=16 NUMEXPR_NUM_THREADS=16 STEPS=50000000 SCREEN_PROFILE=exact-action-canary PREFIX=exact-action-canary-50m-s42-v1 OUT_DIR=/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1 POLL_SECONDS=30 PLAN_ONLY=0 ARM_DETACH=0 /usr/bin/bash /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/tools/run_reward_screen.sh
+ExecStart=/usr/bin/env -u WARM -u POOL PATH=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CUDA_VISIBLE_DEVICES=0 OMP_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16 MKL_NUM_THREADS=16 NUMEXPR_NUM_THREADS=16 STEPS=50000000 SCREEN_PROFILE=exact-action-canary PREFIX=exact-action-canary-50m-s42-v2 OUT_DIR=/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v2 POLL_SECONDS=30 PLAN_ONLY=0 ARM_DETACH=0 /usr/bin/bash /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/tools/run_reward_screen.sh
 Restart=no
 KillMode=control-group
 TimeoutStartSec=7200
@@ -200,7 +260,17 @@ and off-box preservation; it launches no GPU process.
 Then require `systemd-analyze --user verify` success for the exact real unit,
 exact installed unit-byte equality with Gate 3, `systemctl --user is-enabled`
 reporting disabled, and `NRestarts=0`. Do not enable the unit and do not use a
-restart policy.
+restart policy. Immediately before the one allowed start, repeat the Gate 2
+exact two-regular-file inventory, size/digest checks, subshell-scoped released-
+lock proof, and post-proof re-inventory; require exact equality with Gate 3 and
+no third entry. Require the current manifest SHA-256 to equal the Gate 3
+identity. The real launcher intentionally reuses the plan-only output: when
+`SCREEN_MANIFEST.json` already exists it checks schema version 1, recomputes and
+deep-compares the complete nested `contract` object, rejects any drift, and
+does not rewrite it. It leaves the manifest byte-identical. Capture the
+manifest SHA-256 again at the first live poll
+and require exact equality with Gate 3. Any byte change or contract mismatch
+rejects the canary and requires stopping the unit.
 
 ## Gate 5: launch and live monitoring
 

--- a/docs/qualification-2070-execution-checklist.md
+++ b/docs/qualification-2070-execution-checklist.md
@@ -305,13 +305,22 @@ of a separate canary authorization record. That record must bind:
 - runner, predecessor, candidate, Puffer, module, backend, environment,
   package, host, and library identities;
 - the exact plan-only canary output path, whose already authorized contents are
-  limited to `SCREEN_MANIFEST.json` plus captured plan-only command/stdout/
-  stderr evidence and contain no trainer log, result, checkpoint, or completion
-  artifact;
+  limited to exactly two regular files: `SCREEN_MANIFEST.json` and the
+  launcher's zero-byte, released, hash-bound `.screen.lock`; captured plan-only
+  command/stdout/stderr evidence is external, and no trainer log, result,
+  checkpoint, run directory, or completion artifact exists;
 - exact systemd unit bytes/hash and command;
 - `Restart=no`, `KillMode=control-group`, no reboot enablement;
 - an `ExecStartPre` qualification revalidation and empty-GPU-process check;
 - `env -u WARM -u POOL` around the exact one-seed 50M canary launcher.
+
+The real launch must reuse the plan-only output without rewriting its manifest:
+the frozen launcher checks schema version 1, recomputes and deep-compares the
+complete nested stored `contract` object, rejects any drift, and leaves
+`SCREEN_MANIFEST.json` byte-identical. Immediately before unit start, repeat
+the exact two-regular-file inventory and released-lock proof and require it to
+match the authorization. Require the manifest hash to match immediately before
+unit start and at the first live poll.
 
 The canary is fresh obs-v5, fp32, exact-joint, pool-free, warm-free, has zero
 frozen banks, and has a literal zero hard-integrity budget. Qualification

--- a/training/test_recurrent_cuda_qualification.py
+++ b/training/test_recurrent_cuda_qualification.py
@@ -6,6 +6,7 @@ import hashlib
 import importlib.util
 import json
 import pathlib
+import subprocess
 import tempfile
 import unittest
 from unittest import mock
@@ -18,11 +19,15 @@ PATCH = ROOT / "training" / "puffer_recurrent_cuda_qualification.patch"
 PRIO_PATCH = ROOT / "training" / "puffer_frozen_prio_mask.patch"
 INSTALLER = ROOT / "tools" / "install_puffer_env.sh"
 RUNNER = ROOT / "tools" / "qualify_recurrent_cuda.py"
+SCREEN_LAUNCHER = ROOT / "tools" / "run_reward_screen.sh"
 PLAN = ROOT / "docs" / "plans" / "recurrent-cuda-qualification.md"
+QUALIFICATION_CHECKLIST = ROOT / "docs" / "qualification-2070-execution-checklist.md"
+CANARY_CHECKLIST = ROOT / "docs" / "exact-action-canary-2070-execution-checklist.md"
 AGENTS = ROOT / "AGENTS.md"
 CLAUDE = ROOT / "CLAUDE.md"
 PUFFER_SKILL = ROOT / ".claude" / "skills" / "puffer-env-dev" / "SKILL.md"
 TRAINING_SKILL = ROOT / ".claude" / "skills" / "training-experiments" / "SKILL.md"
+FLEET_SKILL = ROOT / ".claude" / "skills" / "fleet-ops" / "SKILL.md"
 
 
 def load_runner():
@@ -936,6 +941,147 @@ class QualificationValidatorTests(unittest.TestCase):
 
 
 class QualificationPatchContractTests(unittest.TestCase):
+    def test_canary_plan_contract_accounts_for_persistent_screen_lock(self):
+        launcher = SCREEN_LAUNCHER.read_text(encoding="utf-8")
+        self.assertEqual(
+            hashlib.sha256(SCREEN_LAUNCHER.read_bytes()).hexdigest(),
+            "8a08e846764a92306440d5e220e9d6ee894c4bc15a7ee1ee75e55c9c2b041df3",
+        )
+        self.assertIn(
+            "exact-action-canary launcher is frozen at candidate "
+            "a52fc6e2f4ece5a7ff16bb4791e3aca4dd72f2e3",
+            launcher,
+        )
+
+        candidate = "a52fc6e2f4ece5a7ff16bb4791e3aca4dd72f2e3"
+        candidate_launcher_bytes = subprocess.run(
+            ["git", "show", f"{candidate}:tools/run_reward_screen.sh"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+        ).stdout
+        self.assertEqual(
+            hashlib.sha256(candidate_launcher_bytes).hexdigest(),
+            "b4ffe9cd6652a0b5f003956015797c458863a8152adcc278b323ba0a329adda8",
+        )
+        candidate_launcher = candidate_launcher_bytes.decode("utf-8")
+        self.assertIn('exec 8>"$OUT_DIR/.screen.lock"', candidate_launcher)
+        self.assertIn("flock -n 8", candidate_launcher)
+        self.assertIn("if destination.exists():", candidate_launcher)
+        self.assertIn(
+            'recorded.get("schema_version") != 1 or recorded.get("contract") != contract',
+            candidate_launcher,
+        )
+        self.assertIn(
+            "screen plan drift; changed top-level contract fields",
+            candidate_launcher,
+        )
+        exists_start = candidate_launcher.index("if destination.exists():")
+        create_else = candidate_launcher.index("\nelse:\n    payload =", exists_start)
+        manifest_print = candidate_launcher.index(
+            "\nprint(sha(destination))", create_else
+        )
+        existing_manifest_branch = candidate_launcher[exists_start:create_else]
+        create_manifest_branch = candidate_launcher[create_else:manifest_print]
+        self.assertIn('recorded.get("contract") != contract', existing_manifest_branch)
+        self.assertNotIn("write_text", existing_manifest_branch)
+        self.assertNotIn("replace(destination)", existing_manifest_branch)
+        self.assertIn("temporary.write_text", create_manifest_branch)
+        self.assertIn("temporary.replace(destination)", create_manifest_branch)
+
+        freeze_start = candidate_launcher.index("freeze_screen_manifest() {")
+        freeze_end = candidate_launcher.index(
+            'SCREEN_MANIFEST_SHA="$(freeze_screen_manifest)"', freeze_start
+        )
+        frozen_contract_builder = candidate_launcher[freeze_start:freeze_end]
+        self.assertNotIn("PLAN_ONLY", frozen_contract_builder)
+
+        checklist = CANARY_CHECKLIST.read_text(encoding="utf-8")
+        normalized_checklist = " ".join(checklist.split())
+        for fragment in (
+            "exact-action-canary-50m-s42-v2",
+            "| `tools/run_reward_screen.sh` | "
+            "`b4ffe9cd6652a0b5f003956015797c458863a8152adcc278b323ba0a329adda8` |",
+            "exactly two regular files",
+            "`SCREEN_MANIFEST.json` plus `.screen.lock`",
+            "zero bytes",
+            "( exec 9</home/rache/bloodbowl-rl-qualification-artifacts-20260722/"
+            "exact-action-canary-50m-s42-v2/.screen.lock; flock -n 9 )",
+            "closes FD 9 and releases the proof's",
+            "pathname-form `flock`",
+            "byte-identical to the pre-proof inventory",
+            "It leaves the manifest byte-identical",
+            "first live poll",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "15271d946e404ddcd26e9fc075d44b9dbeaa268b6e5e9ffecf536abfd212a331",
+            "6d69a4deb85698279f100079ee6bb3b785af9b36d97cefeb7cc4f11389ce35f7",
+            "2756134a67dfc8010c13d16eb30533b82671580e6e5eb049f430f813ef7482e4",
+            "68d92db88481fb9aaa06b0e31e80429f5da9904b20ef39e6ed15dcad3f551618",
+            "exact-action-canary-50m-s42-v1-plan-rejected-files.tsv",
+            "exact-action-canary-50m-s42-v1-plan-rejected-inventory.sha256",
+            "exact-action-canary-50m-s42-v1-plan-rejection.txt",
+            "mode<TAB>bytes<TAB>relative-path",
+            "three octal permission",
+            "sha256<TWO-SPACES>relative-path",
+            "rejected, never-installed unit identity",
+            "pre-proof inventory",
+            "post-proof inventory",
+            "deep-compares the complete nested `contract` object",
+            "repeat the Gate 2",
+            "Do not delete, relabel, launch, or reuse the v1 output",
+        ):
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, normalized_checklist)
+
+        self.assertIn(
+            "`bloodbowl-exact-action-canary-50m-s42-v1.service`; Gate 1 must prove",
+            checklist,
+        )
+        for line in checklist.splitlines():
+            with self.subTest(line=line):
+                if "exact-action-canary-50m-s42-v1" not in line:
+                    continue
+                self.assertNotIn("PREFIX=", line)
+                self.assertNotIn("OUT_DIR=", line)
+                self.assertNotIn("ExecStart=", line)
+                self.assertNotIn("Unit name:", line)
+        self.assertIn("PREFIX=exact-action-canary-50m-s42-v2", checklist)
+        self.assertIn("bloodbowl-exact-action-canary-50m-s42-v2.service", checklist)
+
+        qualification = QUALIFICATION_CHECKLIST.read_text(encoding="utf-8")
+        self.assertIn("zero-byte, released, hash-bound `.screen.lock`", qualification)
+        self.assertIn("exactly two regular files", qualification)
+        self.assertIn(
+            "leaves `SCREEN_MANIFEST.json` byte-identical",
+            " ".join(qualification.split()),
+        )
+
+        required_guidance = {
+            AGENTS: (
+                "run_reward_screen.sh creates $OUT_DIR/.screen.lock",
+                "hash its mode/size with the manifest",
+            ),
+            CLAUDE: (
+                "The frozen screen launcher intentionally creates and retains",
+                "with both modes, sizes, and hashes bound",
+            ),
+            TRAINING_SKILL: (
+                "The frozen screen launcher creates $OUT_DIR/.screen.lock",
+                "Hash both and their modes/sizes",
+            ),
+            FLEET_SKILL: (
+                "For canary plan-only closure, account for the launcher's persistent ownership inode",
+                "bind both files' modes, sizes, and digests",
+            ),
+        }
+        for path, fragments in required_guidance.items():
+            with self.subTest(path=path):
+                normalized = " ".join(
+                    path.read_text(encoding="utf-8").replace("`", "").split()
+                )
+                for fragment in fragments:
+                    self.assertIn(fragment, normalized)
+
     def test_operator_contract_uses_isolated_exact_action_predecessor(self):
         q = load_runner()
         predecessor = "afc8008933548438ca93c41341f5f08fdd294386"


### PR DESCRIPTION
## Summary

- replace the rejected v1 canary identity with a fresh v2 authority that accounts for the launcher-owned zero-byte `.screen.lock`
- require non-creating, subshell-scoped lock-release proofs, exact pre/post inventories, manifest byte invariance, and a repeated pre-start gate
- bind all rejected-v1 evidence and prove the exact immutable candidate launcher behavior separately from the merged fail-closed control launcher
- update AGENTS/CLAUDE and training/fleet guidance, and enforce the qualification contract test in full-history CI

## Validation

- 34 recurrent-CUDA qualification contract tests
- 19 stopped reward-screen analyzer tests
- 442 engine tests plus reward, state-bank, observation, contact-bot, and BBP v4 suites
- Ruff, py_compile, codegen, YAML parse, and diff checks
- independent read-only review: no P0-P3
- Fable headless review: PASS; both residual P3 proofs subsequently closed and rereviewed

No runtime/launcher source bytes, service, remote trainer, or GPU state were changed by this PR. The v1 plan-only output remains immutable rejection evidence and no canary is authorized until this PR is merged and frozen.