### PR TITLE
Make the backplay curriculum knobs settable, and refuse every silent no-op

### DIFF
--- a/tools/run_reward_ablation.sh
+++ b/tools/run_reward_ablation.sh
@@ -33,6 +33,73 @@ if [ $# -ne 0 ]; then
   exit 1
 fi
 
+# Backplay curriculum knobs. Every default is 0, which reproduces the previous
+# hard-coded flags byte for byte, so a non-ladder run is unchanged.
+#
+# These are validated HERE, before any CUDA/venv preflight, because each one has
+# a failure mode where the env silently ignores the setting and trains something
+# other than what the operator asked for -- and the counters stay clean while it
+# happens (bloodbowl.h:2150 increments demo_fallbacks only for a record that is
+# not a live decision state, never for a selector that found nothing).
+LADDER_RESET_PCT="${LADDER_RESET_PCT:-0}"
+LADDER_ENDZONE_MAXDIST="${LADDER_ENDZONE_MAXDIST:-0}"
+LADDER_PICKUP_MAXDIST="${LADDER_PICKUP_MAXDIST:-0}"
+LADDER_POSTKICK_MAXTURN="${LADDER_POSTKICK_MAXTURN:-0}"
+LADDER_PASS_MAXRANGE="${LADDER_PASS_MAXRANGE:-0}"
+
+case "$LADDER_RESET_PCT" in
+  0|0.0|1|1.0|0.[0-9]*) : ;;
+  *) echo "LADDER_RESET_PCT must be a fraction in [0,1], got '$LADDER_RESET_PCT'" >&2
+     exit 1 ;;
+esac
+for knob in LADDER_ENDZONE_MAXDIST LADDER_PICKUP_MAXDIST \
+            LADDER_POSTKICK_MAXTURN LADDER_PASS_MAXRANGE; do
+  eval "value=\$$knob"
+  case "$value" in
+    ''|*[!0-9]*) echo "$knob must be a non-negative integer, got '$value'" >&2
+                 exit 1 ;;
+  esac
+done
+
+# The env selects a curriculum with an if / else-if chain -- endzone, then
+# pickup, then postkick, then pass (bloodbowl.h ~2056-2130). Setting two means
+# the later one is silently never applied, so refuse instead of quietly training
+# the first.
+LADDER_SELECTORS=0
+for value in "$LADDER_ENDZONE_MAXDIST" "$LADDER_PICKUP_MAXDIST" \
+             "$LADDER_POSTKICK_MAXTURN" "$LADDER_PASS_MAXRANGE"; do
+  [ "$value" -gt 0 ] && LADDER_SELECTORS=$((LADDER_SELECTORS + 1))
+done
+if [ "$LADDER_SELECTORS" -gt 1 ]; then
+  echo "only one curriculum selector may be set: the env applies the first of" >&2
+  echo "endzone/pickup/postkick/pass and silently ignores the rest" >&2
+  exit 1
+fi
+
+case "$LADDER_RESET_PCT" in
+  0|0.0)
+    if [ "$LADDER_SELECTORS" -gt 0 ]; then
+      echo "a curriculum selector is set but LADDER_RESET_PCT is 0, so the env" >&2
+      echo "never draws a banked state and the selector is a no-op" >&2
+      exit 1
+    fi
+    LADDER_STATE_BANK_SHA256="unused"
+    ;;
+  *)
+    # Without a staged bank, bbe_state_bank_load finds nothing, bbe_state_bank_n
+    # stays 0, and the whole curriculum degrades to procgen kickoffs with no
+    # counter to show it. Bind the bank's identity into the run manifest so a
+    # ladder result can never be attributed to the wrong start-state corpus.
+    LADDER_STATE_BANK="$ROOT/vendor/PufferLib/resources/bloodbowl/state_bank.bbs"
+    [ -f "$LADDER_STATE_BANK" ] || {
+      echo "LADDER_RESET_PCT > 0 requires a staged state bank at" >&2
+      echo "  $LADDER_STATE_BANK" >&2
+      echo "without it the curriculum silently degrades to procgen kickoffs" >&2
+      exit 1; }
+    LADDER_STATE_BANK_SHA256="$(sha256sum "$LADDER_STATE_BANK" | awk '{print $1}')"
+    ;;
+esac
+
 : "${BOOTSTRAP_MODE:?BOOTSTRAP_MODE is required}"
 case "$BOOTSTRAP_MODE" in
   fresh-v5-qualification)
@@ -578,9 +645,11 @@ CMD=(env PUFFER_CUDA_RUNTIME_MANIFEST="$RUN_MANIFEST" \
   --vec.total-agents "$TOTAL_AGENTS" --vec.num-buffers "$NUM_BUFFERS" \
   --vec.num-threads "$NUM_THREADS" \
   "${REWARD_ARGS[@]}" \
-  --env.demo-reset-pct 0 --env.demo-endzone-maxdist 0 \
-  --env.demo-pickup-maxdist 0 --env.demo-postkick-maxturn 0 \
-  --env.demo-pass-maxrange 0 \
+  --env.demo-reset-pct "$LADDER_RESET_PCT" \
+  --env.demo-endzone-maxdist "$LADDER_ENDZONE_MAXDIST" \
+  --env.demo-pickup-maxdist "$LADDER_PICKUP_MAXDIST" \
+  --env.demo-postkick-maxturn "$LADDER_POSTKICK_MAXTURN" \
+  --env.demo-pass-maxrange "$LADDER_PASS_MAXRANGE" \
   --train.total-timesteps "$STEPS" --train.learning-rate "$LR" \
   --train.ent-coef "$ENT_COEF" --train.gamma "$GAMMA" \
   --train.gae-lambda "$GAE_LAMBDA" --train.horizon "$HORIZON" \
@@ -618,6 +687,12 @@ META_ARGS=(
   qualification_only "$QUALIFICATION_ONLY" observation_abi obs-v5 \
   observation_version 5 action_abi exact-joint-v1 \
   policy_hidden_size 512 policy_num_layers 3 policy_expansion_factor 1 \
+  ladder_reset_pct "$LADDER_RESET_PCT"
+  ladder_endzone_maxdist "$LADDER_ENDZONE_MAXDIST"
+  ladder_pickup_maxdist "$LADDER_PICKUP_MAXDIST"
+  ladder_postkick_maxturn "$LADDER_POSTKICK_MAXTURN"
+  ladder_pass_maxrange "$LADDER_PASS_MAXRANGE"
+  ladder_state_bank_sha256 "$LADDER_STATE_BANK_SHA256"
   rollout_quantum "$ROLLOUT_QUANTUM" reward_name "$REWARD_NAME"
   reward_sha256 "$REWARD_HASH" reward_manifest "$REWARD_MANIFEST"
   pool "$POOL" pool_identity_sha256 "$POOL_HASH"

--- a/tools/test_ladder_knobs.py
+++ b/tools/test_ladder_knobs.py
@@ -1,0 +1,89 @@
+"""The backplay curriculum knobs must refuse every silent-no-op configuration.
+
+These run the real launcher. The knob validation sits above the CUDA/venv
+preflight precisely so it can be exercised off-box: a rejected configuration
+exits with its own message, and an accepted one falls through to a later,
+different failure. So each test asserts on the SPECIFIC message, never on the
+exit status alone -- a test that only checked "non-zero" would pass for every
+configuration on a machine with no GPU.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = ROOT / "tools" / "run_reward_ablation.sh"
+
+
+def run(**knobs) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    # Enough to get past the required-variable checks and reach the knobs.
+    env.setdefault("TAG", "ladder-knob-test")
+    env.setdefault("REWARD_MANIFEST", str(ROOT / "puffer/config/rewards/s0_both.json"))
+    env.setdefault("BOOTSTRAP_MODE", "fresh-v5-genesis")
+    env.setdefault("STEPS", "1000000")
+    for key, value in knobs.items():
+        env[key] = str(value)
+    return subprocess.run(
+        ["bash", str(LAUNCHER)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=120,
+        cwd=str(ROOT),
+    )
+
+
+class LadderKnobTests(unittest.TestCase):
+    def test_selector_without_reset_pct_is_refused_as_a_no_op(self):
+        # The whole failure mode: a maxdist with reset_pct 0 means the env never
+        # draws a banked state, so the "curriculum" run is a kickoff run.
+        out = run(LADDER_ENDZONE_MAXDIST=6, LADDER_RESET_PCT=0).stdout
+        self.assertIn("selector is a no-op", out)
+
+    def test_two_selectors_are_refused_because_the_env_applies_only_the_first(self):
+        out = run(
+            LADDER_ENDZONE_MAXDIST=6,
+            LADDER_PASS_MAXRANGE=6,
+            LADDER_RESET_PCT="0.5",
+        ).stdout
+        self.assertIn("only one curriculum selector", out)
+
+    def test_reset_pct_out_of_range_is_refused(self):
+        out = run(LADDER_RESET_PCT="1.5").stdout
+        self.assertIn("must be a fraction in [0,1]", out)
+
+    def test_non_integer_selector_is_refused(self):
+        out = run(LADDER_ENDZONE_MAXDIST="six", LADDER_RESET_PCT="0.5").stdout
+        self.assertIn("must be a non-negative integer", out)
+
+    def test_reset_pct_without_a_staged_bank_is_refused(self):
+        # A Mac checkout has no staged bank, so this exercises the real path.
+        bank = ROOT / "vendor/PufferLib/resources/bloodbowl/state_bank.bbs"
+        if bank.exists():
+            self.skipTest("this checkout has a staged bank; covered on the box")
+        out = run(LADDER_RESET_PCT="0.5", LADDER_ENDZONE_MAXDIST=6).stdout
+        self.assertIn("requires a staged state bank", out)
+
+    def test_the_default_configuration_passes_the_knob_gate(self):
+        # With no knobs set the run must reach a LATER failure, never a knob
+        # complaint -- otherwise this change would have broken every ordinary
+        # non-ladder arm.
+        out = run().stdout
+        for message in (
+            "selector is a no-op",
+            "only one curriculum selector",
+            "must be a fraction in [0,1]",
+            "must be a non-negative integer",
+            "requires a staged state bank",
+        ):
+            self.assertNotIn(message, out, f"default config tripped: {message}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The ladder is the only path in this repo's history that ever produced a scoring policy (D67–D74), and it was unreachable from the launcher that has the safety machinery.

## Why here and not `run_native_asym.sh`

`run_reward_ablation.sh` hard-coded all five demo knobs to `0`, so the launcher with lineage-v5 eligibility checks, the live integrity guard, acceptance gating and run manifests could not run a curriculum at all. The only launcher that could is `run_native_asym.sh`, which is obs-v4 era: it defaults `TEACHER` to `bc_v4_cuda.bin` and does no lineage validation. Since obs-v4 and obs-v5 blobs are both 16,066,560 bytes, that is precisely the trap that already cost a 12B-step run. Patching one thing in the modern launcher beats adopting the older one.

## Inert by default

Every knob defaults to `0`, so the emitted flags are identical and non-ladder arms are byte-for-byte unchanged. The full python suite has one *fewer* failure than before (the log-contract literal fixed in #78); the remaining four are pre-existing import errors for optional deps.

## The three silent no-ops it now refuses

Each one trains something other than what the operator asked for, with all sixteen integrity counters clean:

1. **A selector with `reset_pct` 0** — the env never draws a banked state, so a "curriculum" run is a kickoff run.
2. **Two selectors** — `bloodbowl.h` picks endzone / pickup / postkick / pass in an if-else chain, so the first wins and the rest are silently ignored.
3. **`reset_pct > 0` with no staged bank** — `bbe_state_bank_n` stays 0 and every reset degrades to procgen. `demo_fallbacks` does **not** catch this: `bloodbowl.h:2150` increments only for a record that is not a live decision state, never for a selector that found nothing.

The bank's sha256 is bound into the run manifest, so a ladder result cannot be attributed to the wrong start-state corpus.

## Test note

The tests run the real launcher and assert the **specific** message, not a non-zero exit. On a machine without CUDA every configuration exits non-zero, so an exit-status assertion would pass vacuously for all of them. Validation is deliberately placed above the CUDA preflight to make that possible. All three refusals were mutation-verified; one mutation initially reported a false pass because `false || { ... }` *strengthens* the check rather than removing it, so it was redone with `true || { ... }`.

## Deploy constraint

**Do not sync the training box to this commit while the decomposition screen is running.** The screen invokes `run_reward_ablation.sh` once per arm; the behavior is identical for default knobs, but there is no reason to change the launcher under a live 8-arm run. Sync after `SCREEN_COMPLETE.json` exists.