### PR TITLE
Add the disposable backplay-ladder canary recipe

### DIFF
--- a/tools/launch_ladder_canary.sh
+++ b/tools/launch_ladder_canary.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Disposable backplay-ladder canary: does the curriculum mechanism actually work
+# on this harness, and does tds move off zero?
+#
+# This is a CANARY in D219's sense -- never warm-start from its output, never add
+# it to an opponent pool, never quote it as a reward result. Its only job is to
+# answer three questions before a multi-day ladder budget is committed:
+#
+#   1. Do the sixteen hard-integrity counters stay zero with demo_reset_pct > 0?
+#      demo_fallbacks is one of them and fires for a banked record that is not a
+#      live decision state, so this is the first real test of the bank's content
+#      against the loader (all 15,348 filtered records scan as live decision
+#      states, but that was measured by tools/bank_backplay_coverage.c, not by
+#      the env).
+#   2. Does episode_length rise off the ~137.7 floor the kickoff-only runs sit
+#      at? A backplay start puts the carrier near the endzone, so if the knob is
+#      really applied the episode shape must change. If episode_length stays at
+#      137.7 the knob did nothing and the run is a kickoff run wearing a ladder's
+#      name -- the exact silent no-op the launcher's new guards exist to prevent.
+#   3. Does tds move off 0.000? Every kickoff-only run in project history is
+#      scoreless (D26/D34/D40/D49, one capped at 10.1B), and the ladder is the
+#      only thing that ever fixed it (D50/D67-D74).
+#
+# Rung choice: maxdist 6 is D51's backplay-s1 rung. tools/bank_backplay_coverage.c
+# measures 313 qualifying records in the filtered bank (2.04%), giving a 0.5%
+# chance that a reset exhausts the 256-try rejection sampler and silently falls
+# back to a uniform draw. That is small, measured rather than assumed, and the
+# alternative rung 9 (784 records, 1.5e-06) trades scoring proximity for a
+# safety margin we do not need at 0.5%.
+#
+# reset_pct 0.5, not 0.9: D69 retired 0.9 as "drill saturation [that] overwrites
+# game-context behavior" and D74 graduates 0.5 -> 0.25 -> 0. 0.5 is the mixed
+# ratio that transferred.
+
+set -uo pipefail
+
+C="${C:-/home/rache/bloodbowl-rl-qualification-candidate-10619e2}"
+cd "$C" || exit 1
+
+STAMP="${STAMP:-20260723}"
+export CUDA_VISIBLE_DEVICES=0
+export TAG="${TAG:-ladder-canary-d6-$STAMP}"
+export STEPS="${STEPS:-50000000}"
+export BOOTSTRAP_MODE=lineage-v5
+export REWARD_MANIFEST="$C/puffer/config/rewards/s0_both.json"
+export WARM="${WARM:-$C/vendor/PufferLib/checkpoints/bloodbowl/1784833905091/0000000049938432.bin}"
+export POOL="${POOL:-$C/runs/pool-boot-20260723/pool}"
+export EXPECTED_POOL_HASH="${EXPECTED_POOL_HASH:-c75d4baa2b962ce9687607a018ff6a0a0d8c74d781b5de526ee8d6503953d3ab}"
+
+# The curriculum itself.
+export LADDER_RESET_PCT=0.5
+export LADDER_ENDZONE_MAXDIST=6
+
+OUT="${OUT:-$C/runs/ladder-canary-$STAMP}"
+mkdir -p "$OUT"
+export LOG="${LOG:-$OUT/$TAG.log}"
+
+echo "=== ladder canary ==="
+echo "  tag        $TAG"
+echo "  steps      $STEPS"
+echo "  rung       maxdist $LADDER_ENDZONE_MAXDIST at reset_pct $LADDER_RESET_PCT"
+echo "  warm       $WARM"
+echo "  pool       $POOL"
+echo "  bank       $(sha256sum "$C/vendor/PufferLib/resources/bloodbowl/state_bank.bbs" 2>/dev/null | cut -c1-16)"
+echo "  log        $LOG"
+
+bash "$C/tools/run_reward_ablation.sh"
+rc=$?
+echo "LADDER_CANARY_EXIT=$rc"
+
+# Publish a success marker only on a clean exit, so a campaign supervisor cannot
+# mistake a crashed canary for a finished one.
+if [ "$rc" -eq 0 ]; then
+    printf '{"tag":"%s","steps":"%s","endzone_maxdist":%s,"reset_pct":%s,"log":"%s"}\n' \
+        "$TAG" "$STEPS" "$LADDER_ENDZONE_MAXDIST" "$LADDER_RESET_PCT" "$LOG" \
+        > "$OUT/LADDER_CANARY_COMPLETE.json"
+    echo "wrote $OUT/LADDER_CANARY_COMPLETE.json"
+fi
+exit "$rc"


### PR DESCRIPTION
The tracked recipe for the first curriculum run, so the ladder's viability is tested by a 50M canary rather than assumed by a multi-day budget.

## What it checks

1. **Do the sixteen hard counters stay zero with `demo_reset_pct > 0`?** `demo_fallbacks` is one of them and fires for a banked record that is not a live decision state. All 15,348 filtered records scan as live decision states — but that was measured by `tools/bank_backplay_coverage.c`, not by the env itself.
2. **Does `episode_length` rise off the ~137.7 floor?** Every kickoff-only arm sits at 137.7. A backplay start puts the carrier near the endzone, so if the knob is genuinely applied the episode shape must change. If it stays at 137.7 the knob did nothing — the exact silent no-op #82's guards exist to prevent, caught here empirically.
3. **Does `tds` move off 0.000?** No kickoff-only run in project history has scored (D26/D34/D40/D49, one capped at 10.1B). The ladder is the only thing that ever fixed it.

## Parameter choices, from the ledger rather than taste

- **Rung 6** is D51's `backplay-s1` rung. `bank_backplay_coverage` measures 313 qualifying records in the filtered bank (2.04%), a 0.5% chance a reset exhausts the 256-try sampler and silently takes a uniform draw. Rung 9 (784 records, 1.5e-06) trades scoring proximity for a margin we don't need at 0.5%.
- **`reset_pct 0.5`, not 0.9.** D69 retired 0.9 as "drill saturation [that] overwrites game-context behavior"; D74 graduates 0.5 → 0.25 → 0. 0.5 is the ratio that transferred.
- **Disposable**, in D219's sense: never warm-start from its output, never add it to a pool, never quote it as a reward result.

## Honest limitation

This has not been executed — the GPU is busy with the decomposition screen, and the box is pinned below the launcher change on purpose. The new surface it exercises is the `LADDER_*` env contract, whose validation is unit-tested and mutation-verified in #82; the rest is the well-trodden `run_reward_ablation.sh` path. It writes its success marker only on a clean exit, so a supervisor cannot mistake a crash for completion.