### PR TITLE
Stop the live integrity guard from killing every pool run at epoch 0

### DIFF
--- a/tools/live_integrity_guard.py
+++ b/tools/live_integrity_guard.py
@@ -19,6 +19,14 @@ from pathlib import Path
 from typing import Any
 
 
+# Keys the trainer publishes under the `env/` namespace on every epoch even
+# when no episode has finished, so their presence does NOT imply the env
+# aggregated an episode. `elo` is written unconditionally by the self-play
+# league (vendor/PufferLib/pufferlib/selfplay.py, `flat_logs['env/elo']`),
+# unlike its `historical_winrate*` neighbours which are gated on hist_n > 0.
+# Only reachable in a pool run, which is why no genesis arm ever hit it.
+NON_EPISODE_PANEL_KEYS = frozenset({"elo"})
+
 HARD_INTEGRITY_KEYS = (
     "illegal_frac",
     "reward_clip_frac",
@@ -292,11 +300,15 @@ def check_log(
                     offset=line_start,
                 )
             # Before an episode completes, Puffer's schema-2 phase contract
-            # intentionally emits only _puffer_* metadata. Consume that record
-            # without resetting the integrity-panel liveness clock. Once any
-            # environment metric is present, the complete hard registry is
-            # mandatory.
-            if not any(not key.startswith("_") for key in panel):
+            # emits only _puffer_* metadata plus the always-on wrapper metrics
+            # in NON_EPISODE_PANEL_KEYS. Consume that record without resetting
+            # the integrity-panel liveness clock. Once any key that requires an
+            # aggregated episode is present, the complete hard registry is
+            # mandatory -- including `n`, so an env that published metrics
+            # without the registry still fails closed.
+            if not any(
+                    not key.startswith("_") and key not in NON_EPISODE_PANEL_KEYS
+                    for key in panel):
                 continue
             missing = [key for key in HARD_INTEGRITY_KEYS if key not in panel]
             if missing:

--- a/tools/test_live_integrity_guard.py
+++ b/tools/test_live_integrity_guard.py
@@ -203,6 +203,55 @@ class LiveIntegrityGuardTests(unittest.TestCase):
                     "no complete machine integrity panel"):
                 guard.check_log(log, state, failure, now=281.0)
 
+    def test_pool_epoch_zero_elo_only_panel_is_not_a_registry_violation(self):
+        # A self-play pool run publishes env/elo every epoch whether or not an
+        # episode finished, so the first epoch's panel carries elo and nothing
+        # else env-side. That is not a missing registry -- it is a run that has
+        # not aggregated an episode yet. Treating it as a violation killed a
+        # 500M decomposition screen 2M steps in.
+        with tempfile.TemporaryDirectory() as root:
+            root = Path(root)
+            log = root / "arm.log"
+            state = root / "guard-state.json"
+            failure = root / "guard-failure.json"
+            metadata = {
+                "_puffer_schema": 2,
+                "_puffer_agent_steps": 131072.0,
+                "_puffer_epoch": 0,
+                "elo": 0.0,
+            }
+            log.write_text(
+                "PUFFER_ENV_JSON " + json.dumps(metadata) + "\n",
+                encoding="utf-8",
+            )
+            result = guard.check_log(log, state, failure, now=100.0)
+            self.assertEqual(result.total_panels, 0)
+            self.assertFalse(failure.exists())
+
+            # Consumed, but it must not count as liveness either.
+            with self.assertRaisesRegex(
+                    guard.IntegrityFailure,
+                    "no complete machine integrity panel"):
+                guard.check_log(log, state, failure, now=281.0)
+
+    def test_elo_does_not_excuse_a_panel_that_aggregated_an_episode(self):
+        # The exemption is narrow: once any episode-aggregated key appears,
+        # the full registry is mandatory even alongside elo.
+        with tempfile.TemporaryDirectory() as root:
+            values = {key: 0.0 for key in guard.HARD_INTEGRITY_KEYS}
+            values.pop("illegal_frac")
+            values.update({
+                "_puffer_schema": 2,
+                "_puffer_agent_steps": 131072.0,
+                "elo": 1234.0,
+                "n": 775.0,
+            })
+            text = "PUFFER_ENV_JSON " + json.dumps(values) + "\n"
+            with self.assertRaisesRegex(
+                    guard.IntegrityFailure,
+                    "missing hard-integrity keys"):
+                self.run_guard(root, text)
+
     def test_completed_log_rejects_unterminated_tail(self):
         with tempfile.TemporaryDirectory() as root:
             root = Path(root)

--- a/tools/test_puffer_log_contract.py
+++ b/tools/test_puffer_log_contract.py
@@ -20,7 +20,10 @@ class PufferLogContractTests(unittest.TestCase):
     def test_binding_keys_plus_vec_n_fit_patched_capacity(self) -> None:
         binding = BINDING.read_text()
         emitted_keys = len(re.findall(r"\bdict_set\s*\(\s*out\s*,", binding))
-        self.assertEqual(emitted_keys, 123)
+        # Kept exact on purpose: the count is load-bearing history (37 keys vs
+        # capacity 32 corrupted the heap at ~786K steps). binding.c's my_log
+        # CAPACITY comment is the authority -- update both together.
+        self.assertEqual(emitted_keys, 144)
         self.assertLessEqual(emitted_keys + 1, EXPECTED_CAPACITY)
 
     def test_both_puffer_backends_and_installer_pin_same_capacity(self) -> None:


### PR DESCRIPTION
## What broke

The 500M decomposition screen died 2M steps into arm 1 with:

```
LIVE INTEGRITY FAILURE: machine panel is missing hard-integrity keys:
['illegal_frac', 'reward_clip_frac', ... all 16 ...]
```

against panels that plainly contained all sixteen. `LIVE_INTEGRITY_FAILURE.json`
records `offset = 20207`, which is the epoch-0 panel:

```
PUFFER_ENV_JSON {"_puffer_agent_steps": 131072.0, ..., "_puffer_schema": 2, "elo": 0.0}
```

## Why

`selfplay.py` sets `flat_logs['env/elo']` unconditionally every epoch, unlike its
`historical_winrate*` neighbours which are gated on `hist_n > 0`. So a pool run's
first panel carries `elo` and nothing else env-side, before any episode has been
aggregated. The guard's gate — "any non-underscore key means the env published
metrics, so the whole registry is mandatory" — read that as a violation.

Only a pool run reaches it, and every genesis profile forbids `POOL`, so the path
had never once executed. The 50M genesis canary passed for exactly that reason.

## Fix

Exempt only the always-on wrapper keys. Anything implying an aggregated episode —
`n` included — still demands the full 16-key registry, so an env that published
metrics while dropping counters still fails closed.

The regression test was watched to fail against the unfixed guard, reproducing the
production kill, and to pass after.

## Also

`test_puffer_log_contract` was red on main: its hand-maintained literal said the
binding emits 123 keys while `binding.c`'s authoritative CAPACITY comment already
said 144. The bound that matters (`145 <= 160`) always held, and the vendored
`dict_set` aborts loudly rather than dropping keys, so no panel was ever silently
truncated. Literal updated; the exact-count assertion is kept deliberately, since
37-keys-vs-capacity-32 once corrupted the heap at ~786K steps.