### PR TITLE
Add a campaign supervisor to keep the GPU on an ordered stage plan

### DIFF
--- a/tools/campaign_supervisor.py
+++ b/tools/campaign_supervisor.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Advance a multi-stage training campaign one tick at a time.
+
+Why this exists rather than tools/experiment_queue.py: the queue's plan is
+SHA-pinned up front and each stage can receive exactly one path from its
+predecessor, so a campaign whose later stages need a value COMPUTED by an
+earlier stage (a candidate arm chosen by an analysis, a checkpoint selected by
+step count) is not expressible -- editing the plan mid-flight halts the queue.
+The queue is the right tool for a fully pre-authored chain; this is the right
+tool for a chain that resolves its own inputs at launch time.
+
+Why no model in the loop: the previous keeper of this GPU was a cron job that
+dispatched `claude -p` every 30 minutes to decide whether to relaunch. It died
+on 2026-06-12 when the account hit a weekly limit and sat dead for six weeks
+while the GPU idled. Nothing here calls a model, a network, or an API.
+
+Safety properties, all deliberate:
+
+* It never kills, signals, or cleans up anything. A stalled trainer is reported,
+  not terminated -- the screen's own live integrity guard owns that decision
+  (MAX_PANEL_SILENCE_SECONDS), and a supervisor that kills on a heuristic is a
+  supervisor that eventually kills a healthy run.
+* It never launches while a trainer is alive, so it cannot put a second trainer
+  on the GPU. Liveness uses the bracketed pgrep pattern (footgun 12) so the
+  probe cannot match its own command line -- an unbracketed pattern has already
+  reported dead processes as alive twice in this campaign.
+* Each stage has an attempt cap. Exceeding it HALTS the campaign rather than
+  relaunching for the rest of the week.
+* A halt is sticky. Only a human (or a later session) clears it.
+* One tick at a time, serialized by flock on the state file, so overlapping
+  timer firings cannot both launch.
+
+Run it from a systemd timer or a service loop:
+
+    python3 tools/campaign_supervisor.py --plan CAMPAIGN_PLAN.json \
+                                        --state CAMPAIGN_STATE.json
+
+Exit status is 0 for every normal outcome including halt, because a halted
+campaign is a decision, not a crash, and systemd should not restart-loop on it.
+2 is reserved for a malformed plan or an unusable state file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import fcntl
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+# A trainer liveness pattern MUST be bracketed so pgrep cannot match the shell
+# or ssh command line that carries the pattern itself. `[p]uffer` matches the
+# string "puffer" while the literal pattern text does not match itself.
+DEFAULT_TRAINER_PGREP = r"[p]uffer_cuda_runtime.py train|[p]uffer train"
+
+
+class PlanError(Exception):
+    """The plan or state file cannot be used as given."""
+
+
+def _utc() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def _load_json(path: Path, label: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise PlanError(f"{label} not found: {path}") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PlanError(f"{label} is unreadable: {path}: {exc}") from exc
+
+
+def _write_json_atomic(path: Path, payload: Any) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def validate_plan(plan: Any) -> dict:
+    """Reject a plan we cannot execute, rather than half-executing it."""
+    if not isinstance(plan, dict):
+        raise PlanError("plan is not an object")
+    if plan.get("schema_version") != SCHEMA_VERSION:
+        raise PlanError(
+            f"plan schema_version must be {SCHEMA_VERSION}, got "
+            f"{plan.get('schema_version')!r}"
+        )
+    for key in ("campaign_id", "root", "stages"):
+        if not plan.get(key):
+            raise PlanError(f"plan is missing required key: {key}")
+    root = Path(plan["root"])
+    if not root.is_absolute():
+        raise PlanError(f"plan root must be absolute: {root}")
+
+    pattern = plan.get("trainer_pgrep", DEFAULT_TRAINER_PGREP)
+    if "[" not in pattern:
+        # Refuse the footgun outright instead of documenting it.
+        raise PlanError(
+            "trainer_pgrep must use the bracketed form (e.g. '[p]uffer train') "
+            "so the probe cannot match its own command line"
+        )
+
+    stages = plan["stages"]
+    if not isinstance(stages, list) or not stages:
+        raise PlanError("plan stages must be a non-empty list")
+    seen: set[str] = set()
+    for index, stage in enumerate(stages):
+        if not isinstance(stage, dict):
+            raise PlanError(f"stage {index} is not an object")
+        name = stage.get("name")
+        if not name or not isinstance(name, str):
+            raise PlanError(f"stage {index} has no name")
+        if name in seen:
+            raise PlanError(f"duplicate stage name: {name}")
+        seen.add(name)
+        if not stage.get("success"):
+            raise PlanError(f"stage {name} has no success artifact path")
+        launch = stage.get("launch")
+        if not isinstance(launch, str) or not launch.strip():
+            raise PlanError(f"stage {name} has no launch command string")
+        attempts = stage.get("max_attempts", 3)
+        if not isinstance(attempts, int) or attempts < 1:
+            raise PlanError(f"stage {name} has an invalid max_attempts")
+        stale = stage.get("max_stale_seconds", 1800)
+        if not isinstance(stale, int) or stale < 60:
+            raise PlanError(f"stage {name} has an invalid max_stale_seconds")
+    return plan
+
+
+def trainer_is_alive(pattern: str) -> bool:
+    """True when a trainer process matches. Absence of proof is not proof."""
+    try:
+        done = subprocess.run(
+            ["pgrep", "-f", pattern],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        # If we cannot probe, assume something IS running. Launching a second
+        # trainer onto a busy GPU is far worse than idling one tick.
+        return True
+    return done.returncode == 0 and bool(done.stdout.strip())
+
+
+def stage_progress_age(root: Path, stage: dict) -> float | None:
+    """Seconds since the stage's progress file was last written, if declared."""
+    progress = stage.get("progress")
+    if not progress:
+        return None
+    path = root / progress if not Path(progress).is_absolute() else Path(progress)
+    try:
+        return max(0.0, time.time() - path.stat().st_mtime)
+    except OSError:
+        return None
+
+
+def stage_is_complete(root: Path, stage: dict) -> bool:
+    success = stage["success"]
+    path = root / success if not Path(success).is_absolute() else Path(success)
+    return path.exists()
+
+
+def _blank_state(plan: dict) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "campaign_id": plan["campaign_id"],
+        "halted": False,
+        "halt_reason": None,
+        "complete": False,
+        "stages": {},
+        "history": [],
+        "updated_utc": _utc(),
+    }
+
+
+def _stage_state(state: dict, name: str) -> dict:
+    entry = state["stages"].setdefault(
+        name, {"attempts": 0, "launched_utc": None, "last_pid": None}
+    )
+    return entry
+
+
+def _record(state: dict, message: str, keep: int = 200) -> None:
+    state["history"].append({"utc": _utc(), "event": message})
+    if len(state["history"]) > keep:
+        del state["history"][:-keep]
+
+
+def launch_stage(root: Path, stage: dict, log_dir: Path, attempt: int) -> int:
+    """Start a stage detached so it outlives this tick and its SSH session.
+
+    setsid+nohup is correct HERE because this supervisor is the top-level owner
+    -- it is not running inside an experiment_queue job, where an inner detach
+    would let the trainer escape the job's process-group guards. A stage that
+    the queue owns must set ARM_DETACH=0 and must not be launched from here.
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{stage['name']}-attempt{attempt}.log"
+    env = dict(os.environ)
+    # A detached, non-interactive shell does not source the login profile, so
+    # anything the launcher demands must be set explicitly. run_reward_ablation
+    # refuses to start unless CUDA_VISIBLE_DEVICES is exactly "0"; losing that
+    # silently killed a relaunch already.
+    env.setdefault("CUDA_VISIBLE_DEVICES", "0")
+    for key, value in (stage.get("env") or {}).items():
+        env[str(key)] = str(value)
+
+    with log_path.open("ab") as sink:
+        sink.write(
+            f"\n=== attempt {attempt} launched {_utc()} ===\n".encode("utf-8")
+        )
+        sink.flush()
+        proc = subprocess.Popen(
+            ["setsid", "nohup", "bash", "-lc", stage["launch"]],
+            cwd=str(root),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=sink,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    return proc.pid
+
+
+def tick(plan: dict, state: dict, *, dry_run: bool = False) -> str:
+    """Advance the campaign at most one step. Returns a one-line verdict."""
+    root = Path(plan["root"])
+    pattern = plan.get("trainer_pgrep", DEFAULT_TRAINER_PGREP)
+    log_dir = Path(plan.get("log_dir") or (root / "runs" / "campaign-logs"))
+    if not log_dir.is_absolute():
+        log_dir = root / log_dir
+
+    if state.get("halted"):
+        return f"HALTED {state.get('halt_reason')}"
+
+    stages: list[dict] = plan["stages"]
+    current = None
+    for stage in stages:
+        if not stage_is_complete(root, stage):
+            current = stage
+            break
+
+    if current is None:
+        if not state.get("complete"):
+            state["complete"] = True
+            _record(state, "campaign complete: every stage success artifact present")
+        return "COMPLETE all stages have their success artifact"
+
+    entry = _stage_state(state, current["name"])
+
+    if trainer_is_alive(pattern):
+        age = stage_progress_age(root, current)
+        if age is not None and age > current.get("max_stale_seconds", 1800):
+            # Report, never kill. The run's own integrity guard owns termination.
+            _record(
+                state,
+                f"stage {current['name']}: trainer alive but progress stale "
+                f"{age:.0f}s (> {current.get('max_stale_seconds', 1800)}s) -- "
+                f"reported, not terminated",
+            )
+            return (
+                f"STALE stage={current['name']} progress_age={age:.0f}s "
+                f"(trainer alive; not touching it)"
+            )
+        return f"BUSY stage={current['name']} trainer alive; nothing to do"
+
+    max_attempts = current.get("max_attempts", 3)
+    if entry["attempts"] >= max_attempts:
+        state["halted"] = True
+        state["halt_reason"] = (
+            f"stage {current['name']} reached its attempt cap "
+            f"({entry['attempts']}/{max_attempts}) without producing "
+            f"{current['success']}"
+        )
+        _record(state, state["halt_reason"])
+        return f"HALT {state['halt_reason']}"
+
+    attempt = entry["attempts"] + 1
+    if dry_run:
+        return (
+            f"WOULD-LAUNCH stage={current['name']} attempt={attempt}/"
+            f"{max_attempts} cmd={shlex.quote(current['launch'])[:120]}"
+        )
+
+    pid = launch_stage(root, current, log_dir, attempt)
+    entry["attempts"] = attempt
+    entry["launched_utc"] = _utc()
+    entry["last_pid"] = pid
+    _record(
+        state,
+        f"stage {current['name']}: launched attempt {attempt}/{max_attempts} pid={pid}",
+    )
+    return f"LAUNCHED stage={current['name']} attempt={attempt}/{max_attempts} pid={pid}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", type=Path, required=True)
+    parser.add_argument("--state", type=Path, required=True)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="decide and print, but do not launch or write state",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        plan = validate_plan(_load_json(args.plan, "plan"))
+    except PlanError as exc:
+        print(f"campaign supervisor: {exc}", file=sys.stderr)
+        return 2
+
+    lock_path = args.state.with_suffix(args.state.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            print("BUSY another supervisor tick holds the state lock")
+            return 0
+
+        if args.state.exists():
+            try:
+                state = _load_json(args.state, "state")
+            except PlanError as exc:
+                print(f"campaign supervisor: {exc}", file=sys.stderr)
+                return 2
+            if state.get("campaign_id") != plan["campaign_id"]:
+                print(
+                    "campaign supervisor: state belongs to campaign "
+                    f"{state.get('campaign_id')!r}, plan is {plan['campaign_id']!r}",
+                    file=sys.stderr,
+                )
+                return 2
+            state.setdefault("stages", {})
+            state.setdefault("history", [])
+        else:
+            state = _blank_state(plan)
+
+        verdict = tick(plan, state, dry_run=args.dry_run)
+        print(verdict)
+        if not args.dry_run:
+            state["updated_utc"] = _utc()
+            _write_json_atomic(args.state, state)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_campaign_supervisor.py
+++ b/tools/test_campaign_supervisor.py
@@ -1,0 +1,195 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools import campaign_supervisor as sup
+
+
+def plan(root, *, stages=None, pattern=None):
+    return {
+        "schema_version": 1,
+        "campaign_id": "test-campaign",
+        "root": str(root),
+        "trainer_pgrep": pattern or sup.DEFAULT_TRAINER_PGREP,
+        "stages": stages
+        or [
+            {
+                "name": "one",
+                "success": "one.done",
+                "launch": "true",
+                "max_attempts": 2,
+            },
+            {
+                "name": "two",
+                "success": "two.done",
+                "launch": "true",
+                "max_attempts": 2,
+            },
+        ],
+    }
+
+
+class SupervisorTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.launched = []
+        # Never spawn a real process in a test.
+        self._real_launch = sup.launch_stage
+        self._real_alive = sup.trainer_is_alive
+        sup.launch_stage = lambda root, stage, log_dir, attempt: (
+            self.launched.append((stage["name"], attempt)) or 4242
+        )
+        sup.trainer_is_alive = lambda pattern: False
+
+    def tearDown(self):
+        sup.launch_stage = self._real_launch
+        sup.trainer_is_alive = self._real_alive
+        self._tmp.cleanup()
+
+    def state_for(self, p):
+        return sup._blank_state(p)
+
+    def test_launches_the_first_incomplete_stage(self):
+        p = plan(self.root)
+        st = self.state_for(p)
+        verdict = sup.tick(p, st)
+        self.assertTrue(verdict.startswith("LAUNCHED stage=one"), verdict)
+        self.assertEqual(self.launched, [("one", 1)])
+        self.assertEqual(st["stages"]["one"]["attempts"], 1)
+
+    def test_advances_to_the_next_stage_once_the_artifact_appears(self):
+        p = plan(self.root)
+        st = self.state_for(p)
+        (self.root / "one.done").write_text("x", encoding="utf-8")
+        verdict = sup.tick(p, st)
+        self.assertTrue(verdict.startswith("LAUNCHED stage=two"), verdict)
+        self.assertEqual(self.launched, [("two", 1)])
+
+    def test_never_launches_while_a_trainer_is_alive(self):
+        sup.trainer_is_alive = lambda pattern: True
+        p = plan(self.root)
+        st = self.state_for(p)
+        verdict = sup.tick(p, st)
+        self.assertTrue(verdict.startswith("BUSY"), verdict)
+        self.assertEqual(self.launched, [])
+
+    def test_a_failed_probe_is_treated_as_busy_not_as_idle(self):
+        # If pgrep cannot run we must NOT conclude the GPU is free.
+        def explode(_cmd, **_kw):
+            raise OSError("no pgrep")
+
+        real_run = sup.subprocess.run
+        sup.subprocess.run = explode
+        try:
+            # self._real_alive, not sup.trainer_is_alive: setUp stubs the module
+            # attribute, so the stub would answer instead of the code under test.
+            self.assertTrue(self._real_alive("[p]uffer train"))
+        finally:
+            sup.subprocess.run = real_run
+
+    def test_attempt_cap_halts_instead_of_relaunching_forever(self):
+        p = plan(self.root)
+        st = self.state_for(p)
+        sup.tick(p, st)
+        sup.tick(p, st)
+        self.assertEqual(len(self.launched), 2)
+        verdict = sup.tick(p, st)
+        self.assertTrue(verdict.startswith("HALT"), verdict)
+        self.assertTrue(st["halted"])
+        self.assertIn("attempt cap", st["halt_reason"])
+        self.assertEqual(len(self.launched), 2, "must not launch a third time")
+
+    def test_a_halt_is_sticky(self):
+        p = plan(self.root)
+        st = self.state_for(p)
+        st["halted"] = True
+        st["halt_reason"] = "operator"
+        verdict = sup.tick(p, st)
+        self.assertTrue(verdict.startswith("HALTED"), verdict)
+        self.assertEqual(self.launched, [])
+
+    def test_all_artifacts_present_reports_complete(self):
+        p = plan(self.root)
+        st = self.state_for(p)
+        (self.root / "one.done").write_text("x", encoding="utf-8")
+        (self.root / "two.done").write_text("x", encoding="utf-8")
+        verdict = sup.tick(p, st)
+        self.assertTrue(verdict.startswith("COMPLETE"), verdict)
+        self.assertTrue(st["complete"])
+        self.assertEqual(self.launched, [])
+
+    def test_stale_progress_is_reported_and_nothing_is_killed(self):
+        # Trainer alive, progress file ancient: the supervisor must surface it
+        # and take no action. Terminating on a heuristic eventually kills a
+        # healthy run, and the screen's own integrity guard owns that call.
+        sup.trainer_is_alive = lambda pattern: True
+        stages = [
+            {
+                "name": "one",
+                "success": "one.done",
+                "launch": "true",
+                "progress": "progress.json",
+                "max_stale_seconds": 60,
+            }
+        ]
+        p = plan(self.root, stages=stages)
+        st = self.state_for(p)
+        prog = self.root / "progress.json"
+        prog.write_text("{}", encoding="utf-8")
+        import os
+
+        old = 1_600_000_000
+        os.utime(prog, (old, old))
+        verdict = sup.tick(p, st)
+        self.assertTrue(verdict.startswith("STALE"), verdict)
+        self.assertEqual(self.launched, [])
+        self.assertFalse(st["halted"], "a stall must not halt the campaign")
+
+    def test_unbracketed_trainer_pattern_is_refused(self):
+        # An unbracketed pgrep pattern matches the command line that carries it,
+        # which has already reported dead processes as alive twice.
+        with self.assertRaisesRegex(sup.PlanError, "bracketed"):
+            sup.validate_plan(plan(self.root, pattern="puffer train"))
+
+    def test_relative_root_is_refused(self):
+        p = plan(self.root)
+        p["root"] = "relative/path"
+        with self.assertRaisesRegex(sup.PlanError, "absolute"):
+            sup.validate_plan(p)
+
+    def test_duplicate_stage_names_are_refused(self):
+        stages = [
+            {"name": "dup", "success": "a", "launch": "true"},
+            {"name": "dup", "success": "b", "launch": "true"},
+        ]
+        with self.assertRaisesRegex(sup.PlanError, "duplicate stage name"):
+            sup.validate_plan(plan(self.root, stages=stages))
+
+    def test_state_from_another_campaign_is_refused(self):
+        p = plan(self.root)
+        plan_path = self.root / "plan.json"
+        state_path = self.root / "state.json"
+        plan_path.write_text(json.dumps(p), encoding="utf-8")
+        other = sup._blank_state(p)
+        other["campaign_id"] = "somebody-elses-campaign"
+        state_path.write_text(json.dumps(other), encoding="utf-8")
+        rc = sup.main(["--plan", str(plan_path), "--state", str(state_path)])
+        self.assertEqual(rc, 2)
+
+    def test_dry_run_neither_launches_nor_writes_state(self):
+        p = plan(self.root)
+        plan_path = self.root / "plan.json"
+        state_path = self.root / "state.json"
+        plan_path.write_text(json.dumps(p), encoding="utf-8")
+        rc = sup.main(
+            ["--plan", str(plan_path), "--state", str(state_path), "--dry-run"]
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.launched, [])
+        self.assertFalse(state_path.exists(), "dry run must not write state")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/training/systemd/campaign-supervisor@.service
+++ b/training/systemd/campaign-supervisor@.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Blood Bowl campaign supervisor tick (%i)
+After=network-online.target
+StartLimitIntervalSec=3600
+StartLimitBurst=20
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/bloodbowl-rl-qualification-candidate-10619e2
+Environment=PYTHONUNBUFFERED=1
+Environment=CUDA_VISIBLE_DEVICES=0
+ExecStart=%h/bloodbowl-rl-qualification-candidate-10619e2/vendor/PufferLib/.venv/bin/python %h/bloodbowl-rl-qualification-candidate-10619e2/tools/campaign_supervisor.py --plan %h/bloodbowl-rl-qualification-candidate-10619e2/runs/campaigns/%i/CAMPAIGN_PLAN.json --state %h/bloodbowl-rl-qualification-candidate-10619e2/runs/campaigns/%i/CAMPAIGN_STATE.json
+
+# KillMode=process is REQUIRED here and is not the usual choice. A oneshot unit
+# defaults to KillMode=control-group, which reaps every process left in the
+# unit's cgroup when ExecStart returns -- and the whole job of a tick is to
+# leave a multi-hour trainer running behind it. control-group would kill the
+# training run seconds after launching it.
+#
+# This does NOT contradict the queue rule against escaping process-group guards.
+# That rule protects experiment_queue.py jobs, where the queue OWNS the
+# trainer's lifetime and enforces runtime, thermal, progress and disk limits by
+# signalling the group. This supervisor owns no lifetime and enforces no limits:
+# it launches and observes, and never signals anything. A stage that the queue
+# owns must run under the queue with ARM_DETACH=0, not from here.
+KillMode=process
+TimeoutStopSec=45

--- a/training/systemd/campaign-supervisor@.timer
+++ b/training/systemd/campaign-supervisor@.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Tick the Blood Bowl campaign supervisor (%i)
+
+[Timer]
+# Five minutes is chosen against what a tick costs, not what it gains: a tick is
+# a pgrep plus a few stat() calls, so the only real cost of a miss is up to five
+# minutes of idle GPU between stages. Persistent=true so a tick that was due
+# while the box was down fires once on boot rather than waiting a full interval.
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=campaign-supervisor@%i.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Groundwork for running a multi-day training campaign unattended. `tools/campaign_supervisor.py` plus a systemd timer; the campaign plan itself lands separately.

## Why not `experiment_queue.py`

I tried to use it first — CLAUDE.md points at it for unattended multi-day work, it is production-proven (D183/D185/D186), it has a committed unit, and its 23 tests pass. It cannot express this campaign, for a specific reason: the plan is SHA-pinned up front and each stage receives exactly one path from its predecessor, so a chain whose later stages need a value **computed** by an earlier one has nowhere to put it. Concretely, `paired-confirmation` needs `CANDIDATE_ARM` chosen by an analysis and `EXPECTED_TRANSFER_SHA256` set to a hash that does not exist until the previous stage finishes. Editing the plan mid-flight halts the queue.

The queue remains the right tool for a fully pre-authored chain. This is for a chain that resolves its inputs at launch time.

## Why no model in the loop

The previous keeper of this GPU was a cron job dispatching `claude -p` every 30 minutes to decide whether to relaunch. It died 2026-06-12 on an account weekly limit and sat dead for six weeks while the GPU idled. Its liveness test (`pgrep -fc "puffer train"`) also no longer matches the trainer, so a revived tick would have started a second trainer on an 8GB GPU. Nothing here calls a model, a network, or an API.

## Safety properties, each mutation-tested

| Property | Test | Verified by breaking |
|---|---|---|
| Never launches while a trainer is alive | `test_never_launches_while_a_trainer_is_alive` | ✓ |
| A failed probe means busy, not idle | `test_a_failed_probe_is_treated_as_busy_not_as_idle` | ✓ |
| Attempt cap halts, does not relaunch for a week | `test_attempt_cap_halts_instead_of_relaunching_forever` | ✓ |
| Unbracketed pgrep pattern is refused outright | `test_unbracketed_trainer_pattern_is_refused` | ✓ |

Each was confirmed to fail against a deliberately broken supervisor and pass against the real one, with the restore verified by `git diff --quiet` (an earlier attempt used `git checkout` on an untracked file, which silently restored nothing and made three "passing" runs meaningless).

**It never kills or signals anything.** A stalled trainer is reported, not terminated — the run's own live integrity guard owns that call, and a supervisor that kills on a heuristic eventually kills a healthy run. The unbracketed-pattern refusal is there because that footgun has already reported dead processes as alive twice in this campaign.

## `KillMode=process`

Explained at length in the unit file, because it looks wrong at a glance and reviewers should not have to rediscover it: a `oneshot` unit's default `KillMode=control-group` would reap the trainer the tick just launched.