### PR TITLE
Correct the distance-shaping comment, including one claim that was just wrong

### DIFF
--- a/puffer/bloodbowl/bloodbowl.h
+++ b/puffer/bloodbowl/bloodbowl.h
@@ -450,22 +450,29 @@ typedef struct {
     // runs once tds/match wakes up; NOT a permanent reward (see
     // docs/reward-audit-decision-time.md doctrine vs scaffolding).
     //
-    // NOT CURRENTLY POTENTIAL-BASED, despite what this comment used to claim.
-    // Two defects, both at the emission site below (search pot_carry_prev):
-    //   1. Each potential is NAN whenever its regime is inactive, the emission
-    //      is skipped when either side is NaN, and prev is then overwritten
-    //      with NAN. So on any possession gap the baseline silently
-    //      RE-ANCHORS wherever possession resumes: advances are paid, drops
-    //      across the gap are never charged, and it does not telescope. A
-    //      gain/advance/lose/regain/advance cycle banks reward for zero net
-    //      field progress. BB_BALL_IN_AIR is such a gap, so a completed pass
-    //      earns no distance credit while carrying the same squares earns
-    //      full credit -- an anti-passing bias.
-    //   2. The emission is raw (Phi' - Phi), not beta*(gamma*Phi' - Phi), so
-    //      it is not exact PBRS at gamma != 1.
-    // Fixing 1 requires Phi total (no NaN) with a value for the inactive
-    // regime that charges rather than pays the drop; fixing 2 requires the
-    // env to know gamma, which it currently does not.
+    // Potential-based ONLY when reward_dist_pbrs_gamma > 0 (D226). The two
+    // defects this comment used to describe as unfixed are both fixed on that
+    // path, and both deliberately retained on the legacy gamma == 0 path so
+    // historical runs stay bit-identical:
+    //   1. WAS: each potential went NaN whenever its regime was inactive, the
+    //      emission was skipped when either side was NaN, and prev was then
+    //      overwritten with NaN, so the baseline silently RE-ANCHORED on every
+    //      possession gap -- advances paid, drops across the gap never charged.
+    //      NOW: Phi is total and >= 0 (bbe_potential), inactive reads as 0, so
+    //      a drop across a gap is charged and the sum telescopes.
+    //   2. WAS: the emission was raw (Phi' - Phi), not exact PBRS.
+    //      NOW: gam*Phi' - Phi on every transition, with the terminal emitting
+    //      -Phi(s_T-1) so a closed cycle sums to (gam-1)*sum(Phi) <= 0.
+    // One claim in the old text was simply WRONG and is not merely outdated: it
+    // blamed the anti-passing bias on BB_BALL_IN_AIR being a possession gap. A
+    // pass never enters that state. BB_BALL_IN_AIR is set at exactly one site,
+    // the kickoff scatter (engine/src/proc_match.c:664), where it IS observable
+    // at a decision because kickoff_event pauses for High Kick. So the
+    // BB_BALL_IN_AIR limbo case in bbe_update_ball_possession covers High Kick
+    // and nothing else, and it does NOT shield a pass in flight.
+    // The real anti-passing tax is D230's, still open: a pass with two or more
+    // interception candidates books a phantom loss-plus-gain of net -0.01 per
+    // completed pass. Do not attribute that to this channel.
     float reward_dist_ball;
     float reward_dist_endzone;
     // Exact potential-based form for the two distance channels.


### PR DESCRIPTION
Found while investigating D230's interception phantom tax. The comment block above `reward_dist_ball` is stale in two ways, and one of them is an outright wrong mechanism rather than merely outdated text.

**Outdated:** it describes both pre-D226 defects (NaN re-anchoring, raw rather than discounted emission) as unfixed. Both are fixed whenever `reward_dist_pbrs_gamma > 0`, and both are deliberately retained on the legacy `gamma == 0` path so historical runs stay bit-identical. D226 exists because these channels were documented as "Potential-BASED (telescoping -> un-farmable)" and were neither; leaving the replacement comment stale invites the same class of mistake.

**Wrong:** it blamed the anti-passing bias on `BB_BALL_IN_AIR` being a possession gap. **A pass never enters that state.** `BB_BALL_IN_AIR` is set at exactly one site in the whole engine — the kickoff scatter, `engine/src/proc_match.c:664` — where it genuinely *is* observable at a decision, because `kickoff_event` pauses for High Kick. So the `BB_BALL_IN_AIR` limbo case in `bbe_update_ball_possession` covers High Kick and nothing else, and it does **not** shield a pass in flight.

That matters beyond tidiness: the comment would send the next reader looking for the anti-passing tax in the distance channel, where it isn't. The real one is D230's still-open phantom loss-plus-gain of net −0.01 per completed pass, which lives in the ball-family channels.

## Why I stopped short of fixing D230's tax here

I verified the state machine but not yet the exact window where the transient loss is booked, and D230 records me getting this specific possession mechanism wrong **twice** before landing it. A third rushed attempt at a reward-semantics change is worse than an accurate comment plus a precise note of what remains. The fix is now unblocked (`bloodbowl.h` is free of obs-v6 conflicts) and scoped: establish empirically what `ball.state` is during a 2+-candidate interception window, then suppress the possession transition for a pass in flight rather than widening `BB_BALL_IN_AIR`, which would be an engine/rules-visible change.

Comment-only. 541 native tests, 0 failures. It does change `SOURCE_HASH`, forcing a reinstall and clean rebuild — which obs-v6 already requires and no host has done yet, so the marginal cost is zero.