### PR TITLE
Correct systemd percent authority for exact-action canary

### DIFF
--- a/.claude/skills/fleet-ops/SKILL.md
+++ b/.claude/skills/fleet-ops/SKILL.md
@@ -190,6 +190,12 @@ zero-byte `.screen.lock`; require the empty-file SHA-256, prove the lock is
 released with nonblocking `flock`, and bind both files' modes, sizes, and
 digests. Do not delete the lock or tolerate any third entry.
 
+When Bash is embedded in a systemd unit, bind both escaping layers: `$$`
+delivers one literal `$` to Bash and `%%` delivers one literal `%`. Author an
+intended `printf "%s"` as `printf "%%s"` in unit bytes; bare `%s` is systemd's
+user-shell specifier. Prove empty-output success plus fixed-output and command-
+failure rejection with disposable units before any real trainer unit install.
+
 A final training Steps line is not completion. The audited evaluator may continue
 until the completed-game gate is satisfied. Do not kill it merely because the
 dashboard is no longer advancing training steps. Acceptance requires the explicit

--- a/.claude/skills/training-experiments/SKILL.md
+++ b/.claude/skills/training-experiments/SKILL.md
@@ -148,6 +148,11 @@ checkpoints, and remember that stopped instances can be reclaimed.
   modes/sizes, and require a successful nonblocking `flock` after the plan
   process exits. Never remove the lock to force one-file closure; missing,
   nonempty, held, or additional output rejects that canary identity.
+- For a systemd-wrapped experiment, freeze the systemd-to-Bash escape boundary:
+  `$$` in unit bytes delivers literal `$`, and `%%` delivers literal `%`.
+  Therefore `printf "%s"` must be authored as `printf "%%s"` in the unit.
+  Bare `%s` expands to the user shell. Run disposable empty-output,
+  fixed-output, and command-failure units before installing the real unit.
 - The recurrent runtime is part of the frozen implementation identity. Before
   the exact-action canary, a fresh isolated build must prove zero primary and
   frozen state after CUDA graph warmup, graph-on/off deterministic active-row output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,11 @@ For any causal comparison:
   and hash its mode/size with the manifest. Never delete the lock to make a
   one-file checklist pass; a missing, nonempty, held, or extra entry rejects the
   canary identity.
+- In systemd unit commands, escape for systemd before Bash: `$$` delivers a
+  literal `$`, and `%%` delivers a literal `%`. A `printf` format intended as
+  `%s` must therefore be written `%%s` in unit bytes. Bare `%s` expands to the
+  user shell and rejects the unit authority; prove empty/fixed/command-failure
+  cases with disposable units before installing a real training unit.
 - On an episode-ending step, preserve explicit objective reward (TD) and result
   utility, but do not let incidental action/board shaping co-stack with the
   terminal result. Keep deliberately episode-terminal terms separately visible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,11 @@ newer evidence wins.
   nonblocking-`flock`-verified released `.screen.lock`, with both modes, sizes,
   and hashes bound. Do not delete the lock to satisfy a stale one-file
   checklist; any missing, held, nonempty, or extra entry rejects the canary.
+  Systemd unit commands have a second escape boundary: use `$$` for a literal
+  Bash dollar and `%%` for a literal Bash percent. The intended `printf "%s"`
+  must appear as `printf "%%s"` in unit bytes; bare `%s` is systemd's user-shell
+  specifier. Require disposable empty/fixed/command-failure probes before real
+  unit installation.
 - **`puffer/bloodbowl/` is the SOURCE OF TRUTH; `vendor/PufferLib/ocean/bloodbowl/` is an installed snapshot** written by `tools/install_puffer_env.sh` — the build compiles the snapshot, NOT your edit. The snapshot can lag (the Mac checkout's may still say 1612). Drift guard: `tools/install_puffer_env.sh --check` (exit 1 = re-install). Run it before any build on a training box.
 - After ANY env code change, ON THE TARGET: `bash tools/install_puffer_env.sh`,
   `bash tools/install_puffer_env.sh --check`, then

--- a/docs/exact-action-canary-2070-execution-checklist.md
+++ b/docs/exact-action-canary-2070-execution-checklist.md
@@ -28,7 +28,13 @@ qualification.
   `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v2`
 - Stopped-validation output:
   `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v2-validation`
-- Unit name: `bloodbowl-exact-action-canary-50m-s42-v2.service`
+- Fresh v3 execution-evidence root:
+  `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v3-execution`
+- Fresh v3 authorization destination:
+  `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v3-execution/CANARY_AUTHORIZATION.json`
+- Canonical v3 unit source:
+  `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v3-execution/bloodbowl-exact-action-canary-50m-s42-v3.service`
+- Unit name: `bloodbowl-exact-action-canary-50m-s42-v3.service`
 - Requested agent steps: exactly `50000000`
 - Rollout quantum: exactly `131072` (`2048 * 64`)
 - Minibatch size: exactly `16384`
@@ -73,6 +79,37 @@ process was created. Do not delete, relabel, launch, or reuse the v1 output or
 unit identity. Only the fresh v2 paths above may proceed under this corrected
 authority.
 
+The first v2 Gate 3 authorization and unit bytes are also immutable rejection
+evidence. The plan-only output itself remains accepted and unchanged, but the
+first synthetic empty-output unit exposed that systemd expands `%s` to the user
+shell before Bash. Its journal recorded a `printf` excess-argument warning and
+status 1. The cleanup trap removed all three disposable probe units; the real
+v2 unit was never installed or started, GPU compute remained empty, and BBTV
+remained active. Preserve but never install/reuse:
+
+| Rejected artifact | Absolute path | SHA-256 |
+|---|---|---|
+| Gate 3 authorization | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v2-execution/CANARY_AUTHORIZATION.json` | `3af34715cfa0cc848c0c8ba2effa48a2916f0c1059d0760dcef3a97fb1030d91` |
+| v2 unit bytes | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v2-execution/bloodbowl-exact-action-canary-50m-s42-v2.service` | `00e9c32cde253d8f3639c13985d3e30d181e40735cd027678afd9399e46e274a` |
+| Probe runner | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v2-execution/gate4-synthetic-probes.sh` | `134f4cb066d43dd6e30e910b07e2da30308ffd89a8dbf8fd6939ecd1d1b2e5c9` |
+| Empty-probe journal | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v2-execution/gate4-attempt1-empty-journal.txt` | `20f306a4c042e7fea8ed1fec3107eeb048ecf6ace212a1c82172f42cd32de9ed` |
+| Post-cleanup proof | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v2-execution/gate4-attempt1-post-cleanup.txt` | `9f019876e51a9810c2ddcafa72afbbe96b623c9fc9c970c46a0c73f192f8bf42` |
+| Rejection record | `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-v2-execution/gate4-attempt1-rejection.txt` | `0592a95210e094c7942ffaa9af53a10d8e274991553e47e2366a5fa714902b0e` |
+
+Only a newly hash-bound authorization and the fresh v3 unit identity above may
+proceed. The corrected unit writes `%%s`, which systemd reduces to literal `%s`
+for Bash. This changes only external unit authority; it does not alter or
+rematerialize the accepted v2 plan manifest, candidate runtime, or launcher.
+The entire rejected v2 execution root is immutable. Every newly created
+prelaunch v3 validator capture, canonical unit/probe copy, authorization,
+inventory, status, and journal must be preserved under the fixed, initially
+absent v3 execution-evidence root. Transient systemd-manager unit files must
+live in the manager's required unit-file directory and be removed when the
+checklist requires; Gate 6 artifacts must be written only to the separately
+authorized stopped-validation output; launcher-owned live artifacts remain in
+the accepted canary output. No new evidence may be appended to the v2 execution
+root.
+
 Candidate launch-source SHA-256 identities are:
 
 | File | SHA-256 |
@@ -92,13 +129,13 @@ Re-hash `tools/live_integrity_guard.py` in the same control root and require
 exact SHA-256
 `e9c957ae37671bc6bfd6d09c7ef2d956736a5ead7242395f2357006bfc571ff1`.
 
-Re-hash all six before plan-only materialization and again immediately before
-unit installation. Any mismatch rejects the canary.
+Re-hash all six before Gate 2 revalidation and again immediately before unit
+installation. Any mismatch rejects the canary.
 
 ## Gate 1: accepted prerequisites
 
-All of the following must be captured and hash-bound before plan-only canary
-materialization:
+All of the following must be captured and hash-bound before Gate 2
+revalidation:
 
 1. The recovery preservation verifier accepted the off-box copy, and the local
    recovery manifest file SHA-256 and inventory SHA-256 are fixed.
@@ -115,22 +152,32 @@ materialization:
    still match the accepted qualification.
 6. No recovery trainer, qualification cell, evaluator, or other GPU compute
    process remains. BBTV follower state and public HTTP health are recorded.
-7. The canary output path and unit name do not exist. The exact superseded v1
-   unit identity named above is also absent from the user systemd manager and
-   its unit-file directory, and the original pre-rejection v1 output path
+7. The accepted v2 canary output exists as exactly the unchanged regular
+   `SCREEN_MANIFEST.json` and zero-byte released `.screen.lock` described in
+   Gate 2. The fresh v3 execution-evidence root and exact v3 unit name do not
+   exist. The exact superseded v1 unit identity named above is also absent from
+   the user systemd manager and its unit-file directory, and the original
+   pre-rejection v1 output path
    `/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v1`
    is absent rather than copied alongside its renamed rejection directory.
 8. Recompute the five rejection-only evidence hashes and both canonical
    inventories above from their exact paths; every value must still match.
+9. Recompute the rejected Gate 3/unit/probe hashes in the second table. Require
+   the superseded v2 unit identity absent from the manager and unit-file
+   directory, and require the accepted v2 plan-only manifest, lock, and exact
+   two-file inventories unchanged. Require the fixed stopped-validation output
+   to exist as an empty directory and bind that empty state before launch; do
+   not delete or recreate it merely to satisfy this check.
 
 Any mismatch stops deployment. Do not delete or overwrite an existing output
 to make the precondition true.
 
-## Gate 2: plan-only positive launch proof
+## Gate 2: revalidate the accepted plan-only positive launch proof
 
-From the exact candidate root, with its venv first on `PATH`, run the launcher
-once with `PLAN_ONLY=1`, `ARM_DETACH=0`, and an explicitly empty inherited warm
-and pool environment:
+Do not rerun the launcher and do not rematerialize its output. The accepted
+plan-only invocation was run once from the exact candidate root with its venv
+first on `PATH`, `PLAN_ONLY=1`, `ARM_DETACH=0`, and an explicitly empty inherited
+warm and pool environment. Its frozen command was:
 
 ```text
 /usr/bin/env -u WARM -u POOL \
@@ -145,7 +192,9 @@ and pool environment:
   /usr/bin/bash /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/tools/run_reward_screen.sh
 ```
 
-Require exit zero and exactly two regular files directly under the new output:
+Recompute the preserved command/stdout/stderr/status hashes and require the
+recorded exit zero. Require exactly two regular files directly under the
+accepted output:
 `SCREEN_MANIFEST.json` plus `.screen.lock`, with no directory or other entry.
 Complete and accept this regular-file/type inventory before opening the lock;
 never run the probe against a symlink, FIFO, device, directory, or an
@@ -185,14 +234,28 @@ completion artifact. Independently validate the manifest contract:
 - `arm_detach=0` and exact external output path.
 
 Hash the manifest, the zero-byte released lock, the exact two-file mode/size
-inventory, and every plan-only stdout/stderr/command artifact. A plan-only
-rejection, missing/held/nonempty lock, unexpected file or directory, or
-manifest mismatch blocks the canary.
+inventory, and every preserved plan-only stdout/stderr/command artifact. Run
+the independent manifest validator twice again from fresh candidate-interpreter
+processes and require byte-identical accepted output. Only after all preceding
+read-only checks accept, atomically create the exact previously absent v3
+execution-evidence root. Persist each fresh validator's stdout, stderr, and
+status separately under that root as
+`gate2-validator-{1,2}.{stdout,stderr,status}`; require both status files encode
+zero, both stderr files are empty, and both stdout files are byte-identical.
+Close and hash the resulting six-file relative-name/type/mode/size/digest set
+before Gate 3. A changed plan-only artifact, missing/held/nonempty lock,
+unexpected file or directory, validator disagreement, or manifest mismatch
+blocks the canary. Rerunning the launcher,
+deleting the lock, or rewriting the manifest is forbidden.
 
 ## Gate 3: hash-bound authorization record
 
-Create one canonical JSON authorization outside the source checkout. It must
-bind, by absolute path plus SHA-256 where applicable:
+First require the exact v3 execution-evidence root to contain only Gate 2's
+closed six-file validator set, and require both the canonical v3 unit source and
+authorization destination from Fixed scope absent. Atomically write the exact
+unit bytes shown in Gate 4 to the canonical v3 unit source, then create one
+canonical JSON authorization at the exact fixed v3 destination outside the
+source checkout. It must bind, by absolute path plus SHA-256 where applicable:
 
 - accepted off-box recovery preservation manifest and inventory identity;
 - predecessor throughput baseline and its complete artifact inventory;
@@ -204,21 +267,27 @@ bind, by absolute path plus SHA-256 where applicable:
   output directory;
 - canary `SCREEN_MANIFEST.json`, zero-byte released `.screen.lock`, exact
   two-file plan-only inventory, and output path;
-- exact unit bytes and unit SHA-256;
+- exact unit name `bloodbowl-exact-action-canary-50m-s42-v3.service`, exact unit
+  bytes, and unit SHA-256;
 - exact canary command and environment;
 - `Restart=no`, `KillMode=control-group`, `ARM_DETACH=0`, and the two-hour
   service ceiling;
 - an explicit statement that qualification and canary outputs are
   qualification-only, ancestry-ineligible, and reward-evidence-ineligible.
 
-Write the authorization atomically, hash it, copy it off-box, and independently
-recompute it before installing the unit. Presence without exact content does
-not authorize launch.
+Write the unit and authorization atomically at their fixed v3 destinations,
+hash them, copy the authorization off-box, and independently recompute it before
+installing the unit. Bind the
+v3 execution-evidence root's exact relative file set, modes, sizes, and
+digests after each gate. Presence without exact content, a different unit name,
+or any new artifact under the rejected v2 execution root does not authorize
+launch.
 
 ## Gate 4: exact one-shot user unit
 
-Materialize these semantics only after Gate 3 accepts. Substitute no path and
-add no environment variable after hashing:
+Install only the already hash-bound canonical unit bytes below as
+`bloodbowl-exact-action-canary-50m-s42-v3.service` after Gate 3 accepts.
+Substitute no path or unit name and add no environment variable after hashing:
 
 ```ini
 [Unit]
@@ -229,7 +298,7 @@ After=default.target
 Type=oneshot
 WorkingDirectory=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e
 ExecStartPre=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin/python /home/rache/bloodbowl-rl-qualification-control-20260722-v4/tools/qualify_recurrent_cuda.py validate /home/rache/bloodbowl-rl-qualification-artifacts-20260722/candidate-qualification/QUALIFICATION.json
-ExecStartPre=/usr/bin/bash -c 'set -euo pipefail; out="$$(/usr/local/bin/nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)"; stripped="$$(/usr/bin/printf "%s" "$${out}" | /usr/bin/tr -d "[:space:]")"; test -z "$${stripped}"'
+ExecStartPre=/usr/bin/bash -c 'set -euo pipefail; out="$$(/usr/local/bin/nvidia-smi --query-compute-apps=pid --format=csv,noheader,nounits)"; stripped="$$(/usr/bin/printf "%%s" "$${out}" | /usr/bin/tr -d "[:space:]")"; test -z "$${stripped}"'
 ExecStart=/usr/bin/env -u WARM -u POOL PATH=/home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/vendor/PufferLib/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin CUDA_VISIBLE_DEVICES=0 OMP_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16 MKL_NUM_THREADS=16 NUMEXPR_NUM_THREADS=16 STEPS=50000000 SCREEN_PROFILE=exact-action-canary PREFIX=exact-action-canary-50m-s42-v2 OUT_DIR=/home/rache/bloodbowl-rl-qualification-artifacts-20260722/exact-action-canary-50m-s42-v2 POLL_SECONDS=30 PLAN_ONLY=0 ARM_DETACH=0 /usr/bin/bash /home/rache/bloodbowl-rl-qualification-candidate-a52fc6e/tools/run_reward_screen.sh
 Restart=no
 KillMode=control-group
@@ -245,11 +314,17 @@ WantedBy=default.target
 The doubled dollars above are mandatory for this frozen contract: each `$$`
 becomes one literal `$` in the Bash command. This unambiguously passes every
 dollar to Bash and does not depend on systemd's positional environment-variable
-expansion rules.
+expansion rules. The doubled percent in `%%s` is independently mandatory:
+systemd reduces `%%` to one literal `%`, while bare `%s` is its user-shell
+specifier and must never appear in an operative `ExecStartPre` format string.
 
 Before installing the real unit, construct three separately named disposable,
-non-training user units outside every source/output root using the same `$$`
-command-substitution and `$${name}` shell-local syntax. Replace only the probe
+non-training canonical probe units under the v3 execution-evidence root using
+the same `$$` command-substitution, `$${name}` shell-local syntax, and `%%s`
+format escape. Install transient copies only in the systemd user manager's
+required unit-file directory; never place them in a source, canary-output, or
+stopped-validation root.
+Reject any probe bytes containing bare `printf "%s"`. Replace only the probe
 body: the empty-output unit must exit zero; the fixed `123` output unit must
 fail; and the probe-command-nonzero unit must independently fail. Require
 `systemd-analyze --user verify` on all three unit files, capture each unit's
@@ -257,7 +332,8 @@ exact bytes/status/journal separately, then remove all three and require every
 unit name absent. This synthetic proof must run only after the recovery boundary
 and off-box preservation; it launches no GPU process.
 
-Then require `systemd-analyze --user verify` success for the exact real unit,
+Then require `systemd-analyze --user verify` success for the exact canonical
+real unit, copy it to the manager without changing a byte,
 exact installed unit-byte equality with Gate 3, `systemctl --user is-enabled`
 reporting disabled, and `NRestarts=0`. Do not enable the unit and do not use a
 restart policy. Immediately before the one allowed start, repeat the Gate 2

--- a/docs/qualification-2070-execution-checklist.md
+++ b/docs/qualification-2070-execution-checklist.md
@@ -314,6 +314,13 @@ of a separate canary authorization record. That record must bind:
 - an `ExecStartPre` qualification revalidation and empty-GPU-process check;
 - `env -u WARM -u POOL` around the exact one-seed 50M canary launcher.
 
+Any Bash command embedded in a systemd unit must escape both parsers: use `$$`
+where Bash must receive literal `$`, and use `%%` where Bash must receive
+literal `%`. In particular, an empty-GPU `printf` format is `"%%s"` in unit
+bytes; bare `"%s"` is invalid because systemd expands `%s` to the user shell.
+Require the synthetic empty/fixed/command-failure probes to prove these exact
+bytes before installing the real unit.
+
 The real launch must reuse the plan-only output without rewriting its manifest:
 the frozen launcher checks schema version 1, recomputes and deep-compares the
 complete nested stored `contract` object, rejects any drift, and leaves

--- a/training/test_recurrent_cuda_qualification.py
+++ b/training/test_recurrent_cuda_qualification.py
@@ -1029,6 +1029,24 @@ class QualificationPatchContractTests(unittest.TestCase):
             "deep-compares the complete nested `contract` object",
             "repeat the Gate 2",
             "Do not delete, relabel, launch, or reuse the v1 output",
+            "3af34715cfa0cc848c0c8ba2effa48a2916f0c1059d0760dcef3a97fb1030d91",
+            "00e9c32cde253d8f3639c13985d3e30d181e40735cd027678afd9399e46e274a",
+            "134f4cb066d43dd6e30e910b07e2da30308ffd89a8dbf8fd6939ecd1d1b2e5c9",
+            "20f306a4c042e7fea8ed1fec3107eeb048ecf6ace212a1c82172f42cd32de9ed",
+            "9f019876e51a9810c2ddcafa72afbbe96b623c9fc9c970c46a0c73f192f8bf42",
+            "0592a95210e094c7942ffaa9af53a10d8e274991553e47e2366a5fa714902b0e",
+            "Only a newly hash-bound authorization and the fresh v3 unit identity",
+            "exact-action-canary-v3-execution/CANARY_AUTHORIZATION.json",
+            "Every newly created prelaunch v3 validator capture, canonical unit/probe copy, authorization, inventory, status, and journal",
+            "Do not rerun the launcher and do not rematerialize its output",
+            "Run the independent manifest validator twice again",
+            "fixed stopped-validation output to exist as an empty directory",
+            "exact unit name `bloodbowl-exact-action-canary-50m-s42-v3.service`",
+            "gate2-validator-{1,2}.{stdout,stderr,status}",
+            "closed six-file validator set",
+            "Canonical v3 unit source",
+            "Install only the already hash-bound canonical unit bytes",
+            "Gate 6 artifacts must be written only to the separately authorized stopped-validation output",
         ):
             with self.subTest(fragment=fragment):
                 self.assertIn(fragment, normalized_checklist)
@@ -1046,7 +1064,72 @@ class QualificationPatchContractTests(unittest.TestCase):
                 self.assertNotIn("ExecStart=", line)
                 self.assertNotIn("Unit name:", line)
         self.assertIn("PREFIX=exact-action-canary-50m-s42-v2", checklist)
-        self.assertIn("bloodbowl-exact-action-canary-50m-s42-v2.service", checklist)
+        self.assertIn(
+            "- Unit name: `bloodbowl-exact-action-canary-50m-s42-v3.service`",
+            checklist,
+        )
+        self.assertNotIn(
+            "- Unit name: `bloodbowl-exact-action-canary-50m-s42-v2.service`",
+            checklist,
+        )
+        self.assertNotIn(
+            "The canary output path and unit name do not exist",
+            checklist,
+        )
+        self.assertIn(
+            "The accepted v2 canary output exists as exactly the unchanged regular",
+            checklist,
+        )
+        self.assertIn(
+            "Install only the already hash-bound canonical unit bytes below as\n"
+            "`bloodbowl-exact-action-canary-50m-s42-v3.service`",
+            checklist,
+        )
+        rejection_rows = {
+            "Gate 3 authorization": (
+                "exact-action-canary-v2-execution/CANARY_AUTHORIZATION.json",
+                "3af34715cfa0cc848c0c8ba2effa48a2916f0c1059d0760dcef3a97fb1030d91",
+            ),
+            "v2 unit bytes": (
+                "exact-action-canary-v2-execution/"
+                "bloodbowl-exact-action-canary-50m-s42-v2.service",
+                "00e9c32cde253d8f3639c13985d3e30d181e40735cd027678afd9399e46e274a",
+            ),
+            "Probe runner": (
+                "exact-action-canary-v2-execution/gate4-synthetic-probes.sh",
+                "134f4cb066d43dd6e30e910b07e2da30308ffd89a8dbf8fd6939ecd1d1b2e5c9",
+            ),
+            "Empty-probe journal": (
+                "exact-action-canary-v2-execution/gate4-attempt1-empty-journal.txt",
+                "20f306a4c042e7fea8ed1fec3107eeb048ecf6ace212a1c82172f42cd32de9ed",
+            ),
+            "Post-cleanup proof": (
+                "exact-action-canary-v2-execution/gate4-attempt1-post-cleanup.txt",
+                "9f019876e51a9810c2ddcafa72afbbe96b623c9fc9c970c46a0c73f192f8bf42",
+            ),
+            "Rejection record": (
+                "exact-action-canary-v2-execution/gate4-attempt1-rejection.txt",
+                "0592a95210e094c7942ffaa9af53a10d8e274991553e47e2366a5fa714902b0e",
+            ),
+        }
+        rejection_root = (
+            "/home/rache/bloodbowl-rl-qualification-artifacts-20260722/"
+        )
+        for label, (relative_path, digest) in rejection_rows.items():
+            with self.subTest(rejected_artifact=label):
+                self.assertIn(
+                    f"| {label} | `{rejection_root}{relative_path}` | "
+                    f"`{digest}` |",
+                    checklist,
+                )
+
+        unit_block = checklist.split("```ini\n", 1)[1].split("\n```", 1)[0]
+        self.assertIn('/usr/bin/printf "%%s" "$${out}"', unit_block)
+        self.assertNotIn('/usr/bin/printf "%s" "$${out}"', unit_block)
+        self.assertIn("$$(/usr/local/bin/nvidia-smi", unit_block)
+        self.assertIn('test -z "$${stripped}"', unit_block)
+        self.assertIn("bare `%s` is its user-shell", checklist)
+        self.assertIn("`%%s` format escape", normalized_checklist)
 
         qualification = QUALIFICATION_CHECKLIST.read_text(encoding="utf-8")
         self.assertIn("zero-byte, released, hash-bound `.screen.lock`", qualification)
@@ -1055,23 +1138,29 @@ class QualificationPatchContractTests(unittest.TestCase):
             "leaves `SCREEN_MANIFEST.json` byte-identical",
             " ".join(qualification.split()),
         )
+        self.assertIn('`"%%s"` in unit', qualification)
+        self.assertIn('bare `"%s"` is invalid', qualification)
 
         required_guidance = {
             AGENTS: (
                 "run_reward_screen.sh creates $OUT_DIR/.screen.lock",
                 "hash its mode/size with the manifest",
+                "written %%s in unit bytes",
             ),
             CLAUDE: (
                 "The frozen screen launcher intentionally creates and retains",
                 "with both modes, sizes, and hashes bound",
+                'printf "%%s" in unit bytes',
             ),
             TRAINING_SKILL: (
                 "The frozen screen launcher creates $OUT_DIR/.screen.lock",
                 "Hash both and their modes/sizes",
+                'printf "%s" must be authored as printf "%%s"',
             ),
             FLEET_SKILL: (
                 "For canary plan-only closure, account for the launcher's persistent ownership inode",
                 "bind both files' modes, sizes, and digests",
+                'Author an intended printf "%s" as printf "%%s"',
             ),
         }
         for path, fragments in required_guidance.items():


### PR DESCRIPTION
## Summary
- preserve the rejected v2 authorization and synthetic-probe evidence by exact path and hash
- advance only the external service authority to a fresh v3 identity while reusing the accepted immutable v2 plan output
- escape the systemd percent layer (`%%s`) and require disposable positive/negative probes before installation
- make Gate 1–6 evidence placement and chronology internally closed, including a pinned v3 root/unit/authorization
- teach AGENTS.md, CLAUDE.md, and experiment/fleet skills about systemd dollar/percent parsing
- add non-vacuous CI assertions for all six rejection artifacts and the operative unit bytes

## Verification
- `python3 -m unittest training.test_recurrent_cuda_qualification` (34/34)
- `PYTHONPATH=tools python3 -m unittest tools.test_analyze_reward_screen` (19/19)
- `python3 -m py_compile training/test_recurrent_cuda_qualification.py`
- `ruff check training/test_recurrent_cuda_qualification.py`
- `git diff --check`
- independent read-only reviewer: no P0–P3 findings after two correction rounds

No service, remote artifact, GPU process, accepted v2 plan output, or rejected evidence was modified by this PR.